### PR TITLE
Replace find with findBy

### DIFF
--- a/app/controller/toolbar/MinimizedWindows.js
+++ b/app/controller/toolbar/MinimizedWindows.js
@@ -66,7 +66,7 @@ Ext.define('CpsiMapview.controller.toolbar.MinimizedWindows', {
         minimizedWindow.setVisible(true);
         minimizedWindow.isMinimized = false;
 
-        var button = me.getView().items.find(function (item) {
+        var button = me.getView().items.findBy(function (item) {
             return (item.getXType() === 'button') && (item.windowRef === windowRef);
         });
 


### PR DESCRIPTION
The line `var button = me.getView().items.find(function (item) {` was throwing a `items find is not a function` error. 
The function is deprecated for a [Ext.util.ItemCollection](https://docs.sencha.com/extjs/6.2.0/modern/Ext.util.ItemCollection.html#method-find)

The worst thing was the code runs fine locally in dev with the exact same framework, but would fail in the minified production code. 

Replacing with `findBy`. 

Note `find` is used in other places in the codebase but is fine for a [Store](https://docs.sencha.com/extjs/6.2.0/modern/Ext.data.AbstractStore.html#method-find), [Ext.util.Collection](https://docs.sencha.com/extjs/6.2.0/classic/Ext.util.Collection.html#method-find), and standard JS [Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find). 