### PR TITLE
Fire an event with the spatial Ext.util.Filter

### DIFF
--- a/app/controller/button/SpatialQueryButton.js
+++ b/app/controller/button/SpatialQueryButton.js
@@ -23,6 +23,13 @@ Ext.define('CpsiMapview.controller.button.SpatialQueryButtonController', {
     mapComponent: null,
 
     /**
+    * If set to true a Wfs GetFeatures request will be automatically triggered
+    *
+    * @cfg {Boolean} triggerWfsRequest Whether or not to trigger a Wfs GetFeatures request
+    */
+    triggerWfsRequest: true,
+
+    /**
      * Function to determine the query layer if not yet defined in class
      */
     findQueryLayer: function () {
@@ -81,13 +88,51 @@ Ext.define('CpsiMapview.controller.button.SpatialQueryButtonController', {
     },
 
     /**
+    * Normalizes the given degree value.
+    *
+    * @param  {ol.geom.Geometry} geometry The geometry
+    * @return {Ext.util.Filter}       A filter spatial
+    * @private
+    */
+    createSpatialFilter: function (geometry) {
+        var me = this;
+        var filter = null;
+
+        var view = me.getView();
+        if (!view.queryLayer) {
+            return;
+        }
+
+        var mapComp = me.mapComponent || BasiGX.util.Map.getMapComponent();
+        var projString = mapComp.getMap().getView().getProjection().getCode();
+        var geomFieldName = view.queryLayer.get('geomFieldName') ||
+            view.queryLayer.getSource().get('geomFieldName') ||
+            'the_geom';
+
+        if (!Ext.isEmpty(geometry)) {
+            filter = GeoExt.util.OGCFilter.createSpatialFilter(view.spatialOperator, geomFieldName, geometry, projString);
+        }
+
+        return filter;
+
+    },
+
+    /**
      * Help method to create a polygon geometry from drawn irregular polygon.
      *
      * @param {Ext.Event} evt The add-Event containing drawn feature
      */
     getGeometryFromPolygonAndTriggerWfs: function (evt) {
+        var me = this;
         var geometry = evt.element.getGeometry();
-        this.buildAndRequestQuery(geometry);
+        var view = me.getView();
+
+        var filter = me.createSpatialFilter(geometry);
+        view.fireEvent('cmv-spatial-query-filter', filter);
+
+        if (me.triggerWfsRequest === true) {
+            this.buildAndRequestQuery(geometry);
+        }
     },
 
     /**

--- a/app/controller/button/SpatialQueryButton.js
+++ b/app/controller/button/SpatialQueryButton.js
@@ -88,7 +88,7 @@ Ext.define('CpsiMapview.controller.button.SpatialQueryButtonController', {
     },
 
     /**
-    * Normalizes the given degree value.
+    * Creates a Filter object from the passed geometry and queryLayer
     *
     * @param  {ol.geom.Geometry} geometry The geometry
     * @return {Ext.util.Filter}       A filter spatial


### PR DESCRIPTION
Trigger a new custom event containing the spatial filter created by the tool. This can then be combined with other filters external to the tool to make complex filters. 

The current functionality is preserved by default, but can be deactivated by setting the triggerWfsRequest flag to false in cases where the button should simply create a filter and fire the event. 