### PR TITLE
Add toggle option for resetting results

### DIFF
--- a/app/controller/button/DigitizeButtonController.js
+++ b/app/controller/button/DigitizeButtonController.js
@@ -165,13 +165,16 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
                 me.map.getViewport().removeEventListener('contextmenu', me.showContextMenu.bind(me));
             }
             me.drawInteraction.setActive(false);
-            me.drawLayer.getSource().clear();
-            if (me.resultLayer) {
-                me.resultLayer.getSource().clear();
+
+            if (me.getView().getResetOnToggle()) {
+                me.drawLayer.getSource().clear();
+                if (me.resultLayer) {
+                    me.resultLayer.getSource().clear();
+                }
+                // reset context menu entries
+                me.activeGroupIdx = 0;
+                me.contextMenuGroupsCounter = 0;
             }
-            // reset context menu entries
-            me.activeGroupIdx = 0;
-            me.contextMenuGroupsCounter = 0;
         }
     },
 

--- a/app/view/button/DigitizeButton.js
+++ b/app/view/button/DigitizeButton.js
@@ -53,7 +53,7 @@ Ext.define('CpsiMapview.view.button.DigitizeButton', {
         useContextMenu: false,
 
         /**
-         * Shall the drawn feature be removed when a new gets drawn?
+         * Should the drawn feature be removed when a new feature gets drawn?
          */
         clearDrawnFeature: true,
 
@@ -88,7 +88,13 @@ Ext.define('CpsiMapview.view.button.DigitizeButton', {
          */
         pointExtentBuffer: 0,
 
-        resultLayer: null
+        resultLayer: null,
+
+        /**
+        * Should the results and draw layers be reset if the
+        * tool is deactivated?
+        */
+        resetOnToggle: true
     },
 
     /**


### PR DESCRIPTION
This update allows a `resetOnToggle` option to be set on `cmv_digitize_button` that can when `true` (the default) clears the resultLayer when the tool is deactivated, and leaves the features and polygon displayed in the layers when set to `false`. 

This allows a grid to be bound to the resultsLayer without clearing features when the tool is deactivated. 