### PR TITLE
Layer tree - Update tree nodes depending on layers resolution restrictions

### DIFF
--- a/app/plugin/TreeColumnInResolutionRange.js
+++ b/app/plugin/TreeColumnInResolutionRange.js
@@ -137,7 +137,7 @@ Ext.define('CpsiMapview.plugin.TreeColumnInResolutionRange', {
         }
 
         if (maxScale && minScale) {
-            scale = Ext.String.format('Visible between <b>1:{0}</b> and <b>1:{1}</b>', maxScale, minScale);
+            scale = Ext.String.format('Visible between <b>1:{0}</b> and <b>1:{1}</b>', minScale, maxScale);
         } else {
             if (maxScale) {
                 scale = Ext.String.format('Visible at <b>1:{0}</b> and above', maxScale);

--- a/app/plugin/TreeColumnInResolutionRange.js
+++ b/app/plugin/TreeColumnInResolutionRange.js
@@ -58,8 +58,13 @@ Ext.define('CpsiMapview.plugin.TreeColumnInResolutionRange', {
         Ext.each(treeNodes.items, function (node) {
             var inRange = me.layerInResolutionRange(node.getOlLayer(), resolution);
             node[inRange ? 'removeCls' : 'addCls']('cpsi-tree-node-disabled');
+            var descriptionBefore = node.getOlLayer().get('description');
             var description = me.getTooltipText(node, inRange, unit);
+            var changed = description !== descriptionBefore;
             node.getOlLayer().set('description', description);
+            if (changed) {
+                node.triggerUIUpdate();
+            }
         });
         // This triggers the rendering if any existing StyleSwitcherRadioGroups
         treepanel.fireEvent('itemupdate');

--- a/app/plugin/TreeColumnInResolutionRange.js
+++ b/app/plugin/TreeColumnInResolutionRange.js
@@ -1,0 +1,151 @@
+/**
+ * Plugin to change opacity and font style of a layer tree node
+ * if assigned layer is not in range
+ */
+Ext.define('CpsiMapview.plugin.TreeColumnInResolutionRange', {
+    extend: 'Ext.plugin.Abstract',
+    alias: 'plugin.cmv_tree_inresolutionrange',
+    pluginId: 'cmv_tree_inresolutionrange',
+
+    /**
+     * Initialize TreeColumnInResolutionRange plugin
+     * @param {Ext.grid.column.Column} column The column to register the plugin
+     *     for
+     * @private
+     */
+    init: function(column) {
+        var me = this;
+        if (!(column instanceof Ext.grid.column.Column)) {
+            Ext.log.warn('Plugin shall only be applied to instances of' +
+                  ' Ext.grid.column.Column');
+            return;
+        }
+        var mapComponent = BasiGX.util.Map.getMapComponent();
+        mapComponent.getStore().setChangeLayerFilterFn(me.changeLayerFilterFn);
+
+        var map = mapComponent.getMap();
+        map.getView().on('change:resolution', me.onChangeResolution, me);
+
+        me.cmp.up('treepanel').on('afterlayout', function (tp) {
+            if (tp.getStore().count()) {
+                map.getView().dispatchEvent('change:resolution');
+            }
+        });
+    },
+
+    /**
+     * Custom change layer filter function to be applied to store
+     * @param {GeoExt.data.model.Layer} record An GeoExt layer model instance
+     * @private
+     */
+    changeLayerFilterFn: function (record) {
+        var layer = this;
+        return layer.id === record.getOlLayer().id;
+    },
+
+    /**
+     * When resolution changes in map: update tree nodes if needed
+     * @param {ol.Object.Event} evt The openlayers event
+     */
+    onChangeResolution: function (evt) {
+        var me = this;
+        var mapView = evt.target;
+        var unit = mapView.getProjection().getUnits();
+        var resolution = mapView.getResolution();
+        var treepanel = me.cmp.up('treepanel');
+        var nodeStore = treepanel.getStore();
+        var treeNodes = nodeStore.getData();
+        Ext.each(treeNodes.items, function (node) {
+            var inRange = me.layerInResolutionRange(node.getOlLayer(), resolution);
+            node[inRange ? 'removeCls' : 'addCls']('cpsi-tree-node-disabled');
+            var description = me.getTooltipText(node, inRange, unit);
+            node.getOlLayer().set('description', description);
+        });
+        nodeStore.fireEvent('refresh');
+    },
+
+    /**
+     * Check if layer is visible in current resolution range
+     *
+     * @param {ol.layer.Base} layer The OpenLayers layer
+     * @param {Number} currentRes The current map resolution
+     *
+     * @returns {Boolean} layer is in resolution range?
+     */
+    layerInResolutionRange: function (layer, currentRes) {
+        if (!layer || !currentRes) {
+            // It is questionable what we should return in this case, I opted for
+            // false, since we cannot sanely determine a correct answer.
+            return false;
+        }
+        var layerMinRes = layer.getMinResolution(); // default: 0 if unset
+        var layerMaxRes = layer.getMaxResolution(); // default: Infinity if unset
+        // minimum resolution is inclusive, maximum resolution exclusive
+        var within = currentRes >= layerMinRes && currentRes < layerMaxRes;
+        return within;
+    },
+
+    /**
+     * Get tooltip text for node
+     *
+     * @param {Ext.data.NodeInterface} node The layer tree node
+     * @param {Boolean} inRange Is layer in range
+     * @param {String} unit The unit defined in current map projection
+     *
+     * @returns {String} The toolip text valid for current range
+     */
+    getTooltipText: function (node, inRange, unit) {
+        if (!Ext.isDefined(node.originalQtip)) {
+            node.originalQtip = node.getOlLayer().get('description') || '';
+        }
+
+        if (inRange) {
+            return node.originalQtip.length > 0 ? node.originalQtip : undefined;
+        }
+
+        var currentTip = node.getOlLayer().get('description');
+        if (currentTip && (currentTip.indexOf('<br />') > -1 ||
+            currentTip.indexOf('Visible') > -1)) {
+            return currentTip;
+        }
+
+        var description = this.enhanceTooltip(node.getOlLayer(), unit);
+        return description;
+    },
+
+    /**
+     * Adds scale restriction information to decription text
+     * @param {ol.layer.Base} layer The OpenLayers layer
+     * @param {String} unit The unit defined in current map projection
+     *
+     * @returns {String} The enhanced toolip text
+     */
+    enhanceTooltip: function (layer, unit) {
+        var scale = '', maxScale, minScale;
+        maxScale = BasiGX.util.Map.getScaleForResolution(layer.getMaxResolution(), unit);
+        minScale = BasiGX.util.Map.getScaleForResolution(layer.getMinResolution(), unit);
+        if (maxScale) {
+            // round to nearest 10
+            maxScale = Math.round(maxScale / 10) * 10;
+            maxScale = Ext.util.Format.number(maxScale, '0,000');
+        }
+        if (minScale) {
+            // round both to nearest 10
+            minScale = Math.round(minScale / 10) * 10;
+            minScale = Ext.util.Format.number(minScale, '0,000');
+        }
+
+        if (maxScale && minScale) {
+            scale = Ext.String.format('Visible between <b>1:{0}</b> and <b>1:{1}</b>', maxScale, minScale);
+        } else {
+            if (maxScale) {
+                scale = Ext.String.format('Visible at <b>1:{0}</b> and above', maxScale);
+            }
+            if (minScale) {
+                scale = Ext.String.format('Visible at <b>1:{0}<b> and below', minScale);
+            }
+        }
+        return layer.get('description') ? (layer.get('description').trim() + '<br />' + scale) : scale;
+    }
+
+});

--- a/app/plugin/TreeColumnInResolutionRange.js
+++ b/app/plugin/TreeColumnInResolutionRange.js
@@ -26,7 +26,7 @@ Ext.define('CpsiMapview.plugin.TreeColumnInResolutionRange', {
         var map = mapComponent.getMap();
         map.getView().on('change:resolution', me.onChangeResolution, me);
 
-        me.cmp.up('treepanel').on('afterlayout', function (tp) {
+        me.cmp.up('treepanel').on('boxready', function (tp) {
             if (tp.getStore().count()) {
                 map.getView().dispatchEvent('change:resolution');
             }
@@ -61,7 +61,8 @@ Ext.define('CpsiMapview.plugin.TreeColumnInResolutionRange', {
             var description = me.getTooltipText(node, inRange, unit);
             node.getOlLayer().set('description', description);
         });
-        nodeStore.fireEvent('refresh');
+        // This triggers the rendering if any existing StyleSwitcherRadioGroups
+        treepanel.fireEvent('itemupdate');
     },
 
     /**

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -48,6 +48,8 @@ Ext.define('CpsiMapview.view.LayerTree', {
                         'cmv_menuitem_layerrefresh',
                         'cmv_menuitem_layerlabels'
                     ]
+                }, {
+                    ptype: 'cmv_tree_inresolutionrange'
                 }]
             }
         ]

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -6,8 +6,10 @@
     "isDefaultBaseLayer": false,
     "text": "Grey Background",
     "url": "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}",
+    "qtip": "This is the background layer",
     "openLayers": {
-      "maxResolution": 1222.99245234375,
+      "maxResolution": 560,
+      "minResolution": 28,
       "numZoomLevels": 13,
       "projection": "EPSG:900913",
       "visibility": true,
@@ -148,7 +150,7 @@
         "maxResolution": 1222.99245234375,
         "numZoomLevels": 12,
         "opacity": 0.9,
-        "visibility": true
+        "visibility": false
       },
       "serverOptions": {
         "outputFormat": "application/json; subtype=geojson"

--- a/sass/src/view/LayerTree.scss
+++ b/sass/src/view/LayerTree.scss
@@ -3,3 +3,8 @@
     border: 1px solid transparent;
     border-radius: 6px;
 }
+
+.cpsi-tree-node-disabled {
+    opacity: 0.7;
+    font-style: italic;
+}


### PR DESCRIPTION
This PR adds a new plugin `TreeColumnInResolutionRange` that changes opacity and font style of a layer tree node if the assigned layer is not in range. In addition, the visible scales are shown in a qtip if tree node is hovered.  

![scale_dependent_nodes](https://user-images.githubusercontent.com/10559603/64326953-2e15c480-cfcb-11e9-829c-b4a37519633d.gif)

Depends on https://github.com/geoext/geoext3/pull/580, as soon as this is merged, I'll remove WIP state