### PR TITLE
Add new util class to handle WMS filter creation

### DIFF
--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -10,6 +10,7 @@ Ext.define('CpsiMapview.factory.Layer', {
         'CpsiMapview.util.Legend',
         'CpsiMapview.view.main.Map',
         'CpsiMapview.view.layer.ToolTip',
+        'CpsiMapview.util.WmsFilter',
         'BasiGX.util.Layer',
         'BasiGX.util.Map',
         'BasiGX.util.WFS',
@@ -949,16 +950,18 @@ Ext.define('CpsiMapview.factory.Layer', {
                         activeStyle += ',' + labelClassName;
                     }
 
-                    var wmsFilter = '';
-
                     if (filters && filters.length > 0) {
-                        wmsFilter = GeoExt.util.OGCFilter.getOgcFilterFromExtJsFilter(filters, 'wms', 'and', '1.1.0');
+                        newLayerSource.getParams().FILTER = GeoExt.util.OGCFilter.getOgcFilterFromExtJsFilter(filters, 'wms', 'and', '1.1.0');
                     }
+
+                    // ensure there is a filter for every layer listed in the WMS request (required by MapServer)
+                    var wmsFilterUtil = CpsiMapview.util.WmsFilter;
+                    var wmsFilterString = wmsFilterUtil.getWmsFilterString(newLayer);
 
                     // apply new style parameter and reload layer
                     var newParams = {
                         STYLES: activeStyle,
-                        FILTER: wmsFilter,
+                        FILTER: wmsFilterString,
                         cacheBuster: Math.random()
                     };
 

--- a/app/util/WmsFilter.js
+++ b/app/util/WmsFilter.js
@@ -1,0 +1,60 @@
+/**
+ * Util class for working with WMS filters.
+ * These are a vendor-specific parameter for WMS supported by MapServer
+ * under https://mapserver.org/development/rfc/ms-rfc-118.html
+ * It also relies on https://github.com/MapServer/MapServer/pull/6139 to
+ * correctly implement duplicated layer names in a WMS request with filters
+ *
+ * @class CpsiMapview.util.WmsFilter
+ */
+Ext.define('CpsiMapview.util.WmsFilter', {
+    alternateClassName: 'WmsFilterUtil',
+
+    singleton: true,
+
+    /**
+    * Executed when this menu item is clicked.
+    * Forces redraw of the connected layer.
+    */
+    getWmsFilterString: function (layer) {
+
+        var wmsSource = layer.getSource();
+        var wmsParams = wmsSource.getParams();
+
+        var layers = wmsParams.LAYERS || [];
+        var originalFilters = wmsParams.FILTER || [];
+
+        var layerList = Ext.isArray(layers) ? layers : layers.split(',');
+
+        // split the list based on filters in brackets e.g. (filter1)(filter2)
+        originalFilters = Ext.isArray(originalFilters) ? originalFilters : originalFilters.split(/(\(.*?\))/).filter(Boolean);
+
+        // every layer item requires a filter - duplicate the first filter
+        // for the layer labels
+        var firstFilter;
+        var finalFilters = [];
+
+        if (originalFilters.length > 0) {
+            firstFilter = originalFilters[0];
+            layerList.forEach(function () {
+                finalFilters.push(firstFilter);
+            });
+        }
+
+        // number of filters must match number of layers for a MapServer WMS request
+        if (finalFilters.length > 0) {
+            Ext.Assert.truthy(finalFilters.length === layerList.length);
+        }
+
+        // currently we only allow a single layer and label layer - max 2
+        Ext.Assert.truthy(layerList.length <= 2);
+        Ext.Assert.truthy(finalFilters.length <= 2);
+
+        var wmsFilterString = finalFilters.map(function (filter) {
+            // wrap each filter in brackets
+            return '(' + filter + ')';
+        }).join('');
+
+        return wmsFilterString;
+    }
+});

--- a/app/view/menuitem/LayerLabels.js
+++ b/app/view/menuitem/LayerLabels.js
@@ -8,7 +8,8 @@ Ext.define('CpsiMapview.view.menuitem.LayerLabels', {
     extend: 'Ext.menu.CheckItem',
     xtype: 'cmv_menuitem_layerlabels',
     requires: [
-        'CpsiMapview.util.Legend'
+        'CpsiMapview.util.Legend',
+        'CpsiMapview.util.WmsFilter'
     ],
 
     /**
@@ -144,11 +145,14 @@ Ext.define('CpsiMapview.view.menuitem.LayerLabels', {
         var wmsSource = me.layer.getSource();
         var wmsParams = wmsSource.getParams();
 
+        // set the checkbox value, but no need to call onCheckChange again
+        var suppressEvents = true;
+
         if (wmsParams && !Ext.isEmpty(wmsParams.STYLES) &&
             wmsParams.STYLES.indexOf(me.labelClassName) !== -1) {
-            checkItem.setChecked(true);
+            checkItem.setChecked(true, suppressEvents);
         } else {
-            checkItem.setChecked(false);
+            checkItem.setChecked(false, suppressEvents);
         }
     },
 
@@ -246,9 +250,14 @@ Ext.define('CpsiMapview.view.menuitem.LayerLabels', {
             layer.set('labelsActive', false);
         }
 
+        // ensure there is a filter for every layer listed in the WMS request (required by MapServer)
+        var wmsFilterUtil = CpsiMapview.util.WmsFilter;
+        var wmsFilterString = wmsFilterUtil.getWmsFilterString(layer);
+
         var newParams = {
             LAYERS: layerList.join(','),
-            STYLES: stylesList.join(',')
+            STYLES: stylesList.join(','),
+            FILTER: wmsFilterString
         };
 
         wmsSource.updateParams(newParams);


### PR DESCRIPTION
Adds in  a util class for working with WMS filters. These are a vendor-specific parameter for WMS supported by MapServer under https://mapserver.org/development/rfc/ms-rfc-118.html
It also relies on https://github.com/MapServer/MapServer/pull/6139 to correctly implement duplicated layer names in a WMS request with filters.

The util class is used in all classes what create WMS requests - the layer labels plugin, the grid, and the layer factory for switch layers. 

A performance improvement is added to the layer labels to prevent duplicate WMS requests when the filter has not changed. 