### PR TITLE
Add layer opacity slider context menu 

### DIFF
--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -693,6 +693,15 @@ Ext.define('CpsiMapview.factory.Layer', {
             LayerFactory.registerLayerTooltip(vtLayer);
         }
 
+        // workaround to apply an opacity for the vector tile layer
+        // just setting 'opacity' to the layer does not work
+        // seems related to https://github.com/openlayers/openlayers/issues/4758
+        if (Ext.isNumber(layerConf.opacity)) {
+            vtLayer.on('precompose', function(evt) {
+                evt.context.globalAlpha = layerConf.opacity;
+            });
+        }
+
         return vtLayer;
     },
 

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -112,6 +112,9 @@ Ext.define('CpsiMapview.factory.Layer', {
             mapLayer.set('refreshLayerOption', allowRefresh);
             // indicator if a label option is drawn in layer context menu
             mapLayer.set('labelClassName', layerConf.labelClassName);
+            // indicator if an opacity slider is offered in layer context menu
+            var allowOpacitySlider = layerConf.opacitySlider !== false;
+            mapLayer.set('opacitySlider', allowOpacitySlider);
         }
 
         return mapLayer;

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -11,6 +11,7 @@ Ext.define('CpsiMapview.view.LayerTree', {
         'CpsiMapview.plugin.TreeColumnContextMenu',
         'CpsiMapview.view.menuitem.LayerRefresh',
         'CpsiMapview.view.menuitem.LayerLabels',
+        'CpsiMapview.view.menuitem.LayerOpacity',
         'CpsiMapview.plugin.TreeColumnStyleSwitcher'
     ],
 
@@ -46,7 +47,8 @@ Ext.define('CpsiMapview.view.LayerTree', {
                     ptype: 'cmv_tree_column_context_menu',
                     menuItems: [
                         'cmv_menuitem_layerrefresh',
-                        'cmv_menuitem_layerlabels'
+                        'cmv_menuitem_layerlabels',
+                        'cmv_menuitem_layeropacity'
                     ]
                 }, {
                     ptype: 'cmv_tree_inresolutionrange'

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -49,7 +49,7 @@ Ext.define('CpsiMapview.view.LayerTree', {
                     menuItems: [
                         'cmv_menuitem_layerrefresh',
                         'cmv_menuitem_layerlabels',
-                        'cmv_menuitem_layeropacity'
+                        'cmv_menuitem_layeropacity',
                         'cmv_menuitem_layergrid'
                     ]
                 }, {

--- a/app/view/menuitem/LayerOpacity.js
+++ b/app/view/menuitem/LayerOpacity.js
@@ -1,0 +1,71 @@
+/**
+ * MenuItem to show a slider to change the layer's opacity.
+ *
+ * @class CpsiMapview.view.menuitem.LayerOpacity
+ */
+Ext.define('CpsiMapview.view.menuitem.LayerOpacity', {
+    extend: 'Ext.menu.Item',
+    xtype: 'cmv_menuitem_layeropacity',
+    requires: [],
+
+    /**
+     * The connected layer for this item.
+     *
+     * @cfg {ol.layer.Base}
+     */
+    layer: null,
+
+    /**
+     * Text shown in this MenuItem
+     * @cfg {String}
+     */
+    text: 'Opacity',
+
+
+    /**
+     * @private
+     */
+    initComponent: function () {
+        var me = this;
+        var allowOpacitySlider = false;
+
+        if (me.layer) {
+            allowOpacitySlider = me.layer.get('opacitySlider');
+        }
+
+        var opacitySlider = Ext.create('Ext.slider.Single', {
+            width: 200,
+            value: me.layer.getOpacity() * 100,
+            minValue: 0,
+            maxValue: 100,
+            tipText: function (thumb) {
+                return Ext.String.format('<div>Visibility: {0}%</div>', thumb.value);
+            },
+            listeners: {
+                change: me.onOpacityChange,
+                scope: me
+            }
+        });
+        me.menu = {
+            plain: true,
+            items: [opacitySlider]
+        };
+
+        me.callParent();
+
+        me.setHidden(!allowOpacitySlider);
+    },
+
+    /**
+     * Executed when the opacity slider in this menue is changed.
+     *
+     * @param  {Ext.slider.Single} slider The opacity slider
+     * @param  {Number} newValue The new value which the slider has been changed to.
+     */
+    onOpacityChange: function (slider, newValue) {
+        var me = this;
+        var opac = newValue / 100;
+
+        me.layer.setOpacity(opac);
+    }
+});

--- a/app/view/menuitem/LayerOpacity.js
+++ b/app/view/menuitem/LayerOpacity.js
@@ -57,7 +57,7 @@ Ext.define('CpsiMapview.view.menuitem.LayerOpacity', {
     },
 
     /**
-     * Executed when the opacity slider in this menue is changed.
+     * Executed when the opacity slider in this menu is changed.
      *
      * @param  {Ext.slider.Single} slider The opacity slider
      * @param  {Number} newValue The new value which the slider has been changed to.
@@ -67,5 +67,16 @@ Ext.define('CpsiMapview.view.menuitem.LayerOpacity', {
         var opac = newValue / 100;
 
         me.layer.setOpacity(opac);
+
+        // treat vector tile layers special since setOpacity has no effect on
+        // them, see https://github.com/openlayers/openlayers/issues/4758
+        if (me.layer.get('isVt')) {
+            var setLayerOpacity = function(evt) {
+                evt.context.globalAlpha = opac;
+            };
+            me.layer.on('precompose', setLayerOpacity);
+            CpsiMapview.view.main.Map.guess().olMap.render();
+        }
+
     }
 });

--- a/app/view/menuitem/LayerOpacity.js
+++ b/app/view/menuitem/LayerOpacity.js
@@ -68,8 +68,8 @@ Ext.define('CpsiMapview.view.menuitem.LayerOpacity', {
 
         me.layer.setOpacity(opac);
 
-        // treat vector tile layers special since setOpacity has no effect on
-        // them, see https://github.com/openlayers/openlayers/issues/4758
+        // treat vector tile layers as a special case since setOpacity has no effect
+        // on them, see https://github.com/openlayers/openlayers/issues/4758
         if (me.layer.get('isVt')) {
             var setLayerOpacity = function(evt) {
                 evt.context.globalAlpha = opac;

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -239,33 +239,37 @@
         "stylesForceNumericFilterVals": true
       },
       {
-          "layerType": "vt",
-          "text": "Light Unit VT",
-          "url": "https://plmonaghandev.compass.ie/mapserver/?mode=tile&tilemode=gmap&tile={x}+{y}+{z}&layers=LightUnit&map.imagetype=mvt",
-          "openLayers": {
-            "visibility": false
+            "layerType": "vt",
+            "text": "Light Unit VT",
+            "url": "https://plmonaghandev.compass.ie/mapserver/?mode=tile&tilemode=gmap&tile={x}+{y}+{z}&layers=LightUnit&map.imagetype=mvt",
+            "openLayers": {
+              "visibility": false
+            },
+            "format": "MVT",
+            "stylesBaseUrl": "https://plmonaghandev.compass.ie/resources/data/styling/",
+            "styles": [ "LightUnit_Type.xml", "LightUnit_Owner.xml" ],
+            "stylesForceNumericFilterVals": true
           },
-          "format": "MVT",
-          "stylesBaseUrl": "https://plmonaghandev.compass.ie/publiclighting-test/resources/data/styling/",
-          "styles": ["LightUnit_Unit_Type.xml", "LightUnit_Owner.xml"],
-          "stylesForceNumericFilterVals": true
-      },
-      {
-          "layerType": "vtwms",
-          "text": "Light Unit VT WMS",
-          "url": "https://plmonaghandev.compass.ie/mapserver/?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=true&LAYERS=LightUnit&TILED=false&CRS=EPSG%3A3857&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&STYLES=Owner&FORMAT=mvt",
-          "openLayers": {
-            "visibility": true
-          },
-          "format": "MVT",
-          "stylesBaseUrl": "https://plmonaghandev.compass.ie/publiclighting-test/resources/data/styling/",
-          "styles": ["LightUnit_Unit_Type.xml", "LightUnit_Owner.xml"],
-          "stylesForceNumericFilterVals": true,
-          "tooltipsConfig": [
+          {
+            "layerType": "vtwms",
+            "text": "Light Unit VT WMS",
+            "url": "https://plmonaghandev.compass.ie/mapserver/?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=true&LAYERS=LightUnit&TILED=false&CRS=EPSG%3A3857&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&STYLES=Owner&FORMAT=mvt",
+            "openLayers": {
+              "visibility": true
+            },
+            "format": "MVT",
+            "stylesBaseUrl": "https://plmonaghandev.compass.ie/resources/data/styling/",
+            "styles": [ "LightUnit_Type.xml", "LightUnit_Owner.xml" ],
+            "stylesForceNumericFilterVals": true,
+            "gridXType": "examplegrid",
+            "layerKey": "LIGHT_UNIT_MVT",
+            "tooltipsConfig": [
               {
-                  "alias": "Unit ID",
-                  "property": "UnitTypeId"
+                "alias": "Unit ID",
+                "property": "UnitTypeId"
               }
-          ]
-      }]
+            ]
+          }
+
+    ]
 }


### PR DESCRIPTION
This adds a layer opacity slider context menu for all layers in the tree (see #146). 

![grafik](https://user-images.githubusercontent.com/1185547/67205774-b5e74f00-f410-11e9-9122-5813fea02c0b.png)

Add `opacitySlider: false` in the layer configuration to avoid the layer opacity slider.

NOTE: Since using `setOpacity` for `ol.layer.VectorTile` instances has no effect, this introduces a workaround by changing `globalAlpha` in `precompose` of the layer.
See openlayers/openlayers#4758
