### PR TITLE
Fix disappearing style radios when moving layer

### DIFF
--- a/app/plugin/TreeColumnStyleSwitcher.js
+++ b/app/plugin/TreeColumnStyleSwitcher.js
@@ -99,21 +99,16 @@ Ext.define('CpsiMapview.plugin.TreeColumnStyleSwitcher', {
         // wait until all layers are loaded to the map
         var mapCmp = CpsiMapview.view.main.Map.guess();
         mapCmp.on('cmv-init-layersadded', function () {
-
             // ensure the radio groups are re-rendered every time the tree view
             // changes (e.g.) layer visibility is changed
             treeColumn.up('treepanel').getView().on('itemupdate', function () {
+                // Unfortun. we have to defer cascading of the LayerTree nodes.
+                // Otherwise they are not ready and we don't have a event.
                 Ext.defer(function () {
                     me.cleanupAllRadioGroups();
                     me.renderRadioGroups();
                 }, 1);
             });
-
-            // Unfortunately we have to defer cascading of the LayerTree nodes.
-            // Otherwise they are not ready and we do not have a fitting event.
-            Ext.defer(function () {
-                me.renderRadioGroups();
-            }, 1);
         });
 
         // ensure that the radio groups are rendered after a node has been

--- a/app/plugin/TreeColumnStyleSwitcher.js
+++ b/app/plugin/TreeColumnStyleSwitcher.js
@@ -115,6 +115,21 @@ Ext.define('CpsiMapview.plugin.TreeColumnStyleSwitcher', {
                 me.renderRadioGroups();
             }, 1);
         });
+
+        // ensure that the radio groups are rendered after a node has been
+        // dragged and dropped
+        treeColumn.up('treepanel').on('drop', function (node, data) {
+            Ext.defer(function () {
+                me.cleanupAllRadioGroups();
+                // updates the whole node for the layer and forces the
+                // me.renderRadioGroups via 'itemupdate' event
+                // directly executing me.renderRadioGroups leaves some artifacts
+                if (data.records && data.records.length > 0 && data.records[0].getOlLayer()) {
+                    var layer = data.records[0].getOlLayer();
+                    treeColumn.up('treepanel').updateLayerNodeUi(layer);
+                }
+            }, 1);
+        });
     },
 
     /**
@@ -133,8 +148,8 @@ Ext.define('CpsiMapview.plugin.TreeColumnStyleSwitcher', {
             if (!node.get('isLayerGroup') && node.get('text') !== 'root') {
                 var lyrRecId = node.get('id');
                 var placeholderDomId = THIS_CLS.getDomId(lyrRecId);
-                var placeholderDiv =
-                    Ext.DomQuery.select('#' + placeholderDomId)[0];
+                // use fly to avoid Ext element cache which raises error
+                var placeholderDiv = Ext.fly(placeholderDomId);
                 var olLayer = node.getOlLayer();
 
                 if (placeholderDiv && olLayer.get('styles')) {

--- a/app/plugin/TreeColumnStyleSwitcher.js
+++ b/app/plugin/TreeColumnStyleSwitcher.js
@@ -160,5 +160,7 @@ Ext.define('CpsiMapview.plugin.TreeColumnStyleSwitcher', {
         Ext.each(me.radioGroups, function (rg) {
             rg.destroy();
         });
+
+        me.radioGroups = [];
     }
 });

--- a/test/spec/view/LayerTree.spec.js
+++ b/test/spec/view/LayerTree.spec.js
@@ -1,0 +1,19 @@
+describe('CpsiMapview.view.LayerTree', function() {
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(CpsiMapview.view.main.Map).not.to.be(undefined);
+        });
+
+        it('can be instantiated', function() {
+            // overwrite helper functions to derive entities
+            CpsiMapview.view.main.Map.guess = function() {
+                return {on: Ext.emptyFn};
+            };
+            BasiGX.util.Map.getMapComponent = function () {
+                return Ext.create('GeoExt.component.Map');
+            };
+            var inst = Ext.create('CpsiMapview.view.LayerTree', {});
+            expect(inst).to.be.a(CpsiMapview.view.LayerTree);
+        });
+    });
+});

--- a/test/spec/view/layer/StyleSwitcherRadioGroup.spec.js
+++ b/test/spec/view/layer/StyleSwitcherRadioGroup.spec.js
@@ -1,0 +1,14 @@
+describe('CpsiMapview.view.layer.StyleSwitcherRadioGroup', function() {
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(CpsiMapview.view.layer.StyleSwitcherRadioGroup).not.to.be(undefined);
+        });
+
+        it('can be instantiated', function() {
+            var inst = Ext.create('CpsiMapview.view.layer.StyleSwitcherRadioGroup', {
+                layer: new ol.layer.Vector()
+            });
+            expect(inst).to.be.a(CpsiMapview.view.layer.StyleSwitcherRadioGroup);
+        });
+    });
+});

--- a/test/spec/view/plugin/TreeColumnStyleSwitcher.spec.js
+++ b/test/spec/view/plugin/TreeColumnStyleSwitcher.spec.js
@@ -1,0 +1,12 @@
+describe('CpsiMapview.plugin.TreeColumnStyleSwitcher', function() {
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(CpsiMapview.plugin.TreeColumnStyleSwitcher).not.to.be(undefined);
+        });
+
+        it('can be instantiated', function() {
+            var inst = Ext.create('CpsiMapview.plugin.TreeColumnStyleSwitcher', {});
+            expect(inst).to.be.a(CpsiMapview.plugin.TreeColumnStyleSwitcher);
+        });
+    });
+});


### PR DESCRIPTION
This ensures that the style radio groups in the LayerTree are rendered after a node has been dragged and dropped. Otherwise they disappear.

Fixes #169 