### PR TITLE
Fix grid size

### DIFF
--- a/app/view/grid/Grid.js
+++ b/app/view/grid/Grid.js
@@ -20,6 +20,7 @@ Ext.define('CpsiMapview.view.grid.Grid', {
 
     plugins: ['gridfilters'],
     width: 1050,
+    height: 550,
 
     /**
      * The distance used to buffer a feature when the zoomToFeature


### PR DESCRIPTION
To avoid expanding off screen when paging is turned off.
Subclasses can override this. 