### PR TITLE
Add a Login form

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,10 +25,10 @@ module.exports = {
             "error",
             4
         ],
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
+        //"linebreak-style": [
+        //    "error",
+        //    "unix"
+        //],
         "quotes": [
             "error",
             "single"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ docker-compose up
 ```
 The application is available via http://localhost:81/ afterwards.
 
+For running tests various dependencies listed in package.json need to be installed. Run the following:
+
+```
+npm install
+```
+
 ## Updating the deployed state
 
 ```
@@ -46,3 +52,28 @@ sencha app build
 npx gh-pages -d build/production/CpsiMapview/ -o upstream
 
 ```
+
+## Testing
+
+Navigate to the project folder and run the following:
+
+```
+npm test
+```
+
+To have tests continually running while making changes:
+
+```
+npm run test:watch
+```
+
+To open in a browser and leave the browser open (to review UI components, debug, etc.).
+`--auto-watch` prevents application JS files being cached. 
+
+```
+karma start --browsers Chrome --single-run=False --debug --auto-watch
+
+```
+
+See also https://glebbahmutov.com/blog/debugging-karma-unit-tests/
+

--- a/app/controller/form/Login.js
+++ b/app/controller/form/Login.js
@@ -1,0 +1,138 @@
+Ext.define('CpsiMapview.controller.form.Login', {
+    extend: 'Ext.app.ViewController',
+    alias: 'controller.cmv_login_form',
+
+    /**
+    * Attempt to login if the user presses the Enter key on
+    * the form
+    */
+    onSpecialKey: function (field, e) {
+        if (e.getKey() === e.ENTER) {
+            this.attemptLogin();
+        }
+    },
+
+    onLoginClick: function () {
+        this.attemptLogin();
+    },
+
+    /**
+    * If a user still has a valid token, don't force them to log
+    * in again
+    * @param {string} token The toggle state of the button
+    */
+    tryAutomaticLogin: function () {
+
+        var me = this;
+        var tokenName = me.getTokenName();
+
+        var token = Ext.util.Cookies.get(tokenName);
+        var jsonData = {};
+
+        if (token) {
+            jsonData[tokenName] = token;
+            me.callLoginService(jsonData);
+        }
+    },
+
+    getTokenName: function () {
+
+        var me = this;
+        return me.getView().tokenName;
+    },
+
+    login: function (response) {
+
+        var me = this;
+        var roles = response.userRoles; // this is an array e.g. ["UPL"]
+        var tokenName = me.getTokenName();
+
+        var loginData = {
+            roles: roles,
+            username: Ext.util.Cookies.get('username')
+        };
+
+        loginData[tokenName] = response.data;
+
+        me.updateCookie(loginData);
+        me.fireEvent('login', loginData);
+    },
+
+    logout: function () {
+
+        // issues with Cookies clear - http://www.sencha.com/forum/showthread.php?98070-CLOSED-Ext.util.Cookies.clear%28%29-not-working
+        // only work when browser is restarted
+        // so instead set them to null
+
+        var me = this;
+        var tokenName = me.getTokenName();
+
+        var loginData = {
+            roles: '',
+            username: ''
+        };
+
+        loginData[tokenName] = '';
+
+        me.updateCookie(loginData);
+        me.fireEvent('logout');
+    },
+
+    updateCookie: function (loginData) {
+
+        var me = this;
+        var tokenName = me.getTokenName();
+
+        Ext.util.Cookies.set(tokenName, loginData[tokenName]);
+        Ext.util.Cookies.set('roles', loginData.roles);
+        Ext.util.Cookies.set('username', loginData.username);
+
+    },
+
+    callLoginService: function (jsonData) {
+
+        var me = this;
+        var serviceUrl = me.getView().serviceUrl;
+
+        Ext.util.Cookies.set('username', jsonData.username);
+
+        Ext.Ajax.request({
+            method: 'POST',
+            url: serviceUrl,
+            headers: {
+                'Content-Type': 'application/json; charset=utf-8' //this must be set or get server 500 errors
+            },
+            params: jsonData,
+            success: function (result) {
+                // successful HTTP connection, not necessarily the log in
+                // call was successful, we should now have a token in the response.data property
+                var response = Ext.decode(result.responseText);
+
+                if (response.success === true) {
+                    me.login(response);
+                }
+                else {
+                    //username / password login failure
+                    me.fireEvent('loginfail');
+                }
+            },
+            failure: function (result) {
+                // indicates HTTP failure
+                me.fireEvent('loginfail', result.statusText);
+            }
+        });
+    },
+
+    attemptLogin: function () {
+
+        var me = this;
+        var view = me.getView();
+
+        var myForm = view.down('form').getForm();
+        var jsonData = Ext.JSON.encode(myForm.getValues());
+
+        me.callLoginService(jsonData);
+
+    }
+
+});

--- a/app/view/form/Login.js
+++ b/app/view/form/Login.js
@@ -6,8 +6,9 @@ Ext.define('CpsiMapview.view.form.Login', {
         'CpsiMapview.controller.form.Login'
     ],
 
-    serviceUrl: 'https://pmstipperarydev.compass.ie/WebServices/authorization/authenticate',
-    tokenName: 'pmstoken',
+    serviceUrl: './WebServices/authorization/authenticate',
+    validateUrl: './WebServices/authorization/validateToken',
+    tokenName: 'token',
 
     controller: 'cmv_login_form',
     bodyPadding: 10,

--- a/app/view/form/Login.js
+++ b/app/view/form/Login.js
@@ -1,0 +1,48 @@
+Ext.define('CpsiMapview.view.form.Login', {
+    extend: 'Ext.window.Window',
+    xtype: 'cmv_login_form',
+
+    requires: [
+        'CpsiMapview.controller.form.Login'
+    ],
+
+    serviceUrl: 'https://pmstipperarydev.compass.ie/WebServices/authorization/authenticate',
+    tokenName: 'pmstoken',
+
+    controller: 'cmv_login_form',
+    bodyPadding: 10,
+    title: 'Login Window',
+    closable: false,
+    autoShow: true,
+    modal: true,
+
+    items: {
+        xtype: 'form',
+        border: false,
+        items: [{
+            xtype: 'textfield',
+            name: 'username',
+            fieldLabel: 'Username',
+            allowBlank: false
+        }, {
+            xtype: 'textfield',
+            name: 'password',
+            inputType: 'password',
+            fieldLabel: 'Password',
+            allowBlank: false,
+            listeners: {
+                specialkey: 'onSpecialKey'
+            }
+        }],
+        buttons: [{
+            xtype: 'label',
+            html: '<a href="/ManagementTool/Account/ForgotPassword" target="_blank">Forgotten Password?</a>'
+        }, '->', {
+            text: 'Login',
+            formBind: true,
+            listeners: {
+                click: 'onLoginClick'
+            }
+        }]
+    }
+});

--- a/app/view/toolbar/MapFooter.js
+++ b/app/view/toolbar/MapFooter.js
@@ -7,7 +7,8 @@ Ext.define('CpsiMapview.view.toolbar.MapFooter', {
 
     requires: [
         'BasiGX.view.combo.ScaleCombo',
-        'BasiGX.view.MapLoadingStatusBar'
+        'BasiGX.view.MapLoadingStatusBar',
+        'CpsiMapview.view.form.Login'
     ],
 
     items: [{
@@ -20,5 +21,14 @@ Ext.define('CpsiMapview.view.toolbar.MapFooter', {
     {
         xtype: 'basigx-maploadingstatusbar',
         width: 200
+    }, '->',
+    {
+        xtype: 'button',
+        text: 'Login',
+        scope: this,
+        handler: function () {
+            var win = Ext.create('CpsiMapview.view.form.Login', {});
+            win.show();
+        }
     }]
 });

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,10 +5,19 @@ var commonConfig = require('./karma-conf.common.js');
 
 module.exports = function(config) {
     commonConfig(config); // apply shared configuration
+
+    var sourcePreprocessors = 'coverage';
+    function isDebug(argument) {
+        return argument === '--debug';
+    }
+    if (process.argv.some(isDebug)) {
+        sourcePreprocessors = [];
+    }
+
     config.set({
         // Preprocess so we can gather coverage
         preprocessors: {
-            'app/**/*.js': ['coverage']
+            'app/**/*.js': sourcePreprocessors // remove coverage here if we want to debug a test
         },
 
         // test results reporter to use

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "karma": "4.3.0",
     "karma-chrome-launcher": "3.0.0",
+    "karma-cli": "^2.0.0",
     "karma-coverage": "1.1.2",
     "karma-coverage-istanbul-reporter": "2.1.0",
     "karma-expect": "1.1.3",

--- a/test/resources/data/forms/login.json
+++ b/test/resources/data/forms/login.json
@@ -1,0 +1,16 @@
+{
+  "data": "bfdb15be-7ec9-4956-b2b3-5b25f77d3877",
+  "message": "",
+  "success": true,
+  "userRoles": [
+    "UPL",
+    "Mobile_Upload",
+    "Browser_RoadScheduleEditor",
+    "MECHUPL",
+    "MechanicalData_Upload",
+    "Browser_Administrator",
+    "Browser_BridgeEditor",
+    "Browser_ReadOnly",
+    "Browser_ReadWrite"
+  ]
+}

--- a/test/spec/view/form/Login.spec.js
+++ b/test/spec/view/form/Login.spec.js
@@ -1,0 +1,31 @@
+describe('CpsiMapview.view.form.Login', function() {
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(CpsiMapview.view.form.Login).not.to.be(undefined);
+        });
+
+        it('can be instantiated', function() {
+            var inst = Ext.create('CpsiMapview.view.form.Login');
+            expect(inst).to.be.a(CpsiMapview.view.form.Login);
+        });
+
+        it('can call mocked service', function (done) {
+            var inst = Ext.create('CpsiMapview.view.form.Login', {
+                serviceUrl: '/resources/data/forms/login.json',
+                tokenName: 'mytoken'
+            });
+
+            var ctrlr = inst.getController();
+            ctrlr.attemptLogin();
+
+            ctrlr.on('login', function (jsonData) {
+                var token = Ext.util.Cookies.get('mytoken');
+                expect(token).to.be('bfdb15be-7ec9-4956-b2b3-5b25f77d3877');
+                expect(jsonData.roles.length).to.be(9);
+                done();
+            });
+
+        });
+
+    });
+});


### PR DESCRIPTION
Adds a login form that can connect to an authentication service and save a token to a cookie.
Tests also added. 
As development is done on Windows machines I've turned off Unix line break checks for now. 