### PR TITLE
Add Model-Feature Linking Classes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,8 @@ module.exports = {
         "no-trailing-spaces": "error",
         "indent": [
             "error",
-            4
+            4,
+            { "SwitchCase": 1 }
         ],
         //"linebreak-style": [
         //    "error",

--- a/app/controller/panel/TimeSlider.js
+++ b/app/controller/panel/TimeSlider.js
@@ -155,11 +155,11 @@ Ext.define('CpsiMapview.controller.panel.TimeSlider', {
         var timeIncrementUnit = view.timeIncrementUnit || 'year';
         var dateFormat = '';
         switch (timeIncrementUnit) {
-        case 'month':
-            dateFormat = 'm/Y';
-            break;
-        default:
-            dateFormat = 'Y';
+            case 'month':
+                dateFormat = 'm/Y';
+                break;
+            default:
+                dateFormat = 'Y';
         }
         return Ext.Date.format(
             me.getDateForSliderValue(sliderValue),
@@ -178,12 +178,12 @@ Ext.define('CpsiMapview.controller.panel.TimeSlider', {
         var view = me.getView();
         var timeIncrementUnit = view.timeIncrementUnit || 'year';
         switch (timeIncrementUnit) {
-        case 'month':
-            var month = sliderValue % 12;
-            var year = (sliderValue - month) / 12;
-            return new Date(1900 + year, month, 1);
-        default:
-            return new Date(1900 + sliderValue, 0, 1);
+            case 'month':
+                var month = sliderValue % 12;
+                var year = (sliderValue - month) / 12;
+                return new Date(1900 + year, month, 1);
+            default:
+                return new Date(1900 + sliderValue, 0, 1);
         }
     },
 
@@ -208,16 +208,16 @@ Ext.define('CpsiMapview.controller.panel.TimeSlider', {
         var minValue = 0;
         var maxValue = 100;
         switch (timeIncrementUnit) {
-        case 'month':
-            minValue = Ext.Date.getFirstDateOfMonth(startDate).getYear()
+            case 'month':
+                minValue = Ext.Date.getFirstDateOfMonth(startDate).getYear()
                     * 12 + Ext.Date.getFirstDateOfMonth(startDate).getMonth();
-            maxValue = Ext.Date.getLastDateOfMonth(endDate).getYear()
+                maxValue = Ext.Date.getLastDateOfMonth(endDate).getYear()
                     * 12 + Ext.Date.getLastDateOfMonth(endDate).getMonth();
-            break;
-        default:
-            minValue = startDate.getYear();
-            maxValue = endDate.getYear();
-            break;
+                break;
+            default:
+                minValue = startDate.getYear();
+                maxValue = endDate.getYear();
+                break;
         }
 
         // use passed starting date if selected date is not set
@@ -228,17 +228,17 @@ Ext.define('CpsiMapview.controller.panel.TimeSlider', {
         var rangeLower = 50;
         var rangeUpper = 50;
         switch (timeIncrementUnit) {
-        case 'month':
-            var value = Ext.Date.getFirstDateOfMonth(selDate).getYear()
+            case 'month':
+                var value = Ext.Date.getFirstDateOfMonth(selDate).getYear()
                     * 12 + Ext.Date.getFirstDateOfMonth(selDate).getMonth();
-            rangeLower = value;
-            rangeUpper = isRange ? value + 1 : maxValue;
-            break;
-        default:
-            value = selDate.getYear();
-            rangeLower = value;
-            rangeUpper = isRange ? value + 1 : maxValue;
-            break;
+                rangeLower = value;
+                rangeUpper = isRange ? value + 1 : maxValue;
+                break;
+            default:
+                value = selDate.getYear();
+                rangeLower = value;
+                rangeUpper = isRange ? value + 1 : maxValue;
+                break;
         }
 
         return {

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -30,59 +30,59 @@ Ext.define('CpsiMapview.factory.Layer', {
         var mapLayer;
 
         switch (layerType) {
-        case 'wms':
-            mapLayer = LayerFactory.createWms(layerConf);
-            break;
-        case 'wfs':
-            mapLayer = LayerFactory.createWfs(layerConf);
-            break;
-        case 'xyz':
-            mapLayer = LayerFactory.createXyz(layerConf);
-            break;
-        case 'osm':
-            mapLayer = LayerFactory.createOsm(layerConf);
-            break;
-        case 'empty':
-            mapLayer = LayerFactory.createEmptyLayer(layerConf);
-            break;
-        case 'bing_aerial':
-            mapLayer = LayerFactory.createBing(layerConf, 'Aerial');
-            break;
-        case 'google_roadmap':
-            mapLayer = LayerFactory.createGoogle(layerConf, 'google.maps.MapTypeId.ROADMAP');
-            break;
-        case 'google_terrain':
-            mapLayer = LayerFactory.createGoogle(layerConf, 'google.maps.MapTypeId.TERRAIN');
-            break;
-        case 'google_hybrid':
-            mapLayer = LayerFactory.createGoogle(layerConf, 'google.maps.MapTypeId.HYBRID');
-            break;
-        case 'google_satellite':
-            mapLayer = LayerFactory.createGoogle(layerConf, 'google.maps.MapTypeId.SATELLITE');
-            break;
-        case 'nasa':
-            mapLayer = LayerFactory.createNasa(layerConf);
-            break;
-        case 'os':
-            mapLayer = LayerFactory.createOs(layerConf);
-            break;
-        case 'arcgiscache':
-            mapLayer = LayerFactory.createArcGisCache(layerConf);
-            break;
-        case 'arcgisrest':
-            mapLayer = LayerFactory.createArcGisRest(layerConf);
-            break;
-        case 'switchlayer':
-            mapLayer = LayerFactory.createSwitchLayer(layerConf);
-            break;
-        case 'vt':
-            mapLayer = LayerFactory.createVectorTilesLayer(layerConf);
-            break;
-        case 'vtwms':
-            mapLayer = LayerFactory.createVectorTilesWmsLayer(layerConf);
-            break;
-        default:
-            Ext.log.warn('Layer type not known');
+            case 'wms':
+                mapLayer = LayerFactory.createWms(layerConf);
+                break;
+            case 'wfs':
+                mapLayer = LayerFactory.createWfs(layerConf);
+                break;
+            case 'xyz':
+                mapLayer = LayerFactory.createXyz(layerConf);
+                break;
+            case 'osm':
+                mapLayer = LayerFactory.createOsm(layerConf);
+                break;
+            case 'empty':
+                mapLayer = LayerFactory.createEmptyLayer(layerConf);
+                break;
+            case 'bing_aerial':
+                mapLayer = LayerFactory.createBing(layerConf, 'Aerial');
+                break;
+            case 'google_roadmap':
+                mapLayer = LayerFactory.createGoogle(layerConf, 'google.maps.MapTypeId.ROADMAP');
+                break;
+            case 'google_terrain':
+                mapLayer = LayerFactory.createGoogle(layerConf, 'google.maps.MapTypeId.TERRAIN');
+                break;
+            case 'google_hybrid':
+                mapLayer = LayerFactory.createGoogle(layerConf, 'google.maps.MapTypeId.HYBRID');
+                break;
+            case 'google_satellite':
+                mapLayer = LayerFactory.createGoogle(layerConf, 'google.maps.MapTypeId.SATELLITE');
+                break;
+            case 'nasa':
+                mapLayer = LayerFactory.createNasa(layerConf);
+                break;
+            case 'os':
+                mapLayer = LayerFactory.createOs(layerConf);
+                break;
+            case 'arcgiscache':
+                mapLayer = LayerFactory.createArcGisCache(layerConf);
+                break;
+            case 'arcgisrest':
+                mapLayer = LayerFactory.createArcGisRest(layerConf);
+                break;
+            case 'switchlayer':
+                mapLayer = LayerFactory.createSwitchLayer(layerConf);
+                break;
+            case 'vt':
+                mapLayer = LayerFactory.createVectorTilesLayer(layerConf);
+                break;
+            case 'vtwms':
+                mapLayer = LayerFactory.createVectorTilesWmsLayer(layerConf);
+                break;
+            default:
+                Ext.log.warn('Layer type not known');
             //do nothing, and return empty layer
         }
 

--- a/app/field/Feature.js
+++ b/app/field/Feature.js
@@ -1,0 +1,33 @@
+/**
+* A custom field for linking OpenLayers features
+* The field handles loading to an associated store.
+*/
+Ext.define('CpsiMapview.field.Feature', {
+    extend: 'Ext.data.field.Field',
+
+    alias: 'data.field.feature',
+
+    // ensure the data is sent to the server
+    // https://docs.sencha.com/extjs/6.7.0/modern/Ext.data.field.Field.html#cfg-persist
+    persist: true,
+
+    allowNull: true,
+
+    /**
+     * Load GeoJSON features into the field's feature store
+     */
+    convert: function (data, rec) {
+
+        var me = this;
+        var features = null;
+        var featureStore = rec.featureStores ? rec.featureStores[me.name] : null;
+
+        if (featureStore && data) {
+            features = (new ol.format.GeoJSON().readFeatures(data));
+            featureStore.layer.getSource().addFeatures(features);
+        }
+
+        return data;
+    }
+
+});

--- a/app/field/Line.js
+++ b/app/field/Line.js
@@ -1,0 +1,126 @@
+/**
+* A custom field for storing line features
+* The field handles loading and serializing features to and from an associated store.
+* The linked map layer can have styling properties customized through field properties.
+*/
+Ext.define('CpsiMapview.field.Line', {
+    extend: 'CpsiMapview.field.Feature',
+
+    alias: 'data.field.line',
+
+    /**
+     * Colors and sizes for the default point and line styles
+     */
+    styleDefaults: {
+        lineColor: '#FFFC17',
+        pointColor: '#E9AB17',
+        radius: 5,
+        width: 4
+    },
+
+    /**
+     * Colors and sizes for the point and line selection styles
+     */
+    selectStyleDefaults: {
+        lineColor: 'red',
+        pointColor: 'red'
+    },
+
+    /**
+     * Filter to apply to the feature store
+     */
+    defaultFeatureFilter: function (rec) {
+        // only display LineString and MultiLineString in an associated feature grid
+        var geomType = rec.getFeature().getGeometry().getType();
+        return (Ext.Array.contains(['LineString', 'MultiLineString'], geomType));
+    },
+
+    /**
+     * Return simplified feature properties rather than full GeoJSON
+     */
+    serialize: function (v, rec) {
+
+        var me = this;
+        var featureStore = rec.featureStores ? rec.featureStores[me.name] : null;
+        return me.getFeatureAttributes(featureStore);
+    },
+
+    /**
+     * Create an array containing feature properties
+     */
+    getFeatureAttributes: function (featureStore) {
+
+        var feats = featureStore.getRange();
+        var recs = [];
+
+        Ext.each(feats, function (s) {
+            recs.push(s.data);
+        });
+
+        return recs;
+    },
+
+    /**
+    * Create a new ol style for showing points and lines
+    *
+    * @return {ol.style.Style} The new style
+    */
+    createPointLineStyle: function (lineColor, pointColor) {
+
+        var me = this;
+
+        var style = new ol.style.Style({
+            image: new ol.style.Circle({
+                radius: me.styleDefaults.radius,
+                fill: new ol.style.Fill({
+                    color: pointColor
+                }),
+                stroke: new ol.style.Stroke({
+                    color: lineColor
+                })
+            }),
+            width: me.styleDefaults.width,
+            stroke: new ol.style.Stroke({
+                color: lineColor
+            }),
+            fill: new ol.style.Fill({
+                color: pointColor
+            }),
+        });
+
+        return style;
+    },
+
+    /**
+    * Create a new ol style
+    *
+    * @return {ol.style.Style} The new style
+    */
+    createStyle: function () {
+
+        var me = this;
+        var cfg = me.featureStoreConfig;
+
+        var lineColor = cfg.lineColor || me.styleDefaults.lineColor;
+        var pointColor = cfg.pointColor || me.styleDefaults.pointColor;
+
+        return me.createPointLineStyle(lineColor, pointColor);
+    },
+
+    /**
+    * Create a new ol style for showing points and lines when selected
+    *
+    * @return {ol.style.Style} The new style
+    */
+    createSelectStyle: function () {
+
+        var me = this;
+        var cfg = me.featureStoreConfig;
+
+        var lineColor = cfg.selectLineColor || me.selectStyleDefaults.lineColor;
+        var pointColor = cfg.selectPointColor || me.selectStyleDefaults.pointColor;
+
+        return me.createPointLineStyle(lineColor, pointColor);
+
+    }
+});

--- a/app/field/Polygon.js
+++ b/app/field/Polygon.js
@@ -1,0 +1,85 @@
+/**
+* A custom field for storing polygon features.
+* The field handles loading and serializing features to and from an associated store.
+* The linked map layer can have styling properties customized through field properties.
+*/
+Ext.define('CpsiMapview.field.Polygon', {
+    extend: 'CpsiMapview.field.Feature',
+
+    requires: [
+        'BasiGX.util.Map'
+    ],
+
+    alias: 'data.field.polygon',
+
+    /**
+     * Return a the geometry of a single polygon feature
+     */
+    serialize: function (v, rec) {
+        var me = this;
+        var featureStore = rec.featureStores[me.name];
+        return this.getPolygonGeometry(featureStore.layer);
+    },
+
+    /**
+     * Return a single polygon associated with the layer as a GeoJSON object
+     * @param {any} rec
+     */
+    getPolygonGeometry: function (polygonLayer) {
+
+        var feats, gj = null;
+
+        feats = polygonLayer.getSource().getFeatures();
+        if (feats.length === 1) {
+            var writer = new ol.format.GeoJSON();
+            var geom = feats[0].getGeometry();
+            if (geom.getType() === 'Circle') {
+                // ol.geom.Circle is not supported
+                // in GeoJSON https://stackoverflow.com/questions/16942697/geojson-circles-supported-or-not
+                // convert to a polygon first
+                geom = ol.geom.Polygon.fromCircle(geom);
+            }
+            gj = writer.writeGeometryObject(geom);
+        }
+
+        return gj;
+    },
+
+    /**
+    * Create a new ol style
+    *
+    * @return {ol.style.Style} The new style
+    */
+    createStyle: function () {
+
+        var fill = new ol.style.Fill({
+            color: 'rgba(255,255,255,0.4)'
+        });
+
+        var stroke = new ol.style.Stroke({
+            color: '#3399CC',
+            width: 1.25
+        });
+
+        var style = new ol.style.Style({
+            image: new ol.style.Circle({
+                fill: fill,
+                stroke: stroke,
+                radius: 5
+            }),
+            fill: fill,
+            stroke: stroke
+        });
+
+        return style;
+    },
+
+    /**
+    * Create a new ol style for showing polygons when selected
+    *
+    * @return {ol.style.Style} The new style
+    */
+    createSelectStyle: function () {
+        return null;
+    }
+});

--- a/app/model/FeatureEventsMixin.js
+++ b/app/model/FeatureEventsMixin.js
@@ -1,0 +1,78 @@
+/**
+ * A model mixin that keeps map layers in sync with related models.
+ * Any associated WMS layer or WFS layer that contains the updated
+ * feature is automatically refreshed.
+ * In addition the model is saved a `modelsaved` event is fired to allow for custom hooks.
+ *
+ * Example configuration settings on a model:
+ *
+ *  syncLayerKeys: ['LAYER1_KEY_WMS', 'LAYER2_KEY_WMS']  // associated WMS layers
+ *  syncStoreIds: ['GridStore1', 'GridStore2'] // associated grid store aliases
+ *
+ */
+Ext.define('CpsiMapview.model.FeatureEventsMixin', {
+    requires: [
+        'Ext.data.proxy.Rest', // without this the production apps don't work
+        'CpsiMapview.util.Layer'
+    ],
+    extend: 'Ext.Mixin',
+
+    mixins: {
+        observable: 'Ext.util.Observable'
+    },
+
+    mixinConfig: {
+        on: {
+            constructor: function () {
+                // Ext.mixin.Observable requires the constructor to be called
+                // https://docs.sencha.com/extjs/6.7.0/classic/Ext.mixin.Observable.html
+                this.mixins.observable.constructor.call(this);
+            }
+        },
+        before: {
+            save: 'onSave'
+        }
+    },
+
+    /**
+     * When the model is saved refresh any layers that are linked to the model
+     * Note this will also be fired when a model is successfully deleted
+     * */
+    onModelSaved: function () {
+        var me = this;
+        var layerUtil = CpsiMapview.util.Layer;
+
+        // update associated layers
+        Ext.each(me.syncLayerKeys, function (k) {
+            var layers = BasiGX.util.Layer.getLayersBy('layerKey', k);
+            if (layers) {
+                var layer = layers[0];
+                layerUtil.layerRefresh(layer);
+            }
+        });
+
+        // update associated WFS stores (grid stores)
+        Ext.each(me.syncStoreIds, function (k) {
+            var store = Ext.data.StoreManager.lookup(k);
+            if (store) {
+                store.reload();
+            }
+        });
+
+        me.fireEvent('modelsaved');
+    },
+
+    /**
+     * Add the mixin `onModelSaved` function to any save success callbacks
+     * */
+    onSave: function (options) {
+        var me = this;
+
+        if (options.success) {
+            // last parameter sets the scope for the additional function
+            options.success = Ext.Function.createSequence(options.success, me.onModelSaved, me);
+        } else {
+            options.success = me.onModelSaved;
+        }
+    }
+});

--- a/app/model/FeatureStoreMixin.js
+++ b/app/model/FeatureStoreMixin.js
@@ -1,0 +1,149 @@
+/**
+* A model mixin to create feature stores for feature related fields
+*/
+Ext.define('CpsiMapview.model.FeatureStoreMixin', {
+    extend: 'Ext.Mixin',
+    requires: [
+        'GeoExt.data.store.Features',
+        'BasiGX.util.Map'
+    ],
+    mixinConfig: {
+        after: {
+            constructor: 'createFeatureStores'
+        },
+        before: {
+            destroy: 'destroyFeatureStores'
+        }
+    },
+
+    /**
+    Zoom to the extent of all features associated with the model
+    */
+    getRecordBounds: function () {
+
+        var bounds, layerExtent;
+        var me = this;
+
+        if (me.featureStores) {
+            Ext.Object.each(me.featureStores, function (key, fs) {
+
+                if (fs.layer.getSource().getFeatures().length > 0) {
+                    layerExtent = fs.layer.getSource().getExtent();
+
+                    if (bounds) {
+                        ol.extent.extend(bounds, layerExtent);
+                    }
+                    else {
+                        bounds = layerExtent;
+                    }
+                }
+            });
+        }
+
+        return bounds;
+    },
+
+    /**
+     * Create a new feature store
+     *
+     * @param {Ext.data.Model} model A model to use when loading features
+     * @return {GeoExt.data.store.Features} The new feature store
+     */
+    createFeatureStore: function (field) {
+
+        var me = this;
+
+        var cfg = field.featureStoreConfig || {};
+        var featModel = cfg.model || 'GeoExt.data.model.Feature';
+
+
+        var style = field.createStyle();
+        var selectStyle = field.createSelectStyle();
+
+        var vectorLayer = new ol.layer.Vector({
+            displayInLayerSwitcher: false,
+            source: new ol.source.Vector(),
+            style: style,
+            selectStyle: selectStyle // note selectStyle is a custom property and not a ol.layer.Vector option
+        });
+
+        // add a vector layer that will be linked to the store
+        var mapCmp = BasiGX.util.Map.getMapComponent();
+
+        if (mapCmp) {
+            mapCmp.getMap().addLayer(vectorLayer);
+        }
+
+        var filters = [];
+
+        if (field.defaultFeatureFilter) {
+            filters.push(field.defaultFeatureFilter);
+        }
+
+        var featStore = Ext.create('GeoExt.data.store.Features', {
+            model: featModel,
+            layer: vectorLayer,
+            filters: filters,
+            // ensure that any changes to layers are persisted back to the model
+            // to trigger validation
+            listeners: {
+                add: function (store, features) {
+                    me.set(field.name, features, { convert: false });
+                },
+                clear: function () {
+                    me.set(field.name, null, { convert: false });
+                },
+                remove: function (store) {
+                    var features = store.getRange(); // get all remaining features
+                    me.set(field.name, features, { convert: false });
+                }
+            }
+        });
+        return featStore;
+    },
+
+    /**
+     * Clean up all the layer stores and layers created by the mixin
+     **/
+    destroyFeatureStores: function () {
+        var me = this;
+
+        if (me.featureStores) {
+            Ext.Object.each(me.featureStores, function (key, fs) {
+
+                var mapCmp = BasiGX.util.Map.getMapComponent();
+
+                if (mapCmp) {
+                    mapCmp.getMap().removeLayer(fs.layer);
+                }
+
+                fs.destroy();
+            });
+        }
+    },
+
+    /**
+     * For any feature based fields create an associated feature store
+     **/
+    createFeatureStores: function () {
+        var me = this;
+
+        if (!me.featureStores) {
+            me.featureStores = {};
+        }
+
+        Ext.each(me.getFields(), function (f) {
+
+            switch (true) {
+                case (f.type === 'line' || f.superclass.type == 'line'):
+                case (f.type === 'polygon' || f.superclass.type == 'polygon'):
+                    me.featureStores[f.name] = me.createFeatureStore(f);
+                    break;
+                default:
+                    break;
+            }
+
+        });
+    }
+
+});


### PR DESCRIPTION
This pull request contains several classes that provide links between ExtJS data models and GeoExt feature stores / OpenLayers layers. 

Several application models have fields which store references to collections of features. For example an "edges" property could store a collection of line features relevant to a road survey. 
These fields are populated by JSON, and using the new `CpsiMapview.model.FeatureStoreMixin` automatically have a feature store created for them, a layer added to the map, and the model-store-layer kept in sync. 

Custom fields are also available to serialize OL features back to either simplified JSON arrays or GeoJSON to send back to the server as part of a PUT request. The fields also allow customisation of map layer styling using field properties. 

Finally the `CpsiMapview.model.FeatureEventsMixin` allows layers to be associated with a model, so that they are automatically refreshed when a model is updated. 