### PR TITLE
Switch layer legend with style

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
         "GeoExt": false,
         "CpsiMapview": false,
         "LayerFactory": false,
+        "LegendUtil": false,
         "GeoStylerSLDParser": false,
         "GeoStylerOpenlayersParser": false,
         "google": false

--- a/app/plugin/BasicTreeColumnLegends.js
+++ b/app/plugin/BasicTreeColumnLegends.js
@@ -7,6 +7,8 @@ Ext.define('CpsiMapview.plugin.BasicTreeColumnLegends', {
     alias: 'plugin.cmv_basic_tree_column_legend',
     pluginId: 'cmv_basic_tree_column_legend',
 
+    requires: ['CpsiMapview.util.Legend'],
+
     /**
      * @private
      */
@@ -49,9 +51,16 @@ Ext.define('CpsiMapview.plugin.BasicTreeColumnLegends', {
             var w = layer.get('legendWidth');
             var h = layer.get('legendHeight');
             if (!legendUrl) {
-                // 1px×1px transparent gif
-                legendUrl = staticMe.transparentGif;
-                w = h = 1;
+
+                if (Ext.isNumber(w) || Ext.isNumber(h)) {
+                    // in case we have no URL we try to detect getLegendGraphic
+                    // request for WMS / WFS
+                    legendUrl = LegendUtil.createGetLegendGraphicUrl(layer);
+                } else {
+                    // 1px×1px transparent gif
+                    legendUrl = staticMe.transparentGif;
+                    w = h = 1;
+                }
             }
             // if the legend cannot be obtained (which happens e.g. for cascaded
             // WMS layers, as geoserver does not support legends for these

--- a/app/plugin/TreeColumnStyleSwitcher.js
+++ b/app/plugin/TreeColumnStyleSwitcher.js
@@ -103,8 +103,10 @@ Ext.define('CpsiMapview.plugin.TreeColumnStyleSwitcher', {
             // ensure the radio groups are re-rendered every time the tree view
             // changes (e.g.) layer visibility is changed
             treeColumn.up('treepanel').getView().on('itemupdate', function () {
-                me.cleanupAllRadioGroups();
-                me.renderRadioGroups();
+                Ext.defer(function () {
+                    me.cleanupAllRadioGroups();
+                    me.renderRadioGroups();
+                }, 1);
             });
 
             // Unfortunately we have to defer cascading of the LayerTree nodes.

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -228,5 +228,21 @@ Ext.define('CpsiMapview.view.LayerTree', {
         });
 
         return rootLayerGroup;
+    },
+
+    /**
+     * Updates the layer node UI for the given layer.
+     *
+     * @param  {ol.layer.Base} layer The layer to update in the tree
+     */
+    updateLayerNodeUi: function (layer) {
+        var me = this;
+        var treeStore = me.getStore();
+
+        treeStore.each(function (node) {
+            if (node.getOlLayer().get('name') === layer.get('name')) {
+                node.triggerUIUpdate();
+            }
+        });
     }
 });

--- a/app/view/layer/StyleSwitcherRadioGroup.js
+++ b/app/view/layer/StyleSwitcherRadioGroup.js
@@ -103,6 +103,7 @@ Ext.define('CpsiMapview.view.layer.StyleSwitcherRadioGroup', {
         if (newVal === true) {
             var layer = me.layer;
             var newStyle = radioBtn.inputValue;
+            var layerTreePanel = Ext.ComponentQuery.query('cmv_layertree')[0];
 
             // preserve active style as lookup
             layer.set('activatedStyle', newStyle);
@@ -122,6 +123,11 @@ Ext.define('CpsiMapview.view.layer.StyleSwitcherRadioGroup', {
                 };
                 layer.getSource().updateParams(newParams);
 
+                if (layerTreePanel) {
+                    // force update of corresponding layer node UI (e.g. legend)
+                    layerTreePanel.updateLayerNodeUi(layer);
+                }
+
             } else if (layer.get('isWfs') || layer.get('isVt')) {
 
                 var sldUrl = layer.get('stylesBaseUrl') + newStyle;
@@ -129,6 +135,11 @@ Ext.define('CpsiMapview.view.layer.StyleSwitcherRadioGroup', {
                 var forceNumericFilterVals = layer.get('stylesForceNumericFilterVals');
                 // load and parse SLD and apply it to layer
                 LayerFactory.loadSld(layer, sldUrl, forceNumericFilterVals);
+
+                if (layer.get('isWfs') && layerTreePanel) {
+                    // force update of corresponding layer node UI (e.g. legend)
+                    layerTreePanel.updateLayerNodeUi(layer);
+                }
 
             } else {
                 Ext.Logger.info('Layer type not supported in StyleSwitcherRadioGroup');

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -219,7 +219,9 @@
         "visibility": false
       },
       "styles": ["Unit Type", "Owner"],
-      "labelClassName": "labels"
+      "labelClassName": "labels",
+      "legendWidth": 100
+
     }, {
         "layerType": "wfs",
         "text": "Light Unit WFS",


### PR DESCRIPTION
This ensures that the legend for WMS / WFS is shown by `getLegendGraphic` request (if not defined as static image) and that the legend will be updated in case the layer style is changed by the user.

Convention to activate the automatic `getLegendGraphic` is that either `legendWidth` or `legendHeight` has to be defined in the WMS / WFS layer confinguration and no property `legendUrl` is set.

For WFS the WMS `getLegendGraphic` request is used by convetion, as specified in #117.