### PR TITLE
Use new layers from demo project

### DIFF
--- a/app/view/grid/ExampleGrid.js
+++ b/app/view/grid/ExampleGrid.js
@@ -6,14 +6,22 @@
 Ext.define('CpsiMapview.model.GridExample', {
     requires: 'GeoExt.data.model.Feature',
     extend: 'GeoExt.data.model.Feature',
-    idProperty: 'EquipmentId',
+    idProperty: 'osm_id',
     fields: [
         {
-            name: 'UnitTypeName',
+            name: 'code',
             type: 'string'
         },
         {
-            name: 'EquipmentId',
+            name: 'name',
+            type: 'string'
+        },
+        {
+            name: 'fclass',
+            type: 'string'
+        },
+        {
+            name: 'osm_id',
             type: 'integer'
         }
     ]
@@ -23,16 +31,17 @@ Ext.define('CpsiMapview.model.GridExample', {
 Ext.define('CpsiMapview.store.GridExample', {
     extend: 'CpsiMapview.store.WfsFeatures',
     alias: 'store.GridExample',
-    url: 'https://plmonaghandev.compass.ie/mapserver/?',
+    url: 'https://w08-mapserver.compass.ie/mapserver/?map=/MapServer/apps/mapview-demo/example.map&',
     storeId: 'GridExample',
+    requestMethod: 'POST',
     model: 'CpsiMapview.model.GridExample',
-    typeName: 'LightUnit',
+    typeName: 'ruins',
     layerOptions: {
         displayInLayerSwitcher: false,
         name: 'GridExampleLayer'
     },
     sorters: [{
-        property: 'EquipmentId',
+        property: 'osm_id',
         direction: 'ASC'
     }]
 });
@@ -42,7 +51,7 @@ Ext.define('CpsiMapview.view.grid.ExampleGridModel', {
     extend: 'CpsiMapview.model.grid.Grid',
     alias: 'viewmodel.example_grid',
     data: {
-        vectorLayerKey: 'LIGHT_UNIT_MVT',
+        vectorLayerKey: 'RUINS_WFS',
         gridStoreType: 'GridExample',
         gridLayerName: 'GridExampleLayer' // TODO this is duplicated in layerOptions above
     }
@@ -58,14 +67,30 @@ Ext.define('CpsiMapview.view.grid.ExampleGrid', {
         items: [
             {
                 text: 'Id',
-                dataIndex: 'EquipmentId', // case-sensitive
+                dataIndex: 'osm_id', // case-sensitive
                 filter: {
                     type: 'number'
                 }
             },
             {
-                text: 'Type',
-                dataIndex: 'UnitTypeName',
+                text: 'Code',
+                dataIndex: 'code',
+                flex: 2,
+                filter: {
+                    type: 'string'
+                }
+            },
+            {
+                text: 'Class',
+                dataIndex: 'fclass',
+                flex: 2,
+                filter: {
+                    type: 'string'
+                }
+            },
+            {
+                text: 'Name',
+                dataIndex: 'name',
                 flex: 1,
                 filter: {
                     type: 'string'

--- a/app/view/toolbar/MapTools.js
+++ b/app/view/toolbar/MapTools.js
@@ -116,7 +116,7 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
             xtype: 'cmv_streetview_tool'
         }, {
             xtype: 'cmv_timeslider',
-            startDate: new Date(2014, 0, 1),
+            startDate: new Date(1946, 0, 1),
             endDate: new Date(2020, 11, 30)
         }, {
             xtype: 'cmv_numericattributeslider',

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "eslint": "^6.2.1",
     "geostyler-openlayers-parser": "^0.21.0",
-    "geostyler-sld-parser": "^2.0.0"
+    "geostyler-sld-parser": "^2.0.0",
     "jsonlint": "^1.6.3"
   },
   "devDependencies": {

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -153,50 +153,6 @@
     },
     {
       "layerType": "switchlayer",
-      "layerKey": "LIGHT_UNIT_SWITCH_LAYER",
-      "visibility": false,
-      "layers": [
-        {
-          "layerType": "wms",
-          "text": "Light Unit Switch Layer (far)",
-          "layerKey": "LIGHT_UNIT_SWITCH_LAYER_FAR",
-          "serverOptions": {
-            "layers": "LightUnit",
-            "version": "1.3.0"
-          },
-          "openLayers": {
-            "singleTile": false
-          },
-          "styles": [
-            "Unit Type",
-            "Owner"
-          ],
-          "labelClassName": "labels"
-        },
-        {
-          "layerType": "wfs",
-          "text": "Light Unit Switch Layer (close)",
-          "layerKey": "LIGHT_UNIT_SWITCH_LAYER_CLOSE",
-          "url": "https://plmonaghandev.compass.ie/mapserver/?",
-          "geometryProperty": "msGeometry",
-          "featureType": "LightUnit",
-          "sldUrl": "resources/data/styling/LightUnit_Unit_Type.xml",
-          "openLayers": {},
-          "serverOptions": {
-            "outputFormat": "geojson"
-          },
-          "noCluster": true,
-          "stylesBaseUrl": "https://plmonaghandev.compass.ie/resources/data/styling/",
-          "styles": [
-            "LightUnit_Type.xml",
-            "LightUnit_Owner.xml"
-          ],
-          "stylesForceNumericFilterVals": true
-        }
-      ]
-    },
-    {
-      "layerType": "switchlayer",
       "layerKey": "WATERBODY_SWITCH_LAYER",
       "visibility": false,
       "layers": [
@@ -310,6 +266,8 @@
     {
       "layerType": "wfs",
       "text": "Ruins",
+      "qtip": "Right-click for a layer grid",
+      "gridXType": "cmv_examplegrid",
       "layerKey": "RUINS_WFS",
       "geometryProperty": "msGeometry",
       "featureType": "ruins",

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -5,12 +5,7 @@
     },
     "xyz": {
       "openLayers": {
-        "maxResolution": 560,
-        "minResolution": 28,
-        "numZoomLevels": 13,
-        "projection": "EPSG:900913",
         "visibility": true,
-        "zoomOffset": 7,
         "transitionEffect": "resize"
       },
       "isBaseLayer": true
@@ -18,21 +13,31 @@
     "osm": {
       "isBaseLayer": true,
       "openLayers": {
-        "maxResolution": 1222.99245234375,
-        "numZoomLevels": 12,
+        "numZoomLevels": 20,
         "opacity": 0.7,
-        "projection": "EPSG:900913",
-        "visibility": false,
-        "zoomOffset": 7
+        "visibility": false
       }
     },
     "wms": {
       "isBaseLayer": false,
       "isDefaultBaseLayer": false,
-      "url": "https://plmonaghandev.compass.ie/mapserver/"
+      "url": "https://w08-mapserver.compass.ie/mapserver/?map=/MapServer/apps/mapview-demo/example.map&",
+      "serverOptions": {
+        "version": "1.3.0"
+      },
+      "openLayers": {
+        "visibility": false
+      }
     },
     "wfs": {
-      "url": "https://ows.terrestris.de/geoserver/osm/wfs"
+      "url": "https://w08-mapserver.compass.ie/mapserver/?map=/MapServer/apps/mapview-demo/example.map&",
+      "stylesBaseUrl": "resources/data/styling/",
+      "serverOptions": {
+        "version": "2.0.0"
+      },
+      "openLayers": {
+        "visibility": false
+      }
     },
     "switchlayer": {
       "vectorFeaturesMinScale": 80000
@@ -88,6 +93,7 @@
       "text": "Country WFS",
       "layerKey": "COUNTRY_WFS",
       "qtip": "An OSM based WFS layer",
+      "url": "https://ows.terrestris.de/geoserver/osm/wfs",
       "featureType": "osm:osm-country-borders",
       "geomFieldName": "geometry",
       "namespaceDefinitions": {
@@ -107,12 +113,14 @@
       "layerType": "wfs",
       "text": "GAS WFS",
       "layerKey": "GAS_WFS",
+      "url": "https://ows.terrestris.de/geoserver/osm/wfs",
       "featureType": "osm:osm-fuel",
-      "stylesBaseUrl": "resources/data/styling/",
       "styles": [
         "Test_Gas.xml",
-        {"name":"Test_Alternative_Gas_Style.xml", 
-        "title": "CUSTOM TITLE"}
+        {
+          "name": "Test_Alternative_Gas_Style.xml",
+          "title": "CUSTOM TITLE"
+        }
       ],
       "geomFieldName": "geometry",
       "namespaceDefinitions": {
@@ -188,20 +196,57 @@
       ]
     },
     {
-      "layerType": "wms",
-      "text": "Works_Export (needs proxy)",
-      "layerKey": "WORKS_EXPORT_WMS_PROXY",
-      "url": "mapserver/",
-      "timeitem": "TIME",
-      "dateFormat": "Y",
-      "serverOptions": {
-        "layers": "Works_Type",
-        "version": "1.1.1"
-      },
-      "openLayers": {
-        "singleTile": true,
-        "visibility": false
-      }
+      "layerType": "switchlayer",
+      "layerKey": "WATERBODY_SWITCH_LAYER",
+      "visibility": false,
+      "layers": [
+        {
+          "layerType": "wms",
+          "text": "Waterbody Switch Layer (far)",
+          "layerKey": "WATERBODY_SWITCH_LAYER_FAR",
+          "serverOptions": {
+            "layers": "waterbodies"
+          },
+          "openLayers": {
+            "singleTile": false
+          },
+          "styles": [
+            "Waterbodies",
+            "Type"
+          ],
+          "labelClassName": "labels"
+        },
+        {
+          "layerType": "wfs",
+          "text": "Waterbody Switch Layer (close)",
+          "layerKey": "WATERBODY_SWITCH_LAYER_CLOSE",
+          "geometryProperty": "msGeometry",
+          "featureType": "waterbodies",
+          "noCluster": true,
+          "styles": [
+            "Waterbodies_Default.xml",
+            "Waterbodies_Type.xml"
+          ],
+          "tooltipsConfig": [
+            {
+              "alias": "Id",
+              "property": "osm_id"
+            },
+            {
+              "alias": "Code",
+              "property": "code"
+            },
+            {
+              "alias": "Class",
+              "property": "fclass"
+            },
+            {
+              "alias": "Name",
+              "property": "name"
+            }
+          ]
+        }
+      ]
     },
     {
       "layerType": "wfs",
@@ -224,78 +269,67 @@
     },
     {
       "layerType": "wfs",
-      "text": "Accidents",
-      "layerKey": "ACCIDENTS_WFS",
-      "url": "https://pmstipperarydev.compass.ie/mapserver/?",
+      "text": "Borehole WFS (Time)",
+      "qtip": "Filter records with the timeslider control",
+      "layerKey": "BOREHOLE_WFS",
       "geometryProperty": "msGeometry",
-      "featureType": "Accidents",
+      "featureType": "Boreholes",
       "openLayers": {
-        "maxResolution": 1222.99245234375,
-        "numZoomLevels": 12,
         "opacity": 0.9,
         "visibility": false
       },
-      "serverOptions": {
-        "outputFormat": "application/json; subtype=geojson"
-      },
       "noCluster": false,
-      "timeitem": "DATE",
-      "dateFormat": "Y-m-d",
-      "numericitem": true
+      "timeitem": "YEAR",
+      "dateFormat": "Y"
     },
     {
       "layerType": "wms",
-      "text": "Light Unit WMS",
-      "layerKey": "LIGHT_UNIT_WMS",
+      "text": "Borehole WMS",
+      "layerKey": "BOREHOLE_WMS",
       "serverOptions": {
-        "layers": "LightUnit",
+        "layers": "Boreholes",
         "version": "1.3.0"
       },
       "openLayers": {
         "singleTile": false,
         "visibility": false
       },
-      "styles": [ "Height", 
-                  {"name":"Owner", 
-                  "title": "CUSTOM TITLE"},  
-                  "Type", 
-                  "InterfaceBox", 
-                  "IsMetered", 
-                  "Materials", 
-                  "Sources", 
-                  "SwitchingProfiles" ],
+      "styles": [
+        {
+          "name": "Type",
+          "title": "Borehole Type"
+        },
+        "Depth",
+        {
+          "name": "Unthemed",
+          "title": "Location"
+        }
+      ],
       "labelClassName": "labels"
     },
     {
       "layerType": "wfs",
-      "text": "Light Unit WFS",
-      "layerKey": "LIGHT_UNIT_WFS",
-      "url": "https://plmonaghandev.compass.ie/mapserver/?",
+      "text": "Ruins",
+      "layerKey": "RUINS_WFS",
       "geometryProperty": "msGeometry",
-      "featureType": "LightUnit",
-      "sldUrl": "resources/data/styling/LightUnit_Unit_Type.xml",
-      "openLayers": {
-        "visibility": false
-      }
-    },
-    {
-      "layerType": "vtwms",
-      "text": "Light Unit VT WMS",
-      "layerKey": "LIGHT_UNIT_MVT",
-      "url": "https://plmonaghandev.compass.ie/mapserver/?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=true&LAYERS=LightUnit&TILED=false&CRS=EPSG%3A3857&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&STYLES=Owner&FORMAT=mvt",
-      "openLayers": {
-        "visibility": true
-      },
-      "stylesBaseUrl": "https://plmonaghandev.compass.ie/resources/data/styling/",
-      "styles": [ "LightUnit_Type.xml", 
-                  {"name":"LightUnit_Owner.xml", 
-                  "title": "CUSTOM TITLE"} ],
-      "stylesForceNumericFilterVals": true,
-      "gridXType": "cmv_examplegrid",
+      "featureType": "ruins",
+      "sldUrl": "https://w08-mapserver.compass.ie/mapserver/?map=/MapServer/apps/mapview-demo/example.map&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&LAYERS=ruins",
       "tooltipsConfig": [
         {
-          "alias": "Unit ID",
-          "property": "UnitTypeId"
+          "alias": "Id",
+          "property": "osm_id"
+        },
+        {
+          "alias": "Code",
+          "property": "code"
+        },
+        {
+          "alias": "Class",
+          "property": "fclass"
+        },
+        {
+          "alias": "Name",
+          "property": "name"
         }
       ]
     }

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -43,9 +43,7 @@
       "vectorFeaturesMinScale": 80000
     },
     "vtwms": {
-      "stylesForceNumericFilterVals": true,
-      "format": "MVT",
-      "gridXType": "cmv_examplegrid"
+      "format": "MVT"
     }
   },
   "layers": [
@@ -206,25 +204,6 @@
     },
     {
       "layerType": "wfs",
-      "text": "Test time WFS (needs proxy)",
-      "layerKey": "TIME_WFS_PROXY",
-      "url": "wfs/",
-      "featureType": "test:osm-fuel",
-      "serverOptions": {},
-      "noCluster": true,
-      "timeitem": "time",
-      "dateFormat": "c",
-      "geometryProperty": "the_geom",
-      "openLayers": {
-        "maxResolution": 1222.99245234375,
-        "numZoomLevels": 12,
-        "opacity": 0.7,
-        "projection": "EPSG:900913",
-        "visibility": false
-      }
-    },
-    {
-      "layerType": "wfs",
       "text": "Borehole WFS (Time)",
       "qtip": "Filter records with the timeslider control",
       "layerKey": "BOREHOLE_WFS",
@@ -262,6 +241,34 @@
         }
       ],
       "labelClassName": "labels"
+    },
+    {
+      "layerType": "vtwms",
+      "text": "Waterways VT WMS",
+      "layerKey": "WATERWAYS_VTWMS",
+      "url": "https://w08-mapserver.compass.ie/mapserver/?map=/MapServer/apps/mapview-demo/example.map&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=true&LAYERS=waterways&TILED=false&CRS=EPSG%3A3857&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&STYLES=Waterways&FORMAT=mvt",
+      "openLayers": {
+        "visibility": false
+      },
+      "sldUrl": "https://w08-mapserver.compass.ie/mapserver/?map=/MapServer/apps/mapview-demo/example.map&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&LAYERS=waterways",
+      "tooltipsConfig": [
+        {
+          "alias": "Id",
+          "property": "osm_id"
+        },
+        {
+          "alias": "Code",
+          "property": "code"
+        },
+        {
+          "alias": "Class",
+          "property": "fclass"
+        },
+        {
+          "alias": "Name",
+          "property": "name"
+        }
+      ]
     },
     {
       "layerType": "wfs",

--- a/resources/data/layers/tree.json
+++ b/resources/data/layers/tree.json
@@ -10,7 +10,7 @@
           "isLeaf": true
         },
         {
-          "id": "LIGHT_UNIT_VT",
+          "id": "RUINS_WFS",
           "isLeaf": true
         },
         {
@@ -18,11 +18,11 @@
           "isLeaf": true
         },
         {
-          "id": "LIGHT_UNIT_WMS",
+          "id": "BOREHOLE_WMS",
           "isLeaf": true
         },
         {
-          "id": "ACCIDENTS_WFS",
+          "id": "BOREHOLE_WFS",
           "isLeaf": true
         },
         {
@@ -35,6 +35,14 @@
         },
         {
           "id": "LIGHT_UNIT_SWITCH_LAYER_FAR",
+          "isLeaf": true
+        },
+        {
+          "id": "WATERBODY_SWITCH_LAYER_FAR",
+          "isLeaf": true
+        },
+        {
+          "id": "WATERBODY_SWITCH_LAYER_CLOSE",
           "isLeaf": true
         },
         {

--- a/resources/data/layers/tree.json
+++ b/resources/data/layers/tree.json
@@ -46,6 +46,10 @@
           "isLeaf": true
         },
         {
+          "id": "WATERWAYS_VTWMS",
+          "isLeaf": true
+        },
+        {
           "id": "GAS_WFS",
           "isLeaf": true
         },

--- a/resources/data/styling/Waterbodies_Default.xml
+++ b/resources/data/styling/Waterbodies_Default.xml
@@ -1,0 +1,19 @@
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd">
+    <NamedLayer>
+        <se:Name>waterbodies</se:Name>
+        <UserStyle>
+            <se:Name>Waterbodies</se:Name>
+            <se:IsDefault>true</se:IsDefault>
+            <se:FeatureTypeStyle>
+                <se:Rule>
+                    <se:Name>Waterbodies</se:Name>
+                    <se:PolygonSymbolizer>
+                        <se:Fill>
+                            <se:SvgParameter name="fill">#365f83</se:SvgParameter>
+                        </se:Fill>
+                    </se:PolygonSymbolizer>
+                </se:Rule>
+            </se:FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+</StyledLayerDescriptor>

--- a/resources/data/styling/Waterbodies_Type.xml
+++ b/resources/data/styling/Waterbodies_Type.xml
@@ -1,0 +1,90 @@
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd">
+    <NamedLayer>
+        <se:Name>waterbodies</se:Name>
+        <UserStyle>
+            <se:Name>Type</se:Name>
+            <se:FeatureTypeStyle>
+                <se:Rule>
+                    <se:Name>Dock</se:Name>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>fclass</ogc:PropertyName>
+                            <ogc:Literal>dock</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <se:PolygonSymbolizer>
+                        <se:Fill>
+                            <se:SvgParameter name="fill">#f7fbff</se:SvgParameter>
+                        </se:Fill>
+                    </se:PolygonSymbolizer>
+                </se:Rule>
+                <se:Rule>
+                    <se:Name>Reservoir</se:Name>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>fclass</ogc:PropertyName>
+                            <ogc:Literal>reservoir</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <se:PolygonSymbolizer>
+                        <se:Fill>
+                            <se:SvgParameter name="fill">#d1e3f3</se:SvgParameter>
+                        </se:Fill>
+                    </se:PolygonSymbolizer>
+                </se:Rule>
+                <se:Rule>
+                    <se:Name>River</se:Name>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>fclass</ogc:PropertyName>
+                            <ogc:Literal>river</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <se:PolygonSymbolizer>
+                        <se:Fill>
+                            <se:SvgParameter name="fill">#9ac8e1</se:SvgParameter>
+                        </se:Fill>
+                    </se:PolygonSymbolizer>
+                </se:Rule>
+                <se:Rule>
+                    <se:Name>Water</se:Name>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>fclass</ogc:PropertyName>
+                            <ogc:Literal>water</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <se:PolygonSymbolizer>
+                        <se:Fill>
+                            <se:SvgParameter name="fill">#529dcc</se:SvgParameter>
+                        </se:Fill>
+                    </se:PolygonSymbolizer>
+                </se:Rule>
+                <se:Rule>
+                    <se:Name>Wetland</se:Name>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>fclass</ogc:PropertyName>
+                            <ogc:Literal>wetland</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <se:PolygonSymbolizer>
+                        <se:Fill>
+                            <se:SvgParameter name="fill">#1c6cb1</se:SvgParameter>
+                        </se:Fill>
+                    </se:PolygonSymbolizer>
+                </se:Rule>
+                <!--
+                <se:Rule>
+                    <se:Name>Other</se:Name>
+                    <se:PolygonSymbolizer>
+                        <se:Fill>
+                            <se:SvgParameter name="fill">#08306b</se:SvgParameter>
+                        </se:Fill>
+                    </se:PolygonSymbolizer>
+                </se:Rule>
+                -->
+            </se:FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+</StyledLayerDescriptor>

--- a/resources/data/styling/ruins.xml
+++ b/resources/data/styling/ruins.xml
@@ -1,0 +1,25 @@
+<StyledLayerDescriptor version="1.0.0" xmlns="http://www.opengis.net/sld" xmlns:gml="http://www.opengis.net/gml" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd">
+<NamedLayer>
+<Name>ruins</Name>
+<UserStyle>
+<FeatureTypeStyle>
+<Rule>
+<Name>POI: Ruins</Name>
+<ogc:Filter><ogc:PropertyIsEqualTo><ogc:PropertyName>fclass</ogc:PropertyName><ogc:Literal>ruins</ogc:Literal></ogc:PropertyIsEqualTo></ogc:Filter>
+<PointSymbolizer>
+<Graphic>
+<Mark>
+<WellKnownName>cross</WellKnownName>
+<Fill>
+<CssParameter name="fill">#ffd966</CssParameter>
+</Fill>
+</Mark>
+<Size>8</Size>
+</Graphic>
+</PointSymbolizer>
+</Rule>
+</FeatureTypeStyle>
+</UserStyle>
+</NamedLayer>
+</StyledLayerDescriptor>
+


### PR DESCRIPTION
A new standalone project has been created at https://github.com/compassinformatics/mapview-demo and running at http://w08-mapserver.compass.ie/mapserver/?map=\MapServer\apps\mapview-demo\example.map& to serve layers for the cpsi-mapview project. 

These demo layers will not be subject to changes, unlike several WMS and WFS services currently used in the project. 

Broken layers have been removed and replaced with new layers, while retaining the functionality in the demo. 

Should address #183 and #173
