### PR TITLE
Netsolver default handler

### DIFF
--- a/app/view/button/DigitizeButton.js
+++ b/app/view/button/DigitizeButton.js
@@ -108,7 +108,6 @@ Ext.define('CpsiMapview.view.button.DigitizeButton', {
      */
     listeners: {
         toggle: 'onToggle',
-        beforedestroy: 'onBeforeDestroy',
-        responseFeatures: 'onResponseFeatures'
+        beforedestroy: 'onBeforeDestroy'
     }
 });

--- a/app/view/toolbar/MapTools.js
+++ b/app/view/toolbar/MapTools.js
@@ -97,15 +97,14 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
             useContextMenu: true,
             pointExtentBuffer: 50,
             listeners: {
-                responseFeatures: 'onResponseFeatures'
+                responseFeatures: function () {
+                    this.getController().onResponseFeatures();
+                }
             }
         }, {
             xtype: 'cmv_digitize_button',
             type: 'LineString',
-            tooltip: 'Line',
-            listeners: {
-                responseFeatures: 'onResponseFeatures'
-            }
+            tooltip: 'Line'
         }, {
             xtype: 'cmv_digitize_button',
             type: 'Polygon',
@@ -113,7 +112,9 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
             apiUrl: 'https://pmstipperarydev.compass.ie/WebServices/roadschedule/cutWithPolygon',
             clearDrawnFeature: false,
             listeners: {
-                responseFeatures: 'onResponseFeatures'
+                responseFeatures: function () {
+                    this.getController().onResponseFeatures();
+                }
             }
         }, {
             xtype: 'cmv_digitize_button',
@@ -122,7 +123,9 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
             apiUrl: 'https://pmstipperarydev.compass.ie/WebServices/roadschedule/cutWithPolygon',
             clearDrawnFeature: false,
             listeners: {
-                responseFeatures: 'onResponseFeatures'
+                responseFeatures: function () {
+                    this.getController().onResponseFeatures();
+                }
             }
         }, {
             xtype: 'cmv_streetview_tool'

--- a/app/view/toolbar/MapTools.js
+++ b/app/view/toolbar/MapTools.js
@@ -70,7 +70,7 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
                         title: 'Info',
                         message: msg,
                         buttons: Ext.MessageBox.OK,
-                        icon:  Ext.MessageBox.INFO,
+                        icon: Ext.MessageBox.INFO,
                     });
                 },
                 'cmv-spatial-query-error': function () {
@@ -78,7 +78,7 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
                         title: 'Error',
                         message: 'WFS query not successful',
                         buttons: Ext.MessageBox.OK,
-                        icon:  Ext.MessageBox.ERROR,
+                        icon: Ext.MessageBox.ERROR,
                     });
                 }
             }
@@ -95,23 +95,35 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
             tooltip: 'Point',
             apiUrl: 'https://pmstipperarydev.compass.ie/pmspy/netsolver',
             useContextMenu: true,
-            pointExtentBuffer: 50
+            pointExtentBuffer: 50,
+            listeners: {
+                responseFeatures: 'onResponseFeatures'
+            }
         }, {
             xtype: 'cmv_digitize_button',
             type: 'LineString',
-            tooltip: 'Line'
+            tooltip: 'Line',
+            listeners: {
+                responseFeatures: 'onResponseFeatures'
+            }
         }, {
             xtype: 'cmv_digitize_button',
             type: 'Polygon',
             tooltip: 'Polygon',
             apiUrl: 'https://pmstipperarydev.compass.ie/WebServices/roadschedule/cutWithPolygon',
-            clearDrawnFeature: false
+            clearDrawnFeature: false,
+            listeners: {
+                responseFeatures: 'onResponseFeatures'
+            }
         }, {
             xtype: 'cmv_digitize_button',
             type: 'Circle',
             tooltip: 'Circle',
             apiUrl: 'https://pmstipperarydev.compass.ie/WebServices/roadschedule/cutWithPolygon',
-            clearDrawnFeature: false
+            clearDrawnFeature: false,
+            listeners: {
+                responseFeatures: 'onResponseFeatures'
+            }
         }, {
             xtype: 'cmv_streetview_tool'
         }, {


### PR DESCRIPTION
Only trigger the showcase DigitizeButtonController onResponseFeatures in the sample mapview application
This avoids having to remove the function, or sublass the button in other applications. 