### PR TITLE
Add option to display spatial filter polygon

### DIFF
--- a/app/controller/button/SpatialQueryButton.js
+++ b/app/controller/button/SpatialQueryButton.js
@@ -9,24 +9,28 @@ Ext.define('CpsiMapview.controller.button.SpatialQueryButtonController', {
     /**
      * The {ol.interaction.Draw} used to draw the geometry used in the spatial
      * query
+     * @property{ol.interaction.Draw}
      */
     drawQueryInteraction: null,
 
     /**
      * The {ol.interaction.Modify} used to modify the geometry used in the spatial
      * query
+     * @property{ol.interaction.Modify}
      */
     modifiyQueryInteraction: null,
 
     /**
      * The {ol.interaction.Snap} used to snap to the points of the geometry used
      * in the spatial query
+     * @property{ol.interaction.Snap}
      */
     snapQueryInteraction: null,
 
     /**
      * The layer that contains the geometry used in the spatial query, if
      * displayPermanently is set to true
+     * @property{ol.layer.Vector}
      */
     permanentLayer: null,
 
@@ -134,8 +138,8 @@ Ext.define('CpsiMapview.controller.button.SpatialQueryButtonController', {
             if (view.displayPermanently) {
                 me.modifiyQueryInteraction.setActive(false);
                 me.snapQueryInteraction.setActive(false);
-                me.drawQueryInteraction.on('drawend', me.getFeaturesFromSourceAndTriggerWfs, me);
-                me.modifiyQueryInteraction.on('modifyend', me.getFeaturesFromSourceAndTriggerWfs, me);
+                me.drawQueryInteraction.un('drawend', me.getFeaturesFromSourceAndTriggerWfs, me);
+                me.modifiyQueryInteraction.un('modifyend', me.getFeaturesFromSourceAndTriggerWfs, me);
             } else {
                 view.queryFeatures.un('add', me.getGeometryFromPolygonAndTriggerWfs, me);
             }

--- a/app/controller/button/SpatialQueryButton.js
+++ b/app/controller/button/SpatialQueryButton.js
@@ -13,6 +13,24 @@ Ext.define('CpsiMapview.controller.button.SpatialQueryButtonController', {
     drawQueryInteraction: null,
 
     /**
+     * The {ol.interaction.Modify} used to modify the geometry used in the spatial
+     * query
+     */
+    modifiyQueryInteraction: null,
+
+    /**
+     * The {ol.interaction.Snap} used to snap to the points of the geometry used
+     * in the spatial query
+     */
+    snapQueryInteraction: null,
+
+    /**
+     * The layer that contains the geometry used in the spatial query, if
+     * displayPermanently is set to true
+     */
+    permanentLayer: null,
+
+    /**
     * The OpenLayers map. If not given, will be auto-detected
     */
     map: null,
@@ -63,20 +81,97 @@ Ext.define('CpsiMapview.controller.button.SpatialQueryButtonController', {
             geometryFunction = ol.interaction.Draw.createBox();
         }
 
+        var vectorLayerKey = view.getVectorLayerKey();
+        me.permanentLayer = CpsiMapview.view.button.SpatialQueryButton.findAssociatedPermanentLayer(me.map, vectorLayerKey);
+        if (me.permanentLayer === undefined) {
+            me.permanentLayer = new ol.layer.Vector({ source: new ol.source.Vector() });
+            me.permanentLayer.set('associatedLayerKey', vectorLayerKey);
+            me.permanentLayer.set('isSpatialQueryLayer', true);
+            me.permanentLayer.set('displayInLayerSwitcher', false);
+            me.permanentLayer.set('name', vectorLayerKey + '_spatialfilter');
+            // connect hide and show to query layer hide and show
+            me.connectQueryLayer();
+        }
+        var permanentLayerSource = me.permanentLayer.getSource();
         if (!me.drawQueryInteraction) {
-            me.drawQueryInteraction = new ol.interaction.Draw({
-                features: view.queryFeatures,
-                geometryFunction: geometryFunction,
-                type: type
-            });
+            if (view.displayPermanently) {
+                me.map.addLayer(me.permanentLayer);
+                me.drawQueryInteraction = new ol.interaction.Draw({
+                    source: permanentLayerSource,
+                    geometryFunction: geometryFunction,
+                    type: type
+                });
+
+                me.modifiyQueryInteraction = new ol.interaction.Modify({
+                    source: permanentLayerSource
+                });
+                me.snapQueryInteraction = new ol.interaction.Snap({
+                    source: permanentLayerSource
+                });
+                me.map.addInteraction(me.modifiyQueryInteraction);
+                me.map.addInteraction(me.snapQueryInteraction);
+            } else {
+                me.drawQueryInteraction = new ol.interaction.Draw({
+                    features: view.queryFeatures,
+                    geometryFunction: geometryFunction,
+                    type: type
+                });
+            }
             me.map.addInteraction(me.drawQueryInteraction);
         }
         if (pressed) {
             me.drawQueryInteraction.setActive(true);
-            view.queryFeatures.on('add', me.getGeometryFromPolygonAndTriggerWfs, me);
+            if (view.displayPermanently) {
+                me.modifiyQueryInteraction.setActive(true);
+                me.snapQueryInteraction.setActive(true);
+                me.drawQueryInteraction.on('drawend', me.getFeaturesFromSourceAndTriggerWfs, me);
+                me.modifiyQueryInteraction.on('modifyend', me.getFeaturesFromSourceAndTriggerWfs, me);
+            } else {
+                view.queryFeatures.on('add', me.getGeometryFromPolygonAndTriggerWfs, me);
+            }
         } else {
             me.drawQueryInteraction.setActive(false);
-            view.queryFeatures.un('add', me.getGeometryFromPolygonAndTriggerWfs, me);
+            if (view.displayPermanently) {
+                me.modifiyQueryInteraction.setActive(false);
+                me.snapQueryInteraction.setActive(false);
+                me.drawQueryInteraction.on('drawend', me.getFeaturesFromSourceAndTriggerWfs, me);
+                me.modifiyQueryInteraction.on('modifyend', me.getFeaturesFromSourceAndTriggerWfs, me);
+            } else {
+                view.queryFeatures.un('add', me.getGeometryFromPolygonAndTriggerWfs, me);
+            }
+        }
+    },
+
+    /**
+     * Connects the change:visible event of the query layer
+     * to the permanent layer. Thereby, when the query layer
+     * visibility is changed, the visibility of the permanent layer
+     * changes accordingly.
+     */
+    connectQueryLayer: function () {
+        var me = this;
+        var view = me.getView();
+        var layerKey = view.getVectorLayerKey();
+        if (!layerKey) {
+            return;
+        }
+        if (view.queryLayer) {
+            view.queryLayer.on('change:visible', me.onQueryLayerVisibilityChange.bind(me));
+        }
+    },
+
+    /**
+     * Event handler for the change:visible event of the
+     * query layer.
+     * @param {ol.Object.event} evt change:visible event of layer
+     */
+    onQueryLayerVisibilityChange: function (evt) {
+        var me = this;
+        var visible = evt.target.getVisible();
+        if (visible) {
+            me.onShowAssociatedPermanentLayer();
+        } else {
+            me.onHideAssociatedPermanentLayer();
         }
     },
 
@@ -111,6 +206,27 @@ Ext.define('CpsiMapview.controller.button.SpatialQueryButtonController', {
     },
 
     /**
+     * Handles the modifyend and drawend events of the draw layer
+     * @param {ol.Object.event} evt ol modifyend or drawend event
+     */
+    getFeaturesFromSourceAndTriggerWfs: function (evt) {
+        var me = this;
+        var feature;
+        if (evt.type === 'modifyend') {
+            // We expect to only have one existing feature in source.
+            // In case multiple features exist, we only use the one
+            // that was added last
+            feature = evt.features.getArray()[evt.features.getLength() - 1];
+        } else if (evt.type === 'drawend') {
+            // clear previously drawn features so that only one feature exists
+            me.permanentLayer.getSource().clear();
+            feature = evt.feature;
+        }
+        var fakeEvent = { element: feature };
+        me.getGeometryFromPolygonAndTriggerWfs(fakeEvent);
+    },
+
+    /**
      * Help method to create a polygon geometry from drawn irregular polygon.
      *
      * @param {Ext.Event} evt The add-Event containing drawn feature
@@ -122,7 +238,6 @@ Ext.define('CpsiMapview.controller.button.SpatialQueryButtonController', {
 
         var filter = me.createSpatialFilter(geometry);
         view.fireEvent('cmv-spatial-query-filter', filter);
-
         if (view.triggerWfsRequest === true) {
             this.buildAndRequestQuery(geometry);
         }
@@ -214,5 +329,50 @@ Ext.define('CpsiMapview.controller.button.SpatialQueryButtonController', {
         var mapComp = me.mapComponent || BasiGX.util.Map.getMapComponent();
         mapComp.setLoading(false);
         view.fireEvent('cmv-spatial-query-error', responseTxt);
+    },
+
+    /**
+     * Handles clearing the permanentLayer of the instance.
+     */
+    onClearAssociatedPermanentLayer: function () {
+        var me = this;
+        var layerKey = me.getView().getVectorLayerKey();
+        if (!me.map) {
+            return;
+        }
+        if (!layerKey) {
+            return;
+        }
+        CpsiMapview.view.button.SpatialQueryButton.clearAssociatedPermanentLayer(me.map, layerKey);
+    },
+
+    /**
+     * Handles showing the permanentLayer of the instance.
+     */
+    onShowAssociatedPermanentLayer: function () {
+        var me = this;
+        var layerKey = me.getView().getVectorLayerKey();
+        if (!me.map) {
+            return;
+        }
+        if (!layerKey) {
+            return;
+        }
+        CpsiMapview.view.button.SpatialQueryButton.showAssociatedPermanentLayer(me.map, layerKey);
+    },
+
+    /**
+     * Handles hiding the permanentLayer of the instance.
+     */
+    onHideAssociatedPermanentLayer: function () {
+        var me = this;
+        var layerKey = me.getView().getVectorLayerKey();
+        if (!me.map) {
+            return;
+        }
+        if (!layerKey) {
+            return;
+        }
+        CpsiMapview.view.button.SpatialQueryButton.hideAssociatedPermanentLayer(me.map, layerKey);
     }
 });

--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -56,9 +56,9 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
                 zoom: zoom - 1,
                 duration: duration / 2
             }, {
-                zoom: zoom,
-                duration: duration / 2
-            }
+            zoom: zoom,
+            duration: duration / 2
+        }
         );
     },
 
@@ -325,8 +325,16 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
     * @private
     */
     clearFilters: function () {
-        this.spatialFilter = null;
-        this.getView().getPlugin('gridfilters').clearFilters();
+        var me = this;
+        var view = me.getView();
+        me.spatialFilter = null;
+        view.getPlugin('gridfilters').clearFilters();
+
+        var spatialQueryButton = view.down('cmv_spatial_query_button');
+        if (spatialQueryButton !== null) {
+            spatialQueryButton.fireEvent('clearAssociatedPermanentLayer');
+            spatialQueryButton.toggle(false);
+        }
     },
 
     /**
@@ -340,11 +348,13 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
 
         var gridStoreType = viewModel.get('gridStoreType');
         var layerName = viewModel.get('gridLayerName');
+        var vectorLayerKey = viewModel.get('vectorLayerKey');
 
         // TODO check why we can't simply add a {'queryLayerName'} binding in
         // the grid view - already created ?
         var spatialQueryButton = viewModel.getView().down('cmv_spatial_query_button');
         spatialQueryButton.setQueryLayerName(layerName);
+        spatialQueryButton.setVectorLayerKey(vectorLayerKey);
 
         // dynamically create the store based on the config setting
 

--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -56,9 +56,9 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
                 zoom: zoom - 1,
                 duration: duration / 2
             }, {
-            zoom: zoom,
-            duration: duration / 2
-        }
+                zoom: zoom,
+                duration: duration / 2
+            }
         );
     },
 

--- a/app/view/button/SpatialQueryButton.js
+++ b/app/view/button/SpatialQueryButton.js
@@ -14,12 +14,76 @@ Ext.define('CpsiMapview.view.button.SpatialQueryButton', {
         'CpsiMapview.controller.button.SpatialQueryButtonController'
     ],
 
+    statics: {
+        /**
+         * Finds the associated permanent layer of a layer that is
+         * used for the spatial query. This is done by comparing the
+         * layerKey of the layer to the associatedLayerKey property
+         * of the permanent layer.
+         * @param {ol.Map} map the map in which to look for the layer
+         * @param {String} layerKey layerKey property of the layer
+         */
+        findAssociatedPermanentLayer: function (map, layerKey) {
+            var layers = map.getLayers().getArray();
+            var associatedPermanentLayer = layers.find(function (layer) {
+                var isSpatialQueryLayer = layer.get('isSpatialQueryLayer');
+                var associatedLayerKey = layer.get('associatedLayerKey');
+                return isSpatialQueryLayer && (associatedLayerKey === layerKey);
+            });
+            return associatedPermanentLayer;
+        },
+
+        /**
+         * Clears the geometries of the associated permanent
+         * layer of a layer that is used for the spatial query.
+         * @param {ol.Map} map the map in which to look for the layer
+         * @param {String} layerKey layerKey property of the layer
+         */
+        clearAssociatedPermanentLayer: function (map, layerKey) {
+            var associatedPermanentLayer = CpsiMapview.view.button.SpatialQueryButton.findAssociatedPermanentLayer(map, layerKey);
+            if (associatedPermanentLayer !== undefined) {
+                associatedPermanentLayer.getSource().clear();
+            }
+        },
+
+        /**
+         * Shows the associated permanent layer of a layer that
+         * is used for the spatial query.
+         * @param {ol.Map} map the map in which to look for the layer
+         * @param {String} layerKey layerKey property of the layer
+         */
+        showAssociatedPermanentLayer: function (map, layerKey) {
+            var associatedPermanentLayer = CpsiMapview.view.button.SpatialQueryButton.findAssociatedPermanentLayer(map, layerKey);
+            if (associatedPermanentLayer !== undefined) {
+                associatedPermanentLayer.setVisible(true);
+            }
+        },
+
+        /**
+         * Hides the associated permanent layer of a layer that
+         * is used for the spatial query.
+         * @param {ol.Map} map the map in which to look for the layer
+         * @param {String} layerKey layerKey property of the layer
+         */
+        hideAssociatedPermanentLayer: function (map, layerKey) {
+            var associatedPermanentLayer = CpsiMapview.view.button.SpatialQueryButton.findAssociatedPermanentLayer(map, layerKey);
+            if (associatedPermanentLayer !== undefined) {
+                associatedPermanentLayer.setVisible(false);
+            }
+        },
+    },
+
     config: {
         /**
          * The name of the layer to query
          * This property will be ignored if queryLayer is defined
          */
-        queryLayerName: null
+        queryLayerName: null,
+
+        /**
+         * The layerKey property of the layer to query
+         */
+        vectorLayerKey: null
     },
 
     /**
@@ -61,6 +125,12 @@ Ext.define('CpsiMapview.view.button.SpatialQueryButton', {
     queryFeatures: new ol.Collection(),
 
     /**
+     * If true, the filter geometry will be displayed until filter was cleared
+     * If false, the filter geometry will disappear after filtering
+     */
+    displayPermanently: false,
+
+    /**
      * Enable toggle
      */
     enableToggle: true,
