### PR TITLE
Correct URL for ESRI REST World_Light_Gray_Base

### DIFF
--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -5,7 +5,7 @@
     "isBaseLayer": true,
     "isDefaultBaseLayer": false,
     "text": "Grey Background",
-    "url": "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/",
+    "url": "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}",
     "openLayers": {
       "maxResolution": 1222.99245234375,
       "numZoomLevels": 13,


### PR DESCRIPTION
This corrects the URL of the ESRI REST World_Light_Gray_Base layer since the x-y-z declaration for the tiles has to be given in the config URL (introduced with #107).