### PR TITLE
Remove handler from right-hand side of Windows

### DIFF
--- a/app/view/window/MinimizableWindow.js
+++ b/app/view/window/MinimizableWindow.js
@@ -35,6 +35,8 @@ Ext.define('CpsiMapview.view.window.MinimizableWindow', {
      */
     minimizeTo: null,
 
+    resizeHandles: 's w nw se sw', // don't add a resizer to the top-right (n e ne) as it blocks the close button
+
     listeners: {
         minimize: 'onMinimize',
         show: 'onShow'


### PR DESCRIPTION
The [Resizer](https://docs.sencha.com/extjs/6.2.0/classic/Ext.resizer.Resizer.html) on a Window blocks clicking on the Close button in the top-right of the grid window (whilst not blocking it completely it makes it difficult to click on). 

![image](https://user-images.githubusercontent.com/490840/81811701-5627d100-9525-11ea-976c-67788d209881.png)


This pull request removes the handlers from the right of the Window. 

The handlers can also be reduced from 10px by setting the SASS variable: `$resizer-handle-size: dynamic(5px);` however this only reduced the annoyance slightly. 

