### PR TITLE
Add recursive defaults

### DIFF
--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -138,14 +138,14 @@ Ext.define('CpsiMapview.view.main.Map', {
 
         // general default
         var generalDefaults = defaults['general'];
-        Ext.apply(newLayerConf, generalDefaults);
+        Ext.Object.merge(newLayerConf, generalDefaults);
 
         // layer type default
         var typeDefaults = defaults[layerConf.layerType];
-        Ext.apply(newLayerConf,typeDefaults);
+        Ext.Object.merge(newLayerConf,typeDefaults);
 
         // actual config
-        Ext.apply(newLayerConf, layerConf);
+        Ext.Object.merge(newLayerConf, layerConf);
         return newLayerConf;
     },
 


### PR DESCRIPTION
Before the content of sub-objects in the default settings
were not applied to the layer config if the same sub-object
(also with different properties) already existed. This
commit fixes this issue by replacing the `apply` function
with the `merge` function.