### PR TITLE
Autolegend Generation Fixes 

### DIFF
--- a/app/util/Legend.js
+++ b/app/util/Legend.js
@@ -24,6 +24,8 @@ Ext.define('CpsiMapview.util.Legend', {
 
         var source = layer.getSource();
         var url;
+        var requestParams = '';
+
         var activatedStyle;
         if (layer.get('isWms') || layer.get('isVt')) {
             if (source.getUrls) {
@@ -48,14 +50,12 @@ Ext.define('CpsiMapview.util.Legend', {
                 return;
             }
 
-            if (!url.endsWith('?')) {
-                url += '?';
+            requestParams += 'SERVICE=WMS&VERSION=1.3.0&REQUEST=GetLegendGraphic&';
+            requestParams += 'FORMAT=image%2Fpng&TRANSPARENT=TRUE&SLD_VERSION=1.1.0&';
+            requestParams += 'LAYER=' + layers + '&';
+            if (activatedStyle) {
+                requestParams += 'STYLE=' + activatedStyle;
             }
-
-            url += 'SERVICE=WMS&VERSION=1.3.0&REQUEST=GetLegendGraphic&';
-            url += 'FORMAT=image%2Fpng&TRANSPARENT=TRUE&SLD_VERSION=1.1.0&';
-            url += 'LAYER=' + layers + '&';
-            url += 'STYLE=' + activatedStyle;
 
         } else if (layer.get('isWfs')) {
 
@@ -66,15 +66,22 @@ Ext.define('CpsiMapview.util.Legend', {
                 return;
             }
 
-            if (!url.endsWith('?')) {
-                url += '?';
+            requestParams += 'SERVICE=WMS&VERSION=1.3.0&REQUEST=GetLegendGraphic&';
+            requestParams += 'FORMAT=image%2Fpng&TRANSPARENT=TRUE&SLD_VERSION=1.1.0&';
+            requestParams += 'LAYER=' + ft + '&';
+            if (activatedStyle) {
+                requestParams += 'STYLE=' + LegendUtil.getWmsStyleFromSldFile(activatedStyle);
             }
-
-            url += 'SERVICE=WMS&VERSION=1.3.0&REQUEST=GetLegendGraphic&';
-            url += 'FORMAT=image%2Fpng&TRANSPARENT=TRUE&SLD_VERSION=1.1.0&';
-            url += 'LAYER=' + ft + '&';
-            url += 'STYLE=' + LegendUtil.getWmsStyleFromSldFile(activatedStyle);
         }
+        if (!url) {
+            return;
+        }
+
+        if (!url.endsWith('?') && !url.endsWith('&')) {
+            url += '?';
+        }
+
+        url += requestParams;
 
         return url;
     },


### PR DESCRIPTION
Allow legends to be generated without an explicit STYLE (using the default).
This pull request also fixes URLs for MapServer which often end with an ampersand e.g. mapserv?map=/path/my.map&