### PR TITLE
Switch to getting mapComponent

### DIFF
--- a/app/controller/button/SpatialQueryButton.js
+++ b/app/controller/button/SpatialQueryButton.js
@@ -102,7 +102,9 @@ Ext.define('CpsiMapview.controller.button.SpatialQueryButtonController', {
             return;
         }
 
-        var mapComp = me.mapComponent || BasiGX.util.Map.getMapComponent();
+        if (!me.mapComponent) {
+            me.mapComponent = BasiGX.util.Map.getMapComponent();
+        }
 
         var projString = mapComp.getMap().getView().getProjection().getCode();
         var geomFieldName = view.queryLayer.get('geomFieldName') ||

--- a/app/controller/button/SpatialQueryButton.js
+++ b/app/controller/button/SpatialQueryButton.js
@@ -13,6 +13,16 @@ Ext.define('CpsiMapview.controller.button.SpatialQueryButtonController', {
     drawQueryInteraction: null,
 
     /**
+    * The OpenLayers map. If not given, will be auto-detected
+    */
+    map: null,
+
+    /**
+     * The BasiGX mapComponent. If not given, will be auto-detected
+     */
+    mapComponent: null,
+
+    /**
      * Function to determine the query layer if not yet defined in class
      */
     findQueryLayer: function () {
@@ -35,6 +45,13 @@ Ext.define('CpsiMapview.controller.button.SpatialQueryButtonController', {
         var me = this;
         var view = me.getView();
 
+        if (view.map && view.map instanceof ol.Map) {
+            me.map = view.map;
+        } else {
+            // guess map as fallback
+            me.map = BasiGX.util.Map.getMapComponent().map;
+        }
+
         if (!view.queryLayer) {
             me.findQueryLayer();
         }
@@ -52,7 +69,7 @@ Ext.define('CpsiMapview.controller.button.SpatialQueryButtonController', {
                 geometryFunction: geometryFunction,
                 type: type
             });
-            view.map.addInteraction(me.drawQueryInteraction);
+            me.map.addInteraction(me.drawQueryInteraction);
         }
         if (pressed) {
             me.drawQueryInteraction.setActive(true);
@@ -84,7 +101,9 @@ Ext.define('CpsiMapview.controller.button.SpatialQueryButtonController', {
         if (!view.queryLayer) {
             return;
         }
-        var mapComp = CpsiMapview.view.main.Map.guess();
+
+        var mapComp = me.mapComponent || BasiGX.util.Map.getMapComponent();
+
         var projString = mapComp.getMap().getView().getProjection().getCode();
         var geomFieldName = view.queryLayer.get('geomFieldName') ||
             view.queryLayer.getSource().get('geomFieldName') ||
@@ -128,7 +147,7 @@ Ext.define('CpsiMapview.controller.button.SpatialQueryButtonController', {
     onWfsExecuteSuccess: function (response) {
         var me = this;
         var view = me.getView();
-        var mapComp = CpsiMapview.view.main.Map.guess();
+        var mapComp = me.mapComponent || BasiGX.util.Map.getMapComponent();
         mapComp.setLoading(false);
         var wfsResponse = response.responseText;
         if (wfsResponse.indexOf('Exception') > 0) {
@@ -154,7 +173,7 @@ Ext.define('CpsiMapview.controller.button.SpatialQueryButtonController', {
         if (response && response.responseText) {
             responseTxt = response.responseText;
         }
-        var mapComp = CpsiMapview.view.main.Map.guess();
+        var mapComp = me.mapComponent || BasiGX.util.Map.getMapComponent();
         mapComp.setLoading(false);
         view.fireEvent('cmv-spatial-query-error', responseTxt);
     }

--- a/app/controller/button/SpatialQueryButton.js
+++ b/app/controller/button/SpatialQueryButton.js
@@ -102,9 +102,7 @@ Ext.define('CpsiMapview.controller.button.SpatialQueryButtonController', {
             return;
         }
 
-        if (!me.mapComponent) {
-            me.mapComponent = BasiGX.util.Map.getMapComponent();
-        }
+        var mapComp = me.mapComponent || BasiGX.util.Map.getMapComponent();
 
         var projString = mapComp.getMap().getView().getProjection().getCode();
         var geomFieldName = view.queryLayer.get('geomFieldName') ||


### PR DESCRIPTION
When testing the new SpatialQueryButtonController in #116 I was getting errors that `view.map is null` on the `view.map.addInteraction(me.drawQueryInteraction);` line. 

Also the code was getting a map rather than a mapComponent with:

`var mapComp = CpsiMapview.view.main.Map.guess();`

This switches it to:

`var mapComp = me.mapComponent || BasiGX.util.Map.getMapComponent();`

If not `mapComp.getMap()` is `undefined. 

Several other tools use the same approach e.g. the [DigitizeButtonController](https://github.com/compassinformatics/cpsi-mapview/blob/master/app/controller/button/DigitizeButtonController.js)

@ahennr - could you check the changes to see that they make sense?
Thanks for all the work on the tool!