### PR TITLE
Fix Gas WFS version and hardcode image

### DIFF
--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -112,6 +112,7 @@
       "text": "GAS WFS",
       "layerKey": "GAS_WFS",
       "url": "https://ows.terrestris.de/geoserver/osm/wfs",
+      "legendUrl": "https://ows.terrestris.de/geoserver/osm/wfs?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetLegendGraphic&FORMAT=image%2Fpng&TRANSPARENT=TRUE&SLD_VERSION=1.1.0&LAYER=osm:osm-fuel&STYLE=",
       "featureType": "osm:osm-fuel",
       "styles": [
         {
@@ -128,6 +129,9 @@
       "geomFieldName": "geometry",
       "namespaceDefinitions": {
         "osm": "http://terrestris"
+      },
+      "serverOptions": {
+        "version": "1.1.0"
       },
       "noCluster": true,
       "tooltipsConfig": [


### PR DESCRIPTION
See #214 - it looks like the backend service is may not be configured for WFS 2.0.0
I've switched to 1.1.0 and the layer now displays, and the vector lables added for #144 now work correctly. 

I also hardcoded a legendUrl. Other WFS layers use MapServer WMS styles which mirror a WFS but this may not be the case for the GAS WFS which is hosted on GeoServer. 