### PR TITLE
Add switch layer functionality

### DIFF
--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -108,87 +108,6 @@ Ext.define('CpsiMapview.factory.Layer', {
     },
 
     /**
-     * Loops through all layers, identifies switch layers
-     * and replaces them if required
-     *
-     * @param {ol.Object.Event} evt The event which contains the view.
-     */
-    handleSwitchLayerOnResolutionChange: function (evt) {
-        var resolution = evt.target.getResolution();
-        var allLayers = BasiGX.util.Map.getMapComponent().getMap().getLayers();
-        var overlayGroup = BasiGX.util.Layer.getLayerByName('Layers', allLayers);
-
-        if (!Ext.isDefined(overlayGroup)) {
-            return;
-        }
-        var overlayCollection = overlayGroup.getLayers();
-
-        overlayCollection.forEach(function (layer, index) {
-
-            if(layer.get('isSwitchLayer') && LayerFactory.isLayerSwitchNecessary(layer, resolution)){
-
-                var switchConfiguration = layer.get('switchConfiguration');
-                var newLayer = LayerFactory.createSwitchLayer(switchConfiguration);
-
-                overlayCollection.setAt(index, newLayer);
-
-                LayerFactory.updateLayerTreeForSwitchLayers();
-            }
-        });
-    },
-
-    /**
-     * Checks if the switch layer has to be replaced
-     *
-     * @param {*} layer       the layer to check
-     * @param {*} resolution  the resolution of the map view
-     */
-    isLayerSwitchNecessary: function(layer, resolution){
-
-        var switchConfiguration = layer.get('switchConfiguration');
-
-        // get precomputed switch resolution from layer config
-        var switchResolution = switchConfiguration.switchResolution;
-
-        // logic that checks when a switch layer needs to be replaced
-        var mapviewBelowSwitchResolution = (resolution < switchResolution);
-        var mapViewAboveSwitchResolution = !mapviewBelowSwitchResolution;
-
-        var currentSwitchType = layer.get('currentSwitchType');
-
-        var createCloseView = (mapviewBelowSwitchResolution && (currentSwitchType === 'above_switch_resolution'));
-        var createFarAwayView = (mapViewAboveSwitchResolution && (currentSwitchType === 'below_switch_resolution'));
-
-        return createCloseView || createFarAwayView;
-    },
-
-
-    /**
-     * Updates the switch layer items of the layer tree. This is
-     * necessary when switch layers get replaced.
-     */
-    updateLayerTreeForSwitchLayers: function(){
-
-        var treePanel = Ext.ComponentQuery.query('treepanel')[0];
-        var nodeStore = treePanel.getStore();
-        var treeNodes = nodeStore.getData();
-
-        Ext.each(treeNodes.items, function (node) {
-            var switchConf = node.getOlLayer().get('switchConfiguration');
-
-            // only change for switch layers
-            if(switchConf){
-                node.triggerUIUpdate();
-            }
-        });
-
-        // TODO: not sure if this is required (?)
-        if(treePanel) {
-            treePanel.fireEvent('itemupdate');
-        }
-    },
-
-    /**
      * The handler when a virtual base layer changes its visibility. This method
      * ensures that only one of these virtual base layers is visible at a time.
      *
@@ -936,6 +855,87 @@ Ext.define('CpsiMapview.factory.Layer', {
         });
 
         return gsStyle;
+    },
+
+    /**
+     * Loops through all layers, identifies switch layers
+     * and replaces them if required
+     *
+     * @param {ol.Object.Event} evt The event which contains the view.
+     */
+    handleSwitchLayerOnResolutionChange: function (evt) {
+        var resolution = evt.target.getResolution();
+        var allLayers = BasiGX.util.Map.getMapComponent().getMap().getLayers();
+        var overlayGroup = BasiGX.util.Layer.getLayerByName('Layers', allLayers);
+
+        if (!Ext.isDefined(overlayGroup)) {
+            return;
+        }
+        var overlayCollection = overlayGroup.getLayers();
+
+        overlayCollection.forEach(function (layer, index) {
+
+            if(layer.get('isSwitchLayer') && LayerFactory.isLayerSwitchNecessary(layer, resolution)){
+
+                var switchConfiguration = layer.get('switchConfiguration');
+                var newLayer = LayerFactory.createSwitchLayer(switchConfiguration);
+
+                overlayCollection.setAt(index, newLayer);
+
+                LayerFactory.updateLayerTreeForSwitchLayers();
+            }
+        });
+    },
+
+    /**
+     * Checks if the switch layer has to be replaced
+     *
+     * @param {*} layer       the layer to check
+     * @param {*} resolution  the resolution of the map view
+     */
+    isLayerSwitchNecessary: function(layer, resolution){
+
+        var switchConfiguration = layer.get('switchConfiguration');
+
+        // get precomputed switch resolution from layer config
+        var switchResolution = switchConfiguration.switchResolution;
+
+        // logic that checks when a switch layer needs to be replaced
+        var mapviewBelowSwitchResolution = (resolution < switchResolution);
+        var mapViewAboveSwitchResolution = !mapviewBelowSwitchResolution;
+
+        var currentSwitchType = layer.get('currentSwitchType');
+
+        var createCloseView = (mapviewBelowSwitchResolution && (currentSwitchType === 'above_switch_resolution'));
+        var createFarAwayView = (mapViewAboveSwitchResolution && (currentSwitchType === 'below_switch_resolution'));
+
+        return createCloseView || createFarAwayView;
+    },
+
+
+    /**
+     * Updates the switch layer items of the layer tree. This is
+     * necessary when switch layers get replaced.
+     */
+    updateLayerTreeForSwitchLayers: function(){
+
+        var treePanel = Ext.ComponentQuery.query('treepanel')[0];
+        var nodeStore = treePanel.getStore();
+        var treeNodes = nodeStore.getData();
+
+        Ext.each(treeNodes.items, function (node) {
+            var switchConf = node.getOlLayer().get('switchConfiguration');
+
+            // only change for switch layers
+            if(switchConf){
+                node.triggerUIUpdate();
+            }
+        });
+
+        // TODO: not sure if this is required (?)
+        if(treePanel) {
+            treePanel.fireEvent('itemupdate');
+        }
     }
 
 });

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -926,7 +926,6 @@ Ext.define('CpsiMapview.factory.Layer', {
      * necessary when switch layers get replaced.
      */
     updateLayerTreeForSwitchLayers: function(){
-
         var treePanel = Ext.ComponentQuery.query('treepanel')[0];
         var nodeStore = treePanel.getStore();
         var treeNodes = nodeStore.getData();
@@ -939,11 +938,6 @@ Ext.define('CpsiMapview.factory.Layer', {
                 node.triggerUIUpdate();
             }
         });
-
-        // TODO: not sure if this is required (?)
-        if(treePanel) {
-            treePanel.fireEvent('itemupdate');
-        }
     }
 
 });

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -78,13 +78,6 @@ Ext.define('CpsiMapview.factory.Layer', {
             //do nothing, and return empty layer
         }
 
-        // TODO: make sure this listener is called only once
-
-        // listener that checks the resolution and
-        // changes the switch layer if required
-        var olMap = BasiGX.util.Map.getMapComponent().getMap();
-        olMap.getView().on('change:resolution', LayerFactory.handleSwitchLayerOnResolutionChange);
-
         // This is the same for all types
         if (mapLayer) {
             // handle base layer logic
@@ -121,27 +114,27 @@ Ext.define('CpsiMapview.factory.Layer', {
      * @param {ol.Object.Event} evt The event which contains the view.
      */
     handleSwitchLayerOnResolutionChange: function (evt) {
-
         var resolution = evt.target.getResolution();
-
-        // TODO: this needs to be called more elegantly
         var allLayers = BasiGX.util.Map.getMapComponent().getMap().getLayers();
-        var overlayGroup =  BasiGX.util.Layer.getLayerByName('Layers', allLayers).getLayers();
+        var overlayGroup = BasiGX.util.Layer.getLayerByName('Layers', allLayers);
 
-        overlayGroup.forEach(
-            function (layer, index) {
+        if (!Ext.isDefined(overlayGroup)) {
+            return;
+        }
+        var overlayCollection = overlayGroup.getLayers();
 
-                if(layer.get('isSwitchLayer') && LayerFactory.isLayerSwitchNecessary(layer, resolution)){
+        overlayCollection.forEach(function (layer, index) {
 
-                    var switchConfiguration = layer.get('switchConfiguration');
-                    var newLayer = LayerFactory.createSwitchLayer(switchConfiguration);
+            if(layer.get('isSwitchLayer') && LayerFactory.isLayerSwitchNecessary(layer, resolution)){
 
-                    overlayGroup.setAt(index, newLayer);
+                var switchConfiguration = layer.get('switchConfiguration');
+                var newLayer = LayerFactory.createSwitchLayer(switchConfiguration);
 
-                    LayerFactory.updateLayerTreeForSwitchLayers();
-                }
+                overlayCollection.setAt(index, newLayer);
+
+                LayerFactory.updateLayerTreeForSwitchLayers();
             }
-        );
+        });
     },
 
     /**

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -155,10 +155,16 @@ Ext.define('CpsiMapview.factory.Layer', {
         var resultLayer;
         if (resolution < layerConf.switchResolution) {
             var confBelowSwitchResolution = layerConf.layers[1];
+            // apply overall visibility to sub layer
+            confBelowSwitchResolution.openLayers.visibility =
+                layerConf.visibility;
             resultLayer = LayerFactory.createLayer(confBelowSwitchResolution);
             resultLayer.set('currentSwitchType', 'below_switch_resolution');
         } else {
             var confAboveSwitchResolution = layerConf.layers[0];
+            // apply overall visibility to sub layer
+            confAboveSwitchResolution.openLayers.visibility =
+                layerConf.visibility;
             resultLayer = LayerFactory.createLayer(confAboveSwitchResolution);
             resultLayer.set('currentSwitchType', 'above_switch_resolution');
         }
@@ -878,6 +884,8 @@ Ext.define('CpsiMapview.factory.Layer', {
             if(layer.get('isSwitchLayer') && LayerFactory.isLayerSwitchNecessary(layer, resolution)){
 
                 var switchConfiguration = layer.get('switchConfiguration');
+                // restore current layer visibility
+                switchConfiguration.visibility = layer.getVisible();
                 var newLayer = LayerFactory.createSwitchLayer(switchConfiguration);
 
                 overlayCollection.setAt(index, newLayer);

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -133,8 +133,14 @@ Ext.define('CpsiMapview.factory.Layer', {
         Ext.log.info('Not implemented yet', layerConf);
     },
 
+    /**
+     * Creates an layer which renders shows a WMS for small scales and a WFS
+     * for large scales as sub layer.
+     *
+     * @param  {Object} layerConf The configuration object for this layer
+     * @return {ol.layer.Base}    The created sub layer
+     */
     createSwitchLayer: function(layerConf) {
-
         // compute switch resolution when layer is
         // initialised the first time
         if(!layerConf.switchResolution){
@@ -869,7 +875,7 @@ Ext.define('CpsiMapview.factory.Layer', {
      *
      * @param {ol.Object.Event} evt The event which contains the view.
      */
-    handleSwitchLayerOnResolutionChange: function (evt) {
+    handleSwitchLayerOnResolutionChange: function(evt) {
         var resolution = evt.target.getResolution();
         var allLayers = BasiGX.util.Map.getMapComponent().getMap().getLayers();
         var overlayGroup = BasiGX.util.Layer.getLayerByName('Layers', allLayers);
@@ -898,13 +904,11 @@ Ext.define('CpsiMapview.factory.Layer', {
     /**
      * Checks if the switch layer has to be replaced
      *
-     * @param {*} layer       the layer to check
-     * @param {*} resolution  the resolution of the map view
+     * @param {ol.layer.Base} layer the layer to check
+     * @param {Number} resolution  the resolution of the map view
      */
-    isLayerSwitchNecessary: function(layer, resolution){
-
+    isLayerSwitchNecessary: function(layer, resolution) {
         var switchConfiguration = layer.get('switchConfiguration');
-
         // get precomputed switch resolution from layer config
         var switchResolution = switchConfiguration.switchResolution;
 
@@ -925,10 +929,10 @@ Ext.define('CpsiMapview.factory.Layer', {
      * Updates the switch layer items of the layer tree. This is
      * necessary when switch layers get replaced.
      */
-    updateLayerTreeForSwitchLayers: function(){
+    updateLayerTreeForSwitchLayers: function() {
         var treePanel = Ext.ComponentQuery.query('treepanel')[0];
-        var nodeStore = treePanel.getStore();
-        var treeNodes = nodeStore.getData();
+        var treeStore = treePanel.getStore();
+        var treeNodes = treeStore.getData();
 
         Ext.each(treeNodes.items, function (node) {
             var switchConf = node.getOlLayer().get('switchConfiguration');

--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -188,6 +188,10 @@ Ext.define('CpsiMapview.view.main.Map', {
             me.olMap.on('pointermove', function () {
                 me.fireEvent('cmv-map-pointermove');
             });
+
+            // listener that checks the resolution and changes the switch layer if required
+            me.olMap.getView().on('change:resolution',
+                LayerFactory.handleSwitchLayerOnResolutionChange);
         }
 
         if (me.enablePermalink) {

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -107,7 +107,51 @@
       "projection": "EPSG:900913",
       "visibility": false
     }
-  }, {
+  },{
+    "layerType": "switchlayer",
+    "visibility": false,
+    "vectorFeaturesMinScale": 80000,
+    "layers": [
+      {
+        "layerType": "wms",
+        "text": "Light Unit Switch Layer (far)",
+        "url": "https://plmonaghandev.compass.ie/mapserver/",
+        "isBaseLayer": false,
+        "isDefaultBaseLayer": false,
+        "serverOptions": {
+          "layers": "LightUnit",
+          "version": "1.3.0"
+        },
+        "openLayers": {
+          "singleTile": false
+        },
+        "styles": [
+          "Unit Type",
+          "Owner"
+        ],
+        "labelClassName": "labels"
+      },
+      {
+        "layerType": "wfs",
+        "text": "Light Unit Switch Layer (close)",
+        "url": "https://plmonaghandev.compass.ie/mapserver/?",
+        "geometryProperty": "msGeometry",
+        "featureType": "LightUnit",
+        "sldUrl": "resources/data/styling/LightUnit_Unit_Type.xml",
+        "openLayers": {},
+        "serverOptions": {
+          "outputFormat": "geojson"
+        },
+        "noCluster": true,
+        "stylesBaseUrl": "https://plmonaghandev.compass.ie/publiclighting-test/resources/data/styling/",
+        "styles": [
+          "LightUnit_Unit_Type.xml",
+          "LightUnit_Owner.xml"
+        ],
+        "stylesForceNumericFilterVals": true
+      }
+    ]
+  },{
     "layerType": "wms",
     "text": "Works_Export (needs proxy)",
     "url": "mapserver/",


### PR DESCRIPTION
Hey there!
I created a [switch layer](https://github.com/compassinformatics/cpsi-mapview/issues/103) type in the layer factory. 

It adds a listener on the resolution: when the resolution changes all layers are checked if they are switch layers and if they need to be switched. After a switch the layertree gets updated.

