### PR TITLE
Fix login bug with expired token and destroyed viewmodel

### DIFF
--- a/app/controller/form/Login.js
+++ b/app/controller/form/Login.js
@@ -34,6 +34,8 @@ Ext.define('CpsiMapview.controller.form.Login', {
             jsonData[tokenName] = token;
             jsonData = Ext.JSON.encode(jsonData);
             me.callLoginService(jsonData, serviceUrl, false);
+        } else {
+            me.getView().show();
         }
     },
 
@@ -95,7 +97,7 @@ Ext.define('CpsiMapview.controller.form.Login', {
         var me = this;
         var view = me.getView();
 
-        showMask = showMask && view && view.rendered;
+        showMask = showMask && view.rendered;
 
         if (showMask) {
             view.mask('Logging in');
@@ -115,9 +117,7 @@ Ext.define('CpsiMapview.controller.form.Login', {
 
                 if (response.success === true) {
                     me.login(response);
-                    if (view) {
-                        view.destroy();
-                    }
+                    view.close();
                 }
                 else {
                     //username / password login failure
@@ -125,6 +125,7 @@ Ext.define('CpsiMapview.controller.form.Login', {
                     if (showMask) {
                         view.unmask();
                     }
+                    view.show();
                 }
             },
             failure: function (result) {
@@ -133,6 +134,7 @@ Ext.define('CpsiMapview.controller.form.Login', {
                 if (showMask) {
                     view.unmask();
                 }
+                view.show();
             }
 
         });

--- a/app/util/ApplicationMixin.js
+++ b/app/util/ApplicationMixin.js
@@ -9,6 +9,8 @@ Ext.define('CpsiMapview.util.ApplicationMixin', {
     // see https://docs.sencha.com/extjs/6.7.0/classic/Ext.app.Application.html#cfg-quickTips
     quickTips: false,
 
+    loginWindow: null,
+
     // when the platform is matched any properties are placed on the class
     platformConfig: {
         desktop: {
@@ -137,16 +139,26 @@ Ext.define('CpsiMapview.util.ApplicationMixin', {
     },
 
     /**
-     * Open the login form when the application is opened
+     * Open the login form when the application is opened. Attempt
+     * to login automatically if the user already has a cookie and token.
+     * If the form has already been created then simply show it.
      * */
     doLogin: function () {
-        Ext.create('CpsiMapview.view.form.Login', {
-            viewModel: {
-                tokenName: this.tokenName,
-                serviceUrl: '/WebServices/authorization/authenticate',
-                validateUrl: '/WebServices/authorization/validateToken'
-            }
-        });
+
+        var me = this;
+
+        if (!me.loginWindow) {
+            me.loginWindow = Ext.create('CpsiMapview.view.form.Login', {
+                viewModel: {
+                    tokenName: this.tokenName,
+                    serviceUrl: '/WebServices/authorization/authenticate',
+                    validateUrl: '/WebServices/authorization/validateToken'
+                }
+            });
+            me.loginWindow.getController().tryAutomaticLogin();
+        } else {
+            me.loginWindow.show();
+        }
     },
 
     /**

--- a/app/view/form/Login.js
+++ b/app/view/form/Login.js
@@ -16,7 +16,7 @@ Ext.define('CpsiMapview.view.form.Login', {
     bodyPadding: 10,
     title: 'Login Window',
     closable: false,
-    autoShow: true,
+    closeAction: 'hide',
     modal: true,
 
     items: {


### PR DESCRIPTION
Fix use case when automatic login destroys view and then tries to show automatically. This caused various viewmodel calls when the form had been destroyed (causing JS errors). 

Now the ApplicationMixin keeps a reference to the form and shows it when necessary. 