### PR TITLE
Display baselayers with radio buttons

### DIFF
--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -160,11 +160,8 @@ Ext.define('CpsiMapview.view.LayerTree', {
 
             me.getRootNode().cascade(function (node) {
                 var data = node.getData();
-                if (data.leaf) {
-                    var isBaseLayer =  data.get('isBaseLayer');
-                    if (isBaseLayer) {
-                        node.addCls('cpsi-tree-node-baselayer');
-                    }
+                if (data.leaf && data.get('isBaseLayer')) {
+                    node.addCls('cpsi-tree-node-baselayer');
                 }
             });
 

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -160,7 +160,7 @@ Ext.define('CpsiMapview.view.LayerTree', {
 
             me.getRootNode().cascade(function (node) {
                 var data = node.getData();
-                if (typeof data.get === 'function') {
+                if (data.leaf) {
                     var isBaseLayer =  data.get('isBaseLayer');
                     if (isBaseLayer) {
                         node.addCls('cpsi-tree-node-baselayer');

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -78,7 +78,7 @@ Ext.define('CpsiMapview.view.LayerTree', {
      *
      * @param  {Object} cfg The configuration of the tree which we may change.
      */
-    constructor: function(cfg) {
+    constructor: function (cfg) {
         var me = this;
 
         me.callParent([cfg]);
@@ -113,7 +113,7 @@ Ext.define('CpsiMapview.view.LayerTree', {
      *
      * TODO this may change to use the passed map view from the mapready event.
      */
-    autoConnectToMap: function() {
+    autoConnectToMap: function () {
         var me = this;
         if (me.map) {
             var store = me.makeLayerStore();
@@ -131,7 +131,7 @@ Ext.define('CpsiMapview.view.LayerTree', {
      *
      * @return {GeoExt.data.store.LayersTree} The created store.
      */
-    makeLayerStore: function() {
+    makeLayerStore: function () {
         var me = this;
 
         // filter function for LayerTreeStore to hide unwanted layers in tree
@@ -157,6 +157,16 @@ Ext.define('CpsiMapview.view.LayerTree', {
                 filters: layerFilter
             });
             me.setStore(groupedLayerTreeStore);
+
+            me.getRootNode().cascade(function (node) {
+                var data = node.getData();
+                if (typeof data.get === 'function') {
+                    var isBaseLayer =  data.get('isBaseLayer');
+                    if (isBaseLayer) {
+                        node.addCls('cpsi-tree-node-baselayer');
+                    }
+                }
+            });
 
             // expand all folders in this tree
             me.expandAll();
@@ -193,11 +203,11 @@ Ext.define('CpsiMapview.view.LayerTree', {
             Ext.Ajax.request({
                 url: 'resources/data/layers/tree.json',
                 method: 'GET',
-                success: function(response) {
+                success: function (response) {
                     var respJson = Ext.decode(response.responseText);
                     resolve(respJson);
                 },
-                failure: function(response) {
+                failure: function (response) {
                     reject(response.status);
                 }
             });

--- a/sass/src/view/LayerTree.scss
+++ b/sass/src/view/LayerTree.scss
@@ -8,3 +8,9 @@
     opacity: 0.7;
     font-style: italic;
 }
+
+.cpsi-tree-node-baselayer {
+    .x-tree-checkbox {
+        background-image: url(images/form/radio.png);
+    }
+}


### PR DESCRIPTION
BaseLayers will now be displayed with radio buttons instead of checkboxes. Uses property `isBaseLayer` for distinguishing baseLayers from overlays.

![image](https://user-images.githubusercontent.com/12186477/75764905-df10d800-5d3e-11ea-9b70-b6cad39ab505.png)

fixes #143 