### PR TITLE
Fix StreetView toggling

### DIFF
--- a/app/controller/button/StreetViewTool.js
+++ b/app/controller/button/StreetViewTool.js
@@ -147,7 +147,9 @@ Ext.define('CpsiMapview.controller.button.StreetViewTool', {
             }
             // cleanup
             me.vectorLayer.getSource().clear();
-            me.streetViewWin.close();
+            if (me.streetViewWin) {
+                me.streetViewWin.close();
+            }
         }
 
         // activate / deactivate click


### PR DESCRIPTION
If the tool is toggled before the window is created a JS error is thrown