### PR TITLE
Make default values work recursivly 

### DIFF
--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -138,14 +138,14 @@ Ext.define('CpsiMapview.view.main.Map', {
 
         // general default
         var generalDefaults = defaults['general'];
-        Ext.apply(newLayerConf, generalDefaults);
+        Ext.Object.merge(newLayerConf, generalDefaults);
 
         // layer type default
         var typeDefaults = defaults[layerConf.layerType];
-        Ext.apply(newLayerConf,typeDefaults);
+        Ext.Object.merge(newLayerConf,typeDefaults);
 
         // actual config
-        Ext.apply(newLayerConf, layerConf);
+        Ext.Object.merge(newLayerConf, layerConf);
         return newLayerConf;
     },
 


### PR DESCRIPTION
This fix also applies the properties of the underlying objects to the layer configuration

see #172 