### PR TITLE
Add default rowdblclick handler to the grid to open an associated form

### DIFF
--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -221,6 +221,45 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
 
         this.filterAssociatedLayers();
     },
+
+
+    /**
+     * If there is an edit / view window for individual records
+     * in the grid then open it with this function
+     *
+     * @param {Ext.grid.View} grid
+     * @param {Ext.data.Model} record
+     * @private
+     */
+    onRowDblClick: function (grid, record) {
+
+        var me = this;
+        var vm = me.getViewModel();
+        var associatedEditWindow = vm.get('associatedEditWindow');
+        var associatedEditModel = vm.get('associatedEditModel');
+        var modelPrototype = Ext.ClassManager.get(associatedEditModel);
+
+        if (associatedEditWindow && modelPrototype) {
+
+            // get a reference to the model class so we can use the
+            // static .load function without creating a new empty model
+            var recId = record.getId();
+
+            grid.mask('Loading Record...');
+            modelPrototype.load(recId, {
+                success: function (rec) {
+                    var win = Ext.create(associatedEditWindow);
+                    var vm = win.getViewModel();
+                    vm.set('currentRecord', rec);
+                    win.show();
+                },
+                callback: function () {
+                    grid.unmask();
+                },
+                scope: this
+            });
+        }
+    },
     /**
     * Enable and disable paging for the grid.
     * Disabling paging allows all records to be loaded into the

--- a/app/view/grid/Grid.js
+++ b/app/view/grid/Grid.js
@@ -79,6 +79,7 @@ Ext.define('CpsiMapview.view.grid.Grid', {
         itemcontextmenu: 'onItemContextMenu',
         columnhide: 'onColumnHide',
         columnshow: 'onColumnShow',
+        rowdblclick: 'onRowDblClick',
         // ensure columns are set when the store is bound to the grid
         reconfigure: 'onColumnsReconfigure'
     },


### PR DESCRIPTION
A generic double click handler that will create a new "detailed" model based on the selected row in the grid. 

This relies on 2 properties being set in the grid ViewModel:

```
        associatedEditModel: 'ProjectName.model.ChildModelName',
        associatedEditWindow: 'ProjectName.view.child.WindowName',
```

If either or these have not been set the handler will do nothing. 
It is recommended to add the model and window classes as requires to the grid's ViewModel where they are referenced. 