### PR TITLE
Only add tool generated layer to the map

### DIFF
--- a/app/controller/button/DigitizeButtonController.js
+++ b/app/controller/button/DigitizeButtonController.js
@@ -142,8 +142,8 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
                     source: new ol.source.Vector(),
                     style: view.getResultLayerStyle()
                 });
+                me.map.addLayer(me.resultLayer);
             }
-            me.map.addLayer(me.resultLayer);
         }
 
         if (pressed) {


### PR DESCRIPTION
This allows more flexibility so the `resultLayer` can be created and added independently of toggling the tool. 