### PR TITLE
Allow Enter key to get Circle results

### DIFF
--- a/app/controller/button/DigitizeButtonController.js
+++ b/app/controller/button/DigitizeButtonController.js
@@ -9,7 +9,8 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
         'Ext.menu.Menu',
         'CpsiMapview.view.window.MinimizableWindow',
         'GeoExt.component.FeatureRenderer',
-        'GeoExt.data.store.Features'
+        'GeoExt.data.store.Features',
+        'CpsiMapview.view.toolbar.CircleSelectionToolbar'
     ],
 
     alias: 'controller.cmv_digitize_button',
@@ -83,9 +84,9 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
             me.map = BasiGX.util.Map.getMapComponent().map;
         }
 
-        // use default parent for circle toolbar if not defined
+        // use default cmv_map Ext.panel.Panel for circle toolbar if not defined
         if (!me.circleToolbarParent) {
-            me.circleToolbarParent = view.findParentByType('cmv_map');
+            me.circleToolbarParent = Ext.ComponentQuery.query('cmv_map')[0];
         }
 
         // create a temporary draw layer unless one has already been set

--- a/app/controller/toolbar/CircleSelectionToolbar.js
+++ b/app/controller/toolbar/CircleSelectionToolbar.js
@@ -28,6 +28,19 @@ Ext.define('CpsiMapview.controller.toolbar.CircleSelectionToolbar', {
     },
 
     /**
+     * Handles a keypress in the textfield and triggers
+     * handleApply when the Enter key is pressed
+     */
+    handleEnterKey: function (fld, e) {
+        var me = this;
+
+        if (e.getCharCode() == Ext.EventObject.ENTER) {
+            me.handleApply();
+        }
+
+    },
+
+    /**
      * Gets the radius of the ol circle feature.
      */
     getCurrentRadius: function () {

--- a/app/view/toolbar/CircleSelectionToolbar.js
+++ b/app/view/toolbar/CircleSelectionToolbar.js
@@ -41,8 +41,10 @@ Ext.define('CpsiMapview.view.toolbar.CircleSelectionToolbar', {
                 fieldLabel: 'Radius in {unit}'
             },
             minValue: 0,
+            enableKeyEvents: true, // required for keypress event
             listeners: {
-                change: 'onRadiusChange'
+                change: 'onRadiusChange',
+                keypress: 'handleEnterKey'
             }
         }, {
             xtype: 'button',


### PR DESCRIPTION
Add an Enter key shortcut to pressing the Apply button.
Also look throughout the entire application for a default parent container (to allow the button control to be added to a floating window rather than a map toolbar). 
Add missing requires. 