### PR TITLE
Remove stylesForceNumericFilterVals

### DIFF
--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -466,7 +466,6 @@ Ext.define('CpsiMapview.factory.Layer', {
             isNumericDependent: Ext.isDefined(layerConf.numericitem),
             styles: layerConf.styles,
             stylesBaseUrl: layerConf.stylesBaseUrl || '',
-            stylesForceNumericFilterVals: layerConf.stylesForceNumericFilterVals,
             sldUrl: layerConf.sldUrl,
             sldUrlLabel: layerConf.sldUrlLabel
         };
@@ -488,7 +487,7 @@ Ext.define('CpsiMapview.factory.Layer', {
 
         if (sldUrl) {
             // load and parse style and apply it to layer
-            LayerFactory.loadSld(wfsLayer, sldUrl, layerConf.stylesForceNumericFilterVals);
+            LayerFactory.loadSld(wfsLayer, sldUrl);
         }
 
         if (layerConf.tooltipsConfig) {
@@ -688,7 +687,6 @@ Ext.define('CpsiMapview.factory.Layer', {
             isVt: true,
             styles: layerConf.styles,
             stylesBaseUrl: layerConf.stylesBaseUrl || '',
-            stylesForceNumericFilterVals: layerConf.stylesForceNumericFilterVals,
             toolTipConfig: layerConf.tooltipsConfig,
             sldUrl: layerConf.sldUrl,
             sldUrlLabel: layerConf.sldUrlLabel
@@ -710,7 +708,7 @@ Ext.define('CpsiMapview.factory.Layer', {
         }
         if (sldUrl) {
             // load and parse style and apply it to layer
-            LayerFactory.loadSld(vtLayer, sldUrl, layerConf.stylesForceNumericFilterVals);
+            LayerFactory.loadSld(vtLayer, sldUrl);
         }
 
         if (layerConf.tooltipsConfig) {
@@ -826,7 +824,7 @@ Ext.define('CpsiMapview.factory.Layer', {
      * @param  {ol.layer.Vector} mapLayer The layer to apply the style to
      * @param  {String} sldUrl   The URL to the SLD
      */
-    loadSld: function (mapLayer, sldUrl, forceNumericFilterVals) {
+    loadSld: function (mapLayer, sldUrl) {
         Ext.Ajax.request({
             url: sldUrl,
             method: 'GET',
@@ -837,11 +835,6 @@ Ext.define('CpsiMapview.factory.Layer', {
 
                 sldParser.readStyle(sldXml)
                     .then(function (gs) {
-
-                        if (forceNumericFilterVals) {
-                            // transform filter values to numbers ('1' => 1)
-                            gs = LayerFactory.forceNumericFilterValues(gs);
-                        }
 
                         olParser.writeStyle(gs).then(function (olStyle) {
                             mapLayer.setStyle(olStyle);
@@ -896,24 +889,6 @@ Ext.define('CpsiMapview.factory.Layer', {
         mapPanel.on('cmv-map-pointerrestout', function () {
             CpsiMapview.view.layer.ToolTip.clear();
         });
-    },
-
-    /**
-     * Transforms the filter values in the given GeoStyler style object to
-     * a number (if numeric).
-     *
-     * @param  {Object} gsStyle GeoStyler style object
-     * @return {Object}         GeoStyler style object with numeric filter vals
-     */
-    forceNumericFilterValues: function (gsStyle) {
-        Ext.each(gsStyle.rules, function (rule) {
-            var filterVal = rule.filter[2];
-            if (Ext.isNumeric(filterVal)) {
-                rule.filter[2] = parseFloat(filterVal);
-            }
-        });
-
-        return gsStyle;
     },
 
     /**
@@ -983,9 +958,8 @@ Ext.define('CpsiMapview.factory.Layer', {
                     // TODO following code duplicated in CpsiMapview.view.layer.StyleSwitcherRadioGroup
                     var sldUrl = newLayer.get('stylesBaseUrl') + activeStyle;
                     // transform filter values to numbers ('1' => 1)
-                    var forceNumericFilterVals = newLayer.get('stylesForceNumericFilterVals');
                     // load and parse SLD and apply it to layer
-                    LayerFactory.loadSld(newLayer, sldUrl, forceNumericFilterVals);
+                    LayerFactory.loadSld(newLayer, sldUrl);
                     newLayerSource.clear();
                     newLayerSource.refresh();
 

--- a/app/view/layer/StyleSwitcherRadioGroup.js
+++ b/app/view/layer/StyleSwitcherRadioGroup.js
@@ -167,10 +167,8 @@ Ext.define('CpsiMapview.view.layer.StyleSwitcherRadioGroup', {
                     }
 
                 }
-                // transform filter values to numbers ('1' => 1)
-                var forceNumericFilterVals = layer.get('stylesForceNumericFilterVals');
                 // load and parse SLD and apply it to layer
-                LayerFactory.loadSld(layer, sldUrl, forceNumericFilterVals);
+                LayerFactory.loadSld(layer, sldUrl);
 
                 if ((layer.get('isWfs') || layer.get('isVt')) && layerTreePanel) {
                     // force update of corresponding layer node UI (e.g. legend)

--- a/app/view/menuitem/LayerLabels.js
+++ b/app/view/menuitem/LayerLabels.js
@@ -57,14 +57,6 @@ Ext.define('CpsiMapview.view.menuitem.LayerLabels', {
     clientSideStyle: null,
 
     /**
-     * Switch if values in filter should be
-     * cast to numeric values.
-     * @property{Boolean}
-     * @readonly
-     */
-    forceNumericFilterVals: null,
-
-    /**
      * @private
      */
     initComponent: function () {
@@ -78,9 +70,6 @@ Ext.define('CpsiMapview.view.menuitem.LayerLabels', {
         if (me.layer && (me.layer.getSource() instanceof ol.source.TileWMS ||
             me.layer.getSource() instanceof ol.source.ImageWMS)) {
             me.labelClassName = me.layer.get('labelClassName');
-        } else if (me.clientSideStyle) {
-            // set required properties for client side labeling
-            me.forceNumericFilterVals = me.layer.get('stylesForceNumericFilterVals');
         }
 
         me.callParent();
@@ -187,7 +176,6 @@ Ext.define('CpsiMapview.view.menuitem.LayerLabels', {
     addLabelStyle: function (addLabel) {
         var me = this;
         var layer = me.layer;
-        var forceNumericFilterVals = me.forceNumericFilterVals;
         var activatedStyle = layer.get('activatedStyle');
 
         var url;
@@ -201,7 +189,7 @@ Ext.define('CpsiMapview.view.menuitem.LayerLabels', {
             if (url) {
                 layer.set('activeLabelStyle', url);
                 layer.set('labelsActive', true);
-                LayerFactory.loadSld(layer, url, forceNumericFilterVals);
+                LayerFactory.loadSld(layer, url);
             }
 
         } else {
@@ -215,7 +203,7 @@ Ext.define('CpsiMapview.view.menuitem.LayerLabels', {
             if (url) {
                 layer.set('activeLabelStyle', undefined);
                 layer.set('labelsActive', false);
-                LayerFactory.loadSld(layer, url, forceNumericFilterVals);
+                LayerFactory.loadSld(layer, url);
             }
 
         }


### PR DESCRIPTION
Some issues arose with SLDs with multiple filters e.g. 

```js
["&&", Array(3), Array(3)]
// [">=", "Height", "0 "]
// ["<", "Height", "7 "]
```

These would throw the following error:

```
Error:   var filterVal = rule.filter[2];
    
Layer.js?_dc=1586508526324:910 Uncaught (in promise) TypeError: Cannot read property '2' of undefined
    at Object.<anonymous> (Layer.js?_dc=1586508526324:910)
    at Object.each (Array.js?_dc=1586508526323:379)
    at constructor.forceNumericFilterValues (Layer.js?_dc=1586508526324:909)
    at Layer.js?_dc=1586508526324:843 
```

Initially I attempted to update this function to handle all filter types (see JS at end of the issue). However when debugging it appeared this was duplicating code in the geostyler-openlayers-parser library, and on further investigation the library also used [parseFloat](https://github.com/geostyler/geostyler-openlayers-parser/blob/master/src/OlStyleParser.ts#L618). 

I believe the issue is with how MapServer creates literals for comparison, leaving an erroneous space which then leads them to be viewed as a string. I can clean these up with Python as a temporary measure and then look at updating MapServer. 

```xml
<ogc:Literal>1 </ogc:Literal>
```

This means the `forceNumericFilterValues` and associated layer property `stylesForceNumericFilterVals` are probably no longer necessary (all numeric styles are working in my test systems now without these functions and with corrected SLD files). 

Initial (now unnecessary) update to forceNumericFilterValues:

```js
    forceNumericFilterValues: function (gsStyle) {
        Ext.each(gsStyle.rules, function (rule) {

            if (rule.filter) {
                var operator = rule.filter[0];
                var filterVal;

                switch (operator) {
                case '==':
                    filterVal = rule.filter[2];
                    if (Ext.isNumeric(filterVal)) {
                        rule.filter[2] = parseFloat(filterVal);
                    }
                    break;
                case '&&':
                    // code block
                    Ext.each(rule.filter, function (clause, index) {
                        if (index > 0) {
                            filterVal = rule.filter[index][2];
                            rule.filter[index][2] = parseFloat(filterVal);
                        }
                    });
                    break;
                default:
                    // code block
                }
                // can sometimes be an array  ["&&", Array(3), Array(3)]
                // ">=", "Height", "0 "
                // ["<", "Height", "7 "]

            };
        });
        return gsStyle;
    },
```   

