### PR TITLE
Set minimizedWindows transparent & position it over map

### DIFF
--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -28,9 +28,6 @@ Ext.define('CpsiMapview.view.main.Map', {
     }, {
         xtype: 'cmv_mapfooter',
         dock: 'bottom'
-    }, {
-        xtype: 'cmv_minimized_windows_toolbar',
-        dock: 'bottom'
     }],
 
     items: [{
@@ -56,6 +53,8 @@ Ext.define('CpsiMapview.view.main.Map', {
         listeners: {
             afterrender: 'afterMapRender'
         }
+    }, {
+        xtype: 'cmv_minimized_windows_toolbar'
     }],
 
     /**

--- a/app/view/toolbar/MinimizedWindows.js
+++ b/app/view/toolbar/MinimizedWindows.js
@@ -16,6 +16,10 @@ Ext.define('CpsiMapview.view.toolbar.MinimizedWindows', {
 
     controller: 'cmv_minimized_windows_toolbar',
 
+    cls: 'cmv_minimized_windows_toolbar',
+
+    layout: 'absolute',
+
     name: null,
 
     hidden: true,

--- a/app/view/toolbar/MinimizedWindows.js
+++ b/app/view/toolbar/MinimizedWindows.js
@@ -19,8 +19,6 @@ Ext.define('CpsiMapview.view.toolbar.MinimizedWindows', {
 
     cls: 'cmv_minimized_windows_toolbar',
 
-    layout: 'absolute',
-
     name: null,
 
     hidden: true,

--- a/app/view/toolbar/MinimizedWindows.js
+++ b/app/view/toolbar/MinimizedWindows.js
@@ -11,7 +11,6 @@ Ext.define('CpsiMapview.view.toolbar.MinimizedWindows', {
     xtype: 'cmv_minimized_windows_toolbar',
 
     requires: [
-        'Ext.layout.container.Absolute',
         'CpsiMapview.controller.toolbar.MinimizedWindows'
     ],
 

--- a/app/view/toolbar/MinimizedWindows.js
+++ b/app/view/toolbar/MinimizedWindows.js
@@ -11,6 +11,7 @@ Ext.define('CpsiMapview.view.toolbar.MinimizedWindows', {
     xtype: 'cmv_minimized_windows_toolbar',
 
     requires: [
+        'Ext.layout.container.Absolute',
         'CpsiMapview.controller.toolbar.MinimizedWindows'
     ],
 

--- a/sass/src/view/main/Main.scss
+++ b/sass/src/view/main/Main.scss
@@ -1,11 +1,21 @@
 // This file can contain specific scss for the Main.js view component
 
 .cmv_minimized_windows_toolbar {
+    position: absolute;
     background-color: transparent;
     // twice the height of a toolbar + padding
-    bottom: calc(2 * 36px + 6px);
+    bottom: 36px;
+    height: 36px !important;
     // unfortunately, we have to use a hack here to overwrite
     // the 'top' property set by Ext, so that our bottom property
     // actually applies.
+    top: unset !important;
+}
+
+.cmv_minimized_windows_toolbar .x-box-inner {
+    height: 36px;
+}
+
+.cmv_minimized_windows_toolbar .x-toolbar-item {
     top: unset !important;
 }

--- a/sass/src/view/main/Main.scss
+++ b/sass/src/view/main/Main.scss
@@ -1,1 +1,11 @@
 // This file can contain specific scss for the Main.js view component
+
+.cmv_minimized_windows_toolbar {
+    background-color: transparent;
+    // twice the height of a toolbar + padding
+    bottom: calc(2 * 36px + 6px);
+    // unfortunately, we have to use a hack here to overwrite
+    // the 'top' property set by Ext, so that our bottom property
+    // actually applies.
+    top: unset !important;
+}


### PR DESCRIPTION
This is a follow up of #179 

The minimizedWindows toolbar is now transparent and was positioned over the map.

![image](https://user-images.githubusercontent.com/12186477/77512975-5506eb80-6e74-11ea-95c1-d1da9830da8a.png)
