### PR TITLE
Remove fixed grids height and use a flex fit layout instead

### DIFF
--- a/app/view/grid/Grid.js
+++ b/app/view/grid/Grid.js
@@ -20,7 +20,6 @@ Ext.define('CpsiMapview.view.grid.Grid', {
 
     plugins: ['gridfilters'],
     width: 1050,
-    height: 550,
 
     /**
      * The distance used to buffer a feature when the zoomToFeature

--- a/app/view/menuitem/LayerGrid.js
+++ b/app/view/menuitem/LayerGrid.js
@@ -78,6 +78,7 @@ Ext.define('CpsiMapview.view.menuitem.LayerGrid', {
 
             Ext.apply(windowConfig, {
                 title: title,
+                layout: 'fit',
                 items: [{
                     xtype: gridXType
                 }],


### PR DESCRIPTION
When creating new grid windows use a flex layout to fill all available space