### PR TITLE
Set different initial EPSG code for mouse position

### DIFF
--- a/app/view/toolbar/MapFooter.js
+++ b/app/view/toolbar/MapFooter.js
@@ -16,6 +16,7 @@ Ext.define('CpsiMapview.view.toolbar.MapFooter', {
     }, {
         xtype: 'basigx-panel-coordinatemouseposition',
         epsgCodeArray: ['EPSG:4326', 'EPSG:29902', 'EPSG:2157'],
+        activeEpsgCode: 'EPSG:29902',
         segmentedButtonLimit: 3
     },
     {


### PR DESCRIPTION
This sets a different initial EPSG code for the mouse position UI (`basigx-panel-coordinatemouseposition`).
Therefore the BasiGX submodule has been updated to the current master (8c8a1d).

Closes #160 