### PR TITLE
Ensure model is not set to dirty when first loaded

### DIFF
--- a/app/field/Feature.js
+++ b/app/field/Feature.js
@@ -22,13 +22,19 @@ Ext.define('CpsiMapview.field.Feature', {
      * Load GeoJSON features into the field's feature store
      */
     convert: function (data, rec) {
+
         var me = this;
         var features = null;
         var featureStore = rec.featureStores ? rec.featureStores[me.name] : null;
 
         if (featureStore && data) {
             features = (new ol.format.GeoJSON().readFeatures(data));
+            // wrap an edit session around updating the field when first loaded
+            // to ensure the model is not marked as dirty
+            rec.beginEdit();
             featureStore.layer.getSource().addFeatures(features);
+            rec.endEdit();
+            Ext.Assert.falsey(rec.dirty);
         }
 
         return features;

--- a/app/model/FeatureStoreMixin.js
+++ b/app/model/FeatureStoreMixin.js
@@ -90,7 +90,10 @@ Ext.define('CpsiMapview.model.FeatureStoreMixin', {
             // to trigger validation
             listeners: {
                 add: function (store, features) {
-                    me.set(field.name, features, { convert: false });
+                    // if in an edit session then this is in initial load from CpsiMapview.field.Feature
+                    // so avoid setting the model to dirty when updating the field
+                    var dirty = !me.editing;
+                    me.set(field.name, features, { convert: false, dirty: dirty });
                 },
                 clear: function () {
                     me.set(field.name, null, { convert: false });


### PR DESCRIPTION
Add edit session when loading features from GeoJSON for the first time, prior to edits, and then check to see if the model is being edited to avoid setting the dirty flag. 