### PR TITLE
Add a new layer GUID property

### DIFF
--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -85,6 +85,7 @@ Ext.define('CpsiMapview.factory.Layer', {
             mapLayer.set('legendUrl', layerConf.legendUrl);
             mapLayer.set('legendHeight', layerConf.legendHeight);
             mapLayer.set('legendWidth', layerConf.legendWidth);
+            mapLayer.set('guid', layerConf.guid);
 
             // this gets transformed to qtip on the layer tree node
             mapLayer.set('description', layerConf.qtip);

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -144,6 +144,7 @@
       "url": "https://pmstipperarydev.compass.ie/mapserver/?",
       "geometryProperty": "msGeometry",
       "featureType": "Accidents",
+      "guid": "0cf84adb-059b-4cf4-8dfc-337c29b1b205",
       "openLayers": {
         "maxResolution": 1222.99245234375,
         "numZoomLevels": 12,


### PR DESCRIPTION
Add a GUID that can be used to find a lyaer. 
This is to avoid events etc. breaking when relying on text labels to find layers, and forgetting to update whenever a label changes. 