### PR TITLE
General mechanism for grouped LayerTree

### DIFF
--- a/app/plugin/TreeColumnStyleSwitcher.js
+++ b/app/plugin/TreeColumnStyleSwitcher.js
@@ -97,13 +97,11 @@ Ext.define('CpsiMapview.plugin.TreeColumnStyleSwitcher', {
         me.callParent();
 
         // wait until all layers are loaded to the map
-        var mapCmp = CpsiMapview.view.main.Map.guess();
-        mapCmp.on('cmv-init-layersadded', function () {
+        var layerTree = treeColumn.up('treepanel');
+        layerTree.on('cmv-init-layertree', function () {
             // ensure the radio groups are re-rendered every time the tree view
             // changes (e.g.) layer visibility is changed
-            treeColumn.up('treepanel').getView().on('itemupdate', function () {
-                // Unfortun. we have to defer cascading of the LayerTree nodes.
-                // Otherwise they are not ready and we don't have a event.
+            layerTree.getView().on('itemupdate', function () {
                 Ext.defer(function () {
                     me.cleanupAllRadioGroups();
                     me.renderRadioGroups();

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -40,12 +40,13 @@
     },
     {
       "layerType": "wms",
+      "text": "A WMS",
+      "layerKey": "OSM_WMS",
       "helpPage": "OSM",
       "qtip": "An OSM based WMS layer",
       "iconCls": "map",
       "isBaseLayer": false,
       "isDefaultBaseLayer": false,
-      "text": "A WMS",
       "url": "https://ows.terrestris.de/osm-gray/service",
       "serverOptions": {
         "layers": "OSM-WMS"
@@ -62,6 +63,7 @@
     {
       "layerType": "wfs",
       "text": "Country WFS",
+      "layerKey": "COUNTRY_WFS",
       "qtip": "An OSM based WFS layer",
       "url": "https://ows.terrestris.de/geoserver/osm/wfs",
       "featureType": "osm:osm-country-borders",
@@ -117,12 +119,14 @@
     },
     {
       "layerType": "switchlayer",
+      "layerKey": "LIGHT_UNIT_SWITCH_LAYER",
       "visibility": false,
       "vectorFeaturesMinScale": 80000,
       "layers": [
         {
           "layerType": "wms",
           "text": "Light Unit Switch Layer (far)",
+          "layerKey": "LIGHT_UNIT_SWITCH_LAYER_FAR",
           "url": "https://plmonaghandev.compass.ie/mapserver/",
           "isBaseLayer": false,
           "isDefaultBaseLayer": false,
@@ -142,6 +146,7 @@
         {
           "layerType": "wfs",
           "text": "Light Unit Switch Layer (close)",
+          "layerKey": "LIGHT_UNIT_SWITCH_LAYER_CLOSE",
           "url": "https://plmonaghandev.compass.ie/mapserver/?",
           "geometryProperty": "msGeometry",
           "featureType": "LightUnit",
@@ -163,6 +168,7 @@
     {
       "layerType": "wms",
       "text": "Works_Export (needs proxy)",
+      "layerKey": "WORKS_EXPORT_WMS_PROXY",
       "url": "mapserver/",
       "isBaseLayer": false,
       "isDefaultBaseLayer": false,
@@ -180,6 +186,7 @@
     {
       "layerType": "wfs",
       "text": "Test time WFS (needs proxy)",
+      "layerKey": "TIME_WFS_PROXY",
       "url": "wfs/",
       "featureType": "test:osm-fuel",
       "serverOptions": {},
@@ -198,10 +205,10 @@
     {
       "layerType": "wfs",
       "text": "Accidents",
+      "layerKey": "ACCIDENTS_WFS",
       "url": "https://pmstipperarydev.compass.ie/mapserver/?",
       "geometryProperty": "msGeometry",
       "featureType": "Accidents",
-      "layerKey": "ACCIDENTS_WFS",
       "openLayers": {
         "maxResolution": 1222.99245234375,
         "numZoomLevels": 12,
@@ -219,6 +226,7 @@
     {
       "layerType": "wms",
       "text": "Light Unit WMS",
+      "layerKey": "LIGHT_UNIT_WMS",
       "url": "https://plmonaghandev.compass.ie/mapserver/",
       "isBaseLayer": false,
       "isDefaultBaseLayer": false,
@@ -236,6 +244,7 @@
     {
       "layerType": "wfs",
       "text": "Light Unit WFS",
+      "layerKey": "LIGHT_UNIT_WFS",
       "url": "https://plmonaghandev.compass.ie/mapserver/?",
       "geometryProperty": "msGeometry",
       "featureType": "LightUnit",
@@ -247,6 +256,7 @@
     {
       "layerType": "vt",
       "text": "Light Unit VT",
+      "layerKey": "LIGHT_UNIT_VT",
       "url": "https://plmonaghandev.compass.ie/mapserver/?mode=tile&tilemode=gmap&tile={x}+{y}+{z}&layers=LightUnit&map.imagetype=mvt",
       "openLayers": {
         "visibility": false
@@ -259,6 +269,7 @@
     {
       "layerType": "vtwms",
       "text": "Light Unit VT WMS",
+      "layerKey": "LIGHT_UNIT_MVT",
       "url": "https://plmonaghandev.compass.ie/mapserver/?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=true&LAYERS=LightUnit&TILED=false&CRS=EPSG%3A3857&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&STYLES=Owner&FORMAT=mvt",
       "openLayers": {
         "visibility": true
@@ -268,7 +279,6 @@
       "styles": [ "LightUnit_Type.xml", "LightUnit_Owner.xml" ],
       "stylesForceNumericFilterVals": true,
       "gridXType": "cmv_examplegrid",
-      "layerKey": "LIGHT_UNIT_MVT",
       "tooltipsConfig": [
         {
           "alias": "Unit ID",

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -2,6 +2,7 @@
   "layers": [
     {
       "layerType": "xyz",
+      "layerKey": "GREY_BACKGROUND",
       "iconCls": "map",
       "isBaseLayer": true,
       "isDefaultBaseLayer": false,
@@ -20,6 +21,7 @@
     },
     {
       "layerType": "osm",
+      "layerKey": "OSM_BACKGROUND",
       "helpPage": "OSM",
       "iconCls": "map",
       "isBaseLayer": true,
@@ -82,6 +84,7 @@
       "text": "GAS WFS",
       "layerKey": "GAS_WFS",
       "url": "https://ows.terrestris.de/geoserver/osm/wfs",
+      "featureType": "osm:osm-fuel",
       "sldUrl": "resources/data/styling/Test_Gas.xml",
       "geomFieldName": "geometry",
       "namespaceDefinitions": {

--- a/resources/data/layers/tree.json
+++ b/resources/data/layers/tree.json
@@ -10,11 +10,43 @@
           "isLeaf": true
         },
         {
+          "id": "LIGHT_UNIT_VT",
+          "isLeaf": true
+        },
+        {
+          "id": "LIGHT_UNIT_WFS",
+          "isLeaf": true
+        },
+        {
+          "id": "LIGHT_UNIT_WMS",
+          "isLeaf": true
+        },
+        {
           "id": "ACCIDENTS_WFS",
           "isLeaf": true
         },
         {
+          "id": "TIME_WFS_PROXY",
+          "isLeaf": true
+        },
+        {
+          "id": "WORKS_EXPORT_WMS_PROXY",
+          "isLeaf": true
+        },
+        {
+          "id": "LIGHT_UNIT_SWITCH_LAYER_FAR",
+          "isLeaf": true
+        },
+        {
           "id": "GAS_WFS",
+          "isLeaf": true
+        },
+        {
+          "id": "COUNTRY_WFS",
+          "isLeaf": true
+        },
+        {
+          "id": "OSM_WMS",
           "isLeaf": true
         }
       ]

--- a/resources/data/layers/tree.json
+++ b/resources/data/layers/tree.json
@@ -1,0 +1,37 @@
+{
+  "id": "root",
+  "children": [
+    {
+      "id": "overlay-folder",
+      "title": "Layers",
+      "children": [
+        {
+          "id": "LIGHT_UNIT_MVT",
+          "isLeaf": true
+        },
+        {
+          "id": "ACCIDENTS_WFS",
+          "isLeaf": true
+        },
+        {
+          "id": "GAS_WFS",
+          "isLeaf": true
+        }
+      ]
+    },
+    {
+      "id": "base-folder",
+      "title": "Base Layers",
+      "children": [
+        {
+          "id": "OSM_BACKGROUND",
+          "isLeaf": true
+        },
+        {
+          "id": "GREY_BACKGROUND",
+          "isLeaf": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This adds a general mechanism for a grouped `LayerTree`, which is based on a JSON tree structure (see resources/data/layers/tree.json) which defines folders and leafs for the `LayerTree`. The corresponding layers are referenced by the property `layerkey`, so the current layer creation (and thus the layer JSON) can stay untouched.

Here is an example for a tree.json

```json
{
  "id": "root",
  "children": [
    {
      "id": "overlay-folder",
      "title": "Layers",
      "children": [
        {
          "id": "LIGHT_UNIT_MVT",
          "isLeaf": true
        },
        {
          "id": "ACCIDENTS_WFS",
          "isLeaf": true
        },
        {
          "id": "GAS_WFS",
          "isLeaf": true
        }
      ]
    },
    {
      "id": "base-folder",
      "title": "Base Layers",
      "children": [
        {
          "id": "OSM_BACKGROUND",
          "isLeaf": true
        },
        {
          "id": "GREY_BACKGROUND",
          "isLeaf": true
        }
      ]
    }
  ]
}
```
Closes #145 