### PR TITLE
Use initViewModel to avoid getViewModel null errors

### DIFF
--- a/app/controller/form/Login.js
+++ b/app/controller/form/Login.js
@@ -153,7 +153,7 @@ Ext.define('CpsiMapview.controller.form.Login', {
 
     },
 
-    init: function () {
+    initViewModel: function () {
         this.tryAutomaticLogin();
     }
 

--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -488,6 +488,10 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
     */
     initViewModel: function (viewModel) {
 
+        var me = this;
+
+        me.addChildModelListener();
+
         var gridStoreType = viewModel.get('gridStoreType');
         var layerName = viewModel.get('gridLayerName');
 
@@ -513,10 +517,5 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
         };
 
         viewModel.setStores(stores);
-    },
-
-    init: function () {
-        var me = this;
-        me.addChildModelListener();
     }
 });


### PR DESCRIPTION
When using init sometimes the this.getViewModel() returned `null`. 