### PR TITLE
Remove unavailable VT layer

### DIFF
--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -254,19 +254,6 @@
       }
     },
     {
-      "layerType": "vt",
-      "text": "Light Unit VT",
-      "layerKey": "LIGHT_UNIT_VT",
-      "url": "https://plmonaghandev.compass.ie/mapserver/?mode=tile&tilemode=gmap&tile={x}+{y}+{z}&layers=LightUnit&map.imagetype=mvt",
-      "openLayers": {
-        "visibility": false
-      },
-      "format": "MVT",
-      "stylesBaseUrl": "https://plmonaghandev.compass.ie/resources/data/styling/",
-      "styles": [ "LightUnit_Type.xml", "LightUnit_Owner.xml" ],
-      "stylesForceNumericFilterVals": true
-    },
-    {
       "layerType": "vtwms",
       "text": "Light Unit VT WMS",
       "layerKey": "LIGHT_UNIT_MVT",


### PR DESCRIPTION
This removes the Vector Tile layer `LIGHT_UNIT_VT` since the service backend is not available anymore. The layer is usable via VT WMS protocol, see layer `LIGHT_UNIT_MVT` (as suggested by @geographika in #186).