### PR TITLE
Apply tree structure after all layers are loaded. See #241

### DIFF
--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -98,7 +98,7 @@ Ext.define('CpsiMapview.view.LayerTree', {
 
     /**
      * Guesses the mapcomponent and assigns the appropriate layers store, if one
-     * could be guessed. 
+     * could be guessed.
      */
     autoConnectToMap: function () {
 


### PR DESCRIPTION
This pull request waits until the map layers have been added to the map before applying the tree structure. 

This allows the structure to work correctly in older version of the Edge browser. It does however rely on the `cmv-init-layersadded` event being called and so does not allow a local configuration. 

In addition this pull request renames "Root" to "root" as this name is used [here in the TreeColumnStyleSwitcher](https://github.com/compassinformatics/cpsi-mapview/blob/7cb03dbf484582e10f9ee5cd718e56b2862c8bbe/app/plugin/TreeColumnStyleSwitcher.js#L145) and is case-sensitive. 