### PR TITLE
Constrain cmv_minimizable_window to Viewport

### DIFF
--- a/app/view/window/MinimizableWindow.js
+++ b/app/view/window/MinimizableWindow.js
@@ -17,6 +17,8 @@ Ext.define('CpsiMapview.view.window.MinimizableWindow', {
 
     controller: 'cmv_minimizable_window',
 
+    constrain: true, // constrain within the viewport
+
     minimizable: true,
 
     /**


### PR DESCRIPTION
By default all `cmv_minimizable_window`s should be constrained