@@ -70,7 +140,10 @@ Ext.define('CpsiMapview.view.button.SpatialQueryButton', {
      * to their corresponding controller methods
      */
     listeners: {
-        toggle: 'onSpatialQueryBtnToggle'
+        toggle: 'onSpatialQueryBtnToggle',
+        clearAssociatedPermanentLayer: 'onClearAssociatedPermanentLayer',
+        hideAssociatedPermanentLayer: 'onHideAssociatedPermanentLayer',
+        showAssociatedPermanentLayer: 'onShowAssociatedPermanentLayer',
     },
 
     bind: {
@@ -83,6 +156,7 @@ Ext.define('CpsiMapview.view.button.SpatialQueryButton', {
     * @cfg {Boolean} triggerWfsRequest Whether or not to trigger a Wfs GetFeatures request
     */
     triggerWfsRequest: true,
+
     /**
      * Initializes this component
      */

--- a/app/view/grid/Grid.js
+++ b/app/view/grid/Grid.js
@@ -109,7 +109,9 @@ Ext.define('CpsiMapview.view.grid.Grid', {
                 spatialOperator: 'intersect',
                 toggleGroup: 'map',
                 triggerWfsRequest: false,
+                displayPermanently: true,
                 glyph: 'xf044@FontAwesome',
+                vectorLayerKey: '{vectorLayerKey}',
                 listeners: {
                     'cmv-spatial-query-filter': 'onSpatialFilter'
                 }

--- a/app/view/menuitem/LayerGrid.js
+++ b/app/view/menuitem/LayerGrid.js
@@ -80,7 +80,24 @@ Ext.define('CpsiMapview.view.menuitem.LayerGrid', {
                 title: title,
                 items: [{
                     xtype: gridXType
-                }]
+                }],
+                listeners: {
+                    hide: function () {
+                        var me = this;
+                        var queryButton = me.down('cmv_spatial_query_button');
+                        if (queryButton !== null) {
+                            queryButton.fireEvent('hideAssociatedPermanentLayer');
+                            queryButton.toggle(false);
+                        }
+                    },
+                    show: function () {
+                        var me = this;
+                        var queryButton = me.down('cmv_spatial_query_button');
+                        if (queryButton !== null) {
+                            queryButton.fireEvent('showAssociatedPermanentLayer');
+                        }
+                    }
+                }
             });
             gridWindow = Ext.create('CpsiMapview.view.window.MinimizableWindow', windowConfig);
         }


### PR DESCRIPTION
Adds the option `displayPermanently` to the `CpsiMapview.view.button.SpatialQueryButton` Component.

If true, a layer will be added that holds the geometry for the spatial query. This layer will remain visible unless the window which holds the LayerGrid will be closed and/or the visibility of the layer to query changes.

**Important:** In order to properly connect to the layer to query, the `layerKey` property of the layer has to be added via `vectorLayerKey` as additional property to the `SpatialQueryButton`.

The `SpatialQueryButton` now has additional static methods for handling the visibility and clearing of a geometry. These functions require the `ol.map` as well as the `layerKey` property of the layer to query. This allows handling the visibility and clearing of the layer from anywhere in the application. Instances of `SpatialQueryButton` implement events for handling the visibility of their own layers without any required arguments.

Additionally, a geometry for the spatial query now is editable. To simplify the editing, the cursor will automatically snap to the corner points of a geometry. Also, it is still only possible to draw a single geometry for the spatial filter.

**Note:** Currently, only the `SpatialQueryButton` in the LayerGrid Window was set to `displayPermanently: true`.

Example Screenshot of the geometry used for the spatial query. The dot on the corner of the geometry shows the snap-functionality for modifying the geometry.
![image](https://user-images.githubusercontent.com/12186477/75678489-09ef2380-5c8e-11ea-8d33-0e82565d9ec7.png)

solves #170 