### PR TITLE
Introduce separate lint script and upgrade eslint 

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "lib": "lib"
   },
   "scripts": {
-    "test": "eslint app"
+    "lint": "eslint app",
+    "test": "npm run lint"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   },
   "homepage": "https://github.com/meggsimum/cpsi-mapview#readme",
   "dependencies": {
-    "eslint": "^5.4.0"
+    "eslint": "^6.2.1"
   }
 }


### PR DESCRIPTION
This PR does 2 things:

  - Introduce separate `lint` script (besides calling it in `test` script)
  - Upgrade eslint to v6.2.1

First small preparation steps for #105