### PR TITLE
Fix SenchaCmd Build in Azure Pipeline

### DIFF
--- a/app.json
+++ b/app.json
@@ -208,13 +208,6 @@
      */
   "js": [
     {
-      "path": "https://maps.googleapis.com/maps/api/js?v=3.36&key=INSERT_YOUR_API_KEY_HERE",
-      "remote": true
-    },
-    //{
-    //  "path": "./lib/openlayers/ol.js"
-    //},
-    {
       "path": "./lib/openlayers/ol-debug.js"
     },
     {
@@ -258,6 +251,10 @@
     },
     {
       "path": "https://cdn.jsdelivr.net/gh/highsource/w3c-schemas@1.4.0/scripts/lib/XLink_1_0.js"
+    },
+    {
+      "path": "https://maps.googleapis.com/maps/api/js?v=3.36&key=INSERT_YOUR_API_KEY_HERE",
+      "remote": true
     },
     {
       "path": "app.js",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,6 @@ steps:
 
 # rename the framework folder to ext
 - powershell: Rename-Item -Path ext-$($env:SENCHA_EXT_VERSION) -newName ext
-  displayName: 'Rename downloaded ExtJS framework folder'
   condition: ne(variables.CACHE_RESTORED, 'true')
   displayName: 'Rename ExtJS Framework Folder'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,9 +24,11 @@ steps:
     key: ext
     path: $(System.DefaultWorkingDirectory)/ext
     cacheHitVar: CACHE_RESTORED
+  displayName: 'Check if ExtJS Framework is Cached'
 
 - powershell: Invoke-WebRequest -Uri "http://cdn.sencha.com/ext/gpl/ext-$($env:SENCHA_EXT_VERSION)-gpl.zip" -OutFile "ExtJS.zip"
   condition: ne(variables.CACHE_RESTORED, 'true')
+  displayName: 'Download ExtJS Framework'
 
 - task: ExtractFiles@1
   inputs:
@@ -35,11 +37,13 @@ steps:
     # set following or it will delete the zip!
     cleanDestinationFolder: false 
   condition: ne(variables.CACHE_RESTORED, 'true')
+  displayName: 'Unzip ExtJS Framework'
 
 # rename the framework folder to ext
 - powershell: Rename-Item -Path ext-$($env:SENCHA_EXT_VERSION) -newName ext
   displayName: 'Rename downloaded ExtJS framework folder'
   condition: ne(variables.CACHE_RESTORED, 'true')
+  displayName: 'Rename ExtJS Framework Folder'
 
 # now let's download and install SenchaCmd
 
@@ -48,23 +52,22 @@ steps:
     key: sencha-cmd
     path: $(System.DefaultWorkingDirectory)/sencha-cmd
     cacheHitVar: CMD_CACHE_RESTORED
+  displayName: 'Check if SenchaCmd is Cached'
 
 - powershell: Invoke-WebRequest -Uri "http://cdn.sencha.com/cmd/$($env:SENCHA_CMD_VERSION)/jre/SenchaCmd-$($env:SENCHA_CMD_VERSION)-windows-64bit.zip" -OutFile "SenchaCmd.zip"
   condition: ne(variables.CMD_CACHE_RESTORED, 'true')
   displayName: 'Download SenchaCmd'
-
-- powershell: Invoke-WebRequest -Uri "http://cdn.sencha.com/cmd/$($env:SENCHA_CMD_VERSION)/jre/SenchaCmd-$($env:SENCHA_CMD_VERSION)-windows-64bit.zip" -OutFile "SenchaCmd.zip"
-  condition: ne(variables.CMD_CACHE_RESTORED, 'true')
-  displayName: 'Download SenchaCmd'  
 
 - task: ExtractFiles@1
   inputs:
     archiveFilePatterns: "$(System.DefaultWorkingDirectory)/SenchaCmd.zip"
     destinationFolder:  $(System.DefaultWorkingDirectory)/sencha-cmd
   condition: ne(variables.CMD_CACHE_RESTORED, 'true')
+  displayName: 'Unzip SenchaCmd'
 
 # Check if sencha.exe is available
 - powershell: $senchaCmdExists = Test-Path -Path "$(System.DefaultWorkingDirectory)/sencha-cmd/sencha.exe"
+  displayName: 'Check if SenchaCmd is Installed'
 
 # If not run the installer
 # https://docs.sencha.com/cmd/guides/intro_to_cmd.html#intro_to_cmd_-_installing_sencha_cmd_silently
@@ -75,11 +78,13 @@ steps:
   condition: ne(variables.senchaCmdExists, True)
 
 # Now we can begin the production build process
+
+- script: git submodule update --init --recursive
+  displayName: 'Update git Dependencies'
+
 - script: |
-    git submodule update --init --recursive
     npm install
-    npm list
-  displayName: 'Install Dependencies'
+  displayName: 'Install NodeJS Dependencies'
 
 - script: npm test
   displayName: 'Run Tests'
@@ -95,3 +100,4 @@ steps:
   inputs:
     pathtoPublish: '$(System.DefaultWorkingDirectory)/build/production/CpsiMapview'
     artifactName: CpsiMapview
+  displayName: 'Publish Output'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ steps:
     key: ext
     path: $(System.DefaultWorkingDirectory)/ext
     cacheHitVar: CACHE_RESTORED
-  displayName: 'Check if ExtJS Framework is Cached'
+  displayName: 'Get Cached ExtJS Framework'
 
 - powershell: Invoke-WebRequest -Uri "http://cdn.sencha.com/ext/gpl/ext-$($env:SENCHA_EXT_VERSION)-gpl.zip" -OutFile "ExtJS.zip"
   condition: ne(variables.CACHE_RESTORED, 'true')
@@ -51,7 +51,7 @@ steps:
     key: sencha-cmd
     path: $(System.DefaultWorkingDirectory)/sencha-cmd
     cacheHitVar: CMD_CACHE_RESTORED
-  displayName: 'Check if SenchaCmd is Cached'
+  displayName: 'Get Cached SenchaCmd'
 
 - powershell: Invoke-WebRequest -Uri "http://cdn.sencha.com/cmd/$($env:SENCHA_CMD_VERSION)/jre/SenchaCmd-$($env:SENCHA_CMD_VERSION)-windows-64bit.zip" -OutFile "SenchaCmd.zip"
   condition: ne(variables.CMD_CACHE_RESTORED, 'true')
@@ -64,11 +64,10 @@ steps:
   condition: ne(variables.CMD_CACHE_RESTORED, 'true')
   displayName: 'Unzip SenchaCmd'
 
-# Check if sencha.exe is available
 - powershell: $senchaCmdExists = Test-Path -Path "$(System.DefaultWorkingDirectory)/sencha-cmd/sencha.exe"
   displayName: 'Check if SenchaCmd is Installed'
 
-# If not run the installer
+# Run the SenchaCmd installer
 # https://docs.sencha.com/cmd/guides/intro_to_cmd.html#intro_to_cmd_-_installing_sencha_cmd_silently
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/powershell?view=azure-devops
 - powershell: ./SenchaCmd-6.5.2.15-windows-64bit.exe -q -dir "."

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,8 +3,6 @@
 # Useful links
 # https://adamtheautomator.com/azure-devops-pipelines-powershell/
 # https://aka.ms/yaml
-# Invoke-WebRequest -Uri "http://cdn.sencha.com/ext/gpl/ext-6.2.0-gpl.zip" -OutFile "ext-6.2.0-gpl.zip"
-# http://cdn.sencha.com/cmd/6.5.2/jre/SenchaCmd-6.5.2-windows-64bit.zip
 
 trigger:
 - master
@@ -18,14 +16,18 @@ variables:
     SENCHA_EXT_VERSION: '6.2.0'
     SENCHA_CMD_VERSION: '6.5.2'
 
+# first get the ExtJS framework and unzip it, unless this has already been cached
+
 steps:
 - task: CacheBeta@1
   inputs:
     key: ext
     path: $(System.DefaultWorkingDirectory)/ext
     cacheHitVar: CACHE_RESTORED
+
 - powershell: Invoke-WebRequest -Uri "http://cdn.sencha.com/ext/gpl/ext-$($env:SENCHA_EXT_VERSION)-gpl.zip" -OutFile "ExtJS.zip"
   condition: ne(variables.CACHE_RESTORED, 'true')
+
 - task: ExtractFiles@1
   inputs:
     archiveFilePatterns: '$(System.DefaultWorkingDirectory)/ExtJS.zip'
@@ -33,49 +35,61 @@ steps:
     # set following or it will delete the zip!
     cleanDestinationFolder: false 
   condition: ne(variables.CACHE_RESTORED, 'true')
+
+# rename the framework folder to ext
 - powershell: Rename-Item -Path ext-$($env:SENCHA_EXT_VERSION) -newName ext
   displayName: 'Rename downloaded ExtJS framework folder'
   condition: ne(variables.CACHE_RESTORED, 'true')
+
+# now let's download and install SenchaCmd
+
 - task: CacheBeta@1
   inputs:
     key: sencha-cmd
     path: $(System.DefaultWorkingDirectory)/sencha-cmd
     cacheHitVar: CMD_CACHE_RESTORED
+
 - powershell: Invoke-WebRequest -Uri "http://cdn.sencha.com/cmd/$($env:SENCHA_CMD_VERSION)/jre/SenchaCmd-$($env:SENCHA_CMD_VERSION)-windows-64bit.zip" -OutFile "SenchaCmd.zip"
   condition: ne(variables.CMD_CACHE_RESTORED, 'true')
   displayName: 'Download SenchaCmd'
+
 - powershell: Invoke-WebRequest -Uri "http://cdn.sencha.com/cmd/$($env:SENCHA_CMD_VERSION)/jre/SenchaCmd-$($env:SENCHA_CMD_VERSION)-windows-64bit.zip" -OutFile "SenchaCmd.zip"
   condition: ne(variables.CMD_CACHE_RESTORED, 'true')
   displayName: 'Download SenchaCmd'  
+
 - task: ExtractFiles@1
   inputs:
     archiveFilePatterns: "$(System.DefaultWorkingDirectory)/SenchaCmd.zip"
     destinationFolder:  $(System.DefaultWorkingDirectory)/sencha-cmd
   condition: ne(variables.CMD_CACHE_RESTORED, 'true')
 
-# TODO duplicated cache? How to check sencha.exe is available?
-- task: CacheBeta@1
-  inputs:
-    key: sencha-cmd-exe
-    path: $(System.DefaultWorkingDirectory)/sencha-cmd
-    cacheHitVar: CMD_EXE_CACHE_RESTORED
+# Check if sencha.exe is available
+- powershell: $senchaCmdExists = Test-Path -Path "$(System.DefaultWorkingDirectory)/sencha-cmd/sencha.exe"
+
+# If not run the installer
 # https://docs.sencha.com/cmd/guides/intro_to_cmd.html#intro_to_cmd_-_installing_sencha_cmd_silently
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/powershell?view=azure-devops
 - powershell: ./SenchaCmd-6.5.2.15-windows-64bit.exe -q -dir "."
   workingDirectory:  $(System.DefaultWorkingDirectory)/sencha-cmd
   displayName: 'Install SenchaCmd'
-  condition: ne(variables.CMD_EXE_CACHE_RESTORED, 'true')
+  condition: ne(variables.senchaCmdExists, True)
 
+# Now we can begin the production build process
 - script: |
     git submodule update --init --recursive
     npm install
+    npm list
+  displayName: 'Install Dependencies'
+
 - script: npm test
-  displayName: 'Test'
+  displayName: 'Run Tests'
 
 - script: |
      $(System.DefaultWorkingDirectory)/sencha-cmd/sencha which
      $(System.DefaultWorkingDirectory)/sencha-cmd/sencha -info app build
-  displayName: 'Build production'
+  displayName: 'Build Production'
+
+# Now publish the build
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/build-artifacts?view=azure-devops&tabs=yaml
 - task: PublishBuildArtifacts@1
   inputs:


### PR DESCRIPTION
This pull request cleans up the Azure Pipeline with additional comments. 

The app.json was also breaking the SenchaCmd build process for unknown reasons. The error was:

```
setting base href to : file:///D:/GitHub/cpsi-mapview/build/temp/production/CpsiMapview/slicer-temp/
== Unhandled Error ==
TypeError: No default value

  https://maps.googleapis.com/maps/api/js?v=3.36&key=INSERT_YOUR_API_KEY_HERE:27 in Ba
  https://maps.googleapis.com/maps/api/js?v=3.36&key=INSERT_YOUR_API_KEY_HERE:27 in value
  file:///D:/GitHub/cpsi-mapview/node_modules/geostyler-sld-parser/browser/sldStyleParser.js:1 in exports
```

The file ``cpsi-mapview\build\temp\production\CpsiMapview\slicer-temp\bootstrap.json`` contained the following:

```json
{"remote":true,"path":"https://maps.googleapis.com/maps/api/js?v\u003d3.36\u0026key\u003dINSERT_YOUR_API_KEY_HERE"},{"path":"../../../../../lib/openlayers/ol-debug.js"},{"path":"../../../../../node_modules/geostyler-sld-parser/browser/sldStyleParser.js"},{"path":"../../../../../node_modules/geostyler-openlayers-parser/browser/olStyleParser.js"}
```

Moving the Google Maps include to the end of the `js` array in `app.json` fixed this build error (although I am not sure why - possibly the keycodes in the URL?). 



