### PR TITLE
Fix disappearing style radio buttons

### DIFF
--- a/app/plugin/TreeColumnStyleSwitcher.js
+++ b/app/plugin/TreeColumnStyleSwitcher.js
@@ -105,7 +105,7 @@ Ext.define('CpsiMapview.plugin.TreeColumnStyleSwitcher', {
 
             // ensure the radio groups are re-rendered every time the tree view
             // changes (e.g.) layer visibility is changed
-            layerTree.getView().on('itemupdate', function () {
+            layerTree.getView().on('refresh', function () {
                 Ext.defer(function () {
                     me.cleanupAllRadioGroups();
                     me.renderRadioGroups();


### PR DESCRIPTION
Use refresh rather than itemupdate as the radiobuttons created by CpsiMapview.plugin.TreeColumnStyleSwitcher were disappearing when layers were shown or hidden. 

To recreate the issue - a layer was hidden using `layer.setVisible(show);`
This triggered a call to `doRefreshView` for the treeview. However at the end `view.refreshNeeded === false` and the `itemupdate` event wasn't triggered. Swtiching to the `refresh` event fixed the issue. 