### PR TITLE
Reload grid if new columns are added

### DIFF
--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -294,7 +294,7 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
     * always be returned even if the column is hidden.
     *
     */
-    onColumnHideShow: function () {
+    getVisibleColumns: function () {
 
         var me = this;
         var grid = me.getView();
@@ -317,6 +317,30 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
             store.propertyName = visibleColumnNames.join(',');
         }
     },
+
+    onColumnHide: function () {
+        this.getVisibleColumns();
+    },
+
+    onColumnsReconfigure: function () {
+        this.getVisibleColumns();
+    },
+
+    onColumnShow: function () {
+
+        var me = this;
+        var grid = me.getView();
+        var store = grid.getStore();
+
+        me.getVisibleColumns();
+
+        // when a new column is displayed 
+        // query the server again to retrieve the data
+        store.reload();
+    },
+
+,
+
 
     /**
     * Clear both the grid filters and any spatial filter.

--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -334,13 +334,10 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
 
         me.getVisibleColumns();
 
-        // when a new column is displayed 
+        // when a new column is displayed
         // query the server again to retrieve the data
         store.reload();
     },
-
-,
-
 
     /**
     * Clear both the grid filters and any spatial filter.

--- a/app/view/grid/Grid.js
+++ b/app/view/grid/Grid.js
@@ -77,10 +77,10 @@ Ext.define('CpsiMapview.view.grid.Grid', {
     listeners: {
         filterchange: 'filterAssociatedLayers',
         itemcontextmenu: 'onItemContextMenu',
-        columnhide: 'onColumnHideShow',
-        columnshow: 'onColumnHideShow',
+        columnhide: 'onColumnHide',
+        columnshow: 'onColumnShow',
         // ensure columns are set when the store is bound to the grid
-        reconfigure: 'onColumnHideShow'
+        reconfigure: 'onColumnsReconfigure'
     },
 
     /**
@@ -152,5 +152,5 @@ Ext.define('CpsiMapview.view.grid.Grid', {
                 boxLabel: 'Page Records?',
                 handler: 'togglePaging'
             }]
-    }]
+    }],
 });


### PR DESCRIPTION
The WFS server only returns data for displayed columns. If new columns are made visible they currently appear empty until a refresh. 
This pull request makes a new server request each time a new column is displayed. 