### PR TITLE
Set CpsiMapview.field.Feature to use an array of OL features

### DIFF
--- a/app/field/Feature.js
+++ b/app/field/Feature.js
@@ -1,6 +1,11 @@
 /**
 * A custom field for linking OpenLayers features
 * The field handles loading to an associated store.
+* The field itself will be set to an array of OpenLayers features.
+* This is set both in the convert function below, and also by
+* CpsiMapview.model.FeatureStoreMixin with the `add`, `clear`, and `remove`
+* listeners on the FeatureStore. This triggers any field validation which may be
+* set.
 */
 Ext.define('CpsiMapview.field.Feature', {
     extend: 'Ext.data.field.Field',
@@ -17,7 +22,6 @@ Ext.define('CpsiMapview.field.Feature', {
      * Load GeoJSON features into the field's feature store
      */
     convert: function (data, rec) {
-
         var me = this;
         var features = null;
         var featureStore = rec.featureStores ? rec.featureStores[me.name] : null;
@@ -27,7 +31,7 @@ Ext.define('CpsiMapview.field.Feature', {
             featureStore.layer.getSource().addFeatures(features);
         }
 
-        return data;
+        return features;
     }
 
 });


### PR DESCRIPTION
Previously a GeoJSON object was saved by the reader, and the OL feature arrays when using the network tools. This led to issues with field validators checking different object types. This pull request ensures it will always be an array of OL features or null. 