### PR TITLE
Check WFS response is not empty

### DIFF
--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -402,7 +402,7 @@ Ext.define('CpsiMapview.factory.Layer', {
                     // on occasion a WFS response from MapServer is empty with no error
                     // but with HTTP status 200 (for unknown reasons)
                     // fail here to avoid OL parsing errors
-                    if (xhr.responseText === "") {
+                    if (xhr.responseText === '') {
                         onError();
                     } else {
                         if (contentType.indexOf('application/json') !== -1) {

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -399,14 +399,21 @@ Ext.define('CpsiMapview.factory.Layer', {
                     var contentType = xhr.getResponseHeader('Content-Type');
                     var format = vectorSource.getFormat();
 
-                    if (contentType.indexOf('application/json') !== -1) {
-                        var features = format.readFeatures(
-                            xhr.responseText
-                        );
-                        vectorSource.addFeatures(features);
-                        vectorSource.dispatchEvent('vectorloadend');
-                    } else {
+                    // on occasion a WFS response from MapServer is empty with no error
+                    // but with HTTP status 200 (for unknown reasons)
+                    // fail here to avoid OL parsing errors
+                    if (xhr.responseText === "") {
                         onError();
+                    } else {
+                        if (contentType.indexOf('application/json') !== -1) {
+                            var features = format.readFeatures(
+                                xhr.responseText
+                            );
+                            vectorSource.addFeatures(features);
+                            vectorSource.dispatchEvent('vectorloadend');
+                        } else {
+                            onError();
+                        }
                     }
                 } else {
                     onError();


### PR DESCRIPTION
Likely an issue in MapServer, but handle in JS for now by checking for an empty string. 

MapServer issue for reference:

Request:

```xml
/mapserver/?map=/MapServer/apps/mapview-demo/example.map&&SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&OUTPUTFORMAT=application/json&TYPENAME=Boreholes&SRSNAME=EPSG:3857&FILTER=<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc"><ogc:And><ogc:PropertyIsGreaterThanOrEqualTo><ogc:PropertyName>YEAR</ogc:PropertyName><ogc:Literal>1951</ogc:Literal></ogc:PropertyIsGreaterThanOrEqualTo><ogc:PropertyIsLessThanOrEqualTo><ogc:PropertyName>YEAR</ogc:PropertyName><ogc:Literal>1983</ogc:Literal></ogc:PropertyIsLessThanOrEqualTo><ogc:BBOX><ogc:PropertyName>msGeometry</ogc:PropertyName><gml:Envelope xmlns:gml="http://www.opengis.net/gml" srsName="EPSG:3857"><gml:lowerCorner>-60112525.02836773 -29258871.435112905</gml:lowerCorner><gml:upperCorner>60112525.02836773 -28850391.955956925</gml:upperCorner></gml:Envelope></ogc:BBOX></ogc:And></ogc:Filter>
```

Log:

```
[Wed Mar 11 21:39:41 2020].397000 FLTLayerApplyPlainFilterToLayer(): (([YEAR] >= 1951) And (([YEAR] <= 1983) And intersects([shape],fromText('')) = TRUE)), rect=-60112525.0283677,-31430906.0308645,60112525.0283677,-28163070.1976166
[Wed Mar 11 21:39:41 2020].397000 msGEOSError(): GEOS library error. °‘N
[Wed Mar 11 21:39:41 2020].397000 msGEOSShapeFromWKT(): GEOS library error. Error reading WKT geometry "".
[Wed Mar 11 21:39:41 2020].397000 msTokenizeExpression(): Expression parser error. Parsing fromText function failed, WKT processing failed.
[Wed Mar 11 21:39:41 2020].397000 msQueryByFilter(): Search returned no results. No matching record(s) found.
[Wed Mar 11 21:39:41 2020].397000 mapserv request processing time (msLoadMap not incl.): 0.000s
[Wed Mar 11 21:39:41 2020].397000 msFreeMap(): freeing map at 00000000013605E0.
```