### PR TITLE
Cache legend images

### DIFF
--- a/app/plugin/BasicTreeColumnLegends.js
+++ b/app/plugin/BasicTreeColumnLegends.js
@@ -45,7 +45,6 @@ Ext.define('CpsiMapview.plugin.BasicTreeColumnLegends', {
             return isChecked && !(layer instanceof ol.layer.Group);
         },
         getLegendHtml: function(rec) {
-            var me = this;
             var staticMe = CpsiMapview.plugin.BasicTreeColumnLegends;
             var layer = rec.data;
             var layerKey = layer.get('layerKey');

--- a/app/plugin/BasicTreeColumnLegends.js
+++ b/app/plugin/BasicTreeColumnLegends.js
@@ -45,11 +45,14 @@ Ext.define('CpsiMapview.plugin.BasicTreeColumnLegends', {
             return isChecked && !(layer instanceof ol.layer.Group);
         },
         getLegendHtml: function(rec) {
+            var me = this;
             var staticMe = CpsiMapview.plugin.BasicTreeColumnLegends;
             var layer = rec.data;
+            var layerKey = layer.get('layerKey');
             var legendUrl = layer.get('legendUrl');
             var w = layer.get('legendWidth');
             var h = layer.get('legendHeight');
+
             if (!legendUrl) {
                 legendUrl = LegendUtil.createGetLegendGraphicUrl(layer);
             }
@@ -64,15 +67,28 @@ Ext.define('CpsiMapview.plugin.BasicTreeColumnLegends', {
                 w = h = 1;
             }
 
-            var ns = 'CpsiMapview.plugin.BasicTreeColumnLegends';
-            return '<img' +
-                ' class="cpsi-layer-legend"' +
-                ' src="' + legendUrl + '"' +
-                (w ? ' width="' + w + '"' : '') +
-                (h ? ' height="' + h + '"' : '') +
-                ' onerror="' + ns + '.checkCleanup(this);"' +
-                ' onload="' + ns + '.checkCleanup(this);"' +
-                '/>';
+            var legendDataUrl = CpsiMapview.view.LayerTree.legendImgLookup[layerKey];
+            if (!legendDataUrl) {
+                // load the legend image and cache it in an static lookup for later re-use
+                // without any server request
+
+                // check if there is an ongoing loading for the legend of this layer
+                // since getLegendHtml is executed several times for one refresh due to
+                // unkwon reasons
+                // Flag set / reset in LegendUtil.getLegendImgHtmlTpl
+                var isLoading = LegendUtil['legendLoading_' + layerKey];
+                if (isLoading) {
+                    // skip loading
+                    return LegendUtil.getLegendImgHtmlTpl(legendUrl, w, h);
+                }
+
+                LegendUtil.cacheLegendImgAsDataUrl(legendUrl, layerKey);
+
+            } else {
+                legendUrl = legendDataUrl;
+            }
+
+            return LegendUtil.getLegendImgHtmlTpl(legendUrl, w, h);
         }
     },
 

--- a/app/util/Html.js
+++ b/app/util/Html.js
@@ -1,0 +1,28 @@
+/**
+ * Static util class for HTML related operations.
+ */
+Ext.define('CpsiMapview.util.Html', {
+
+    statics: {
+        /**
+         * Add events to HTML elements in a cross browser compatible manor.
+         *
+         * Credits: http://stackoverflow.com/a/21140463
+         *
+         * @param {DOMElement} htmlElement The element to attach the event to.
+         * @param {String} eventName The name of the event to attach.
+         * @param {Function} eventFunction The handler for the `eventName` on
+         *     the passed `htmlElement`.
+         */
+        addEvent: function (htmlElement, eventName, eventFunction) {
+            if (htmlElement.addEventListener) { // Modern
+                htmlElement.addEventListener(eventName, eventFunction, false);
+            } else if (htmlElement.attachEvent) { // Internet Explorer
+                htmlElement.attachEvent('on' + eventName, eventFunction);
+            } else { // others
+                htmlElement['on' + eventName] = eventFunction;
+            }
+        }
+    }
+
+});

--- a/app/util/Legend.js
+++ b/app/util/Legend.js
@@ -181,7 +181,7 @@ Ext.define('CpsiMapview.util.Legend', {
      */
     cacheLegendImgAsDataUrl: function(legendUrl, layerKey) {
         var legendImage = new Image();
-        legendImage.crossOrigin="anonymous";
+        legendImage.crossOrigin = 'anonymous';
         CpsiMapview.util.Html.addEvent(
             legendImage, 'load', function() {
 

--- a/app/util/Legend.js
+++ b/app/util/Legend.js
@@ -6,7 +6,8 @@
 Ext.define('CpsiMapview.util.Legend', {
     alternateClassName: 'LegendUtil',
     requires: [
-        'BasiGX.util.Object'
+        'BasiGX.util.Object',
+        'CpsiMapview.util.Html'
     ],
 
     singleton: true,

--- a/app/util/Legend.js
+++ b/app/util/Legend.js
@@ -150,5 +150,63 @@ Ext.define('CpsiMapview.util.Legend', {
         var reducedLayerList = Ext.Array.unique(layerList);
 
         return reducedLayerList.join(',');
+    },
+
+    /**
+     * Returns a string-based HTML template for a legend image.
+     * Can be used within CpsiMapview.plugin.BasicTreeColumnLegend.
+     *
+     * @param {String} legendUrl The URL to the legend image
+     * @param {Number} width Width of the legend image
+     * @param {Number} height Height of the legend image
+     */
+    getLegendImgHtmlTpl: function (legendUrl, width, height) {
+        var ns = 'CpsiMapview.plugin.BasicTreeColumnLegends';
+        return '<img' +
+            ' class="cpsi-layer-legend"' +
+            ' src="' + legendUrl + '"' +
+            (width ? ' width="' + width + '"' : '') +
+            (height ? ' height="' + height + '"' : '') +
+            ' onerror="' + ns + '.checkCleanup(this);"' +
+            ' onload="' + ns + '.checkCleanup(this);"' +
+            '/>';
+    },
+
+    /**
+     * Caches the given legend image for a layer as dataURL in the
+     * static lookup of CpsiMapview.view.LayerTree.
+     *
+     * @param {String} legendUrl The URL to the legend image
+     * @param {String} layerKey The key / ID of the layer (used for storing in lookup)
+     */
+    cacheLegendImgAsDataUrl: function(legendUrl, layerKey) {
+        var legendImage = new Image();
+        legendImage.crossOrigin="anonymous";
+        CpsiMapview.util.Html.addEvent(
+            legendImage, 'load', function() {
+
+                // set width and height
+                var width = this.naturalWidth;
+                var height = this.naturalHeight;
+                // convert to base64 to avoid
+                // reloading of the image
+                var canvas = document.createElement('canvas');
+                canvas.width = width;
+                canvas.height = height;
+
+                var ctx = canvas.getContext('2d');
+                ctx.drawImage(this, 0, 0);
+                var legendDataUrl = canvas.toDataURL('image/png');
+
+                // store in cache for later reuse
+                CpsiMapview.view.LayerTree.legendImgLookup[layerKey] = legendDataUrl;
+
+                LegendUtil['legendLoading_' + layerKey] = false;
+            });
+
+        LegendUtil['legendLoading_' + layerKey] = true;
+
+        // set original legend url to trigger loading
+        legendImage.src = legendUrl;
     }
 });

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -17,6 +17,10 @@ Ext.define('CpsiMapview.view.LayerTree', {
         'CpsiMapview.plugin.TreeColumnStyleSwitcher'
     ],
 
+    statics: {
+        legendImgLookup: {}
+    },
+
     // So that instantiation works without errors, might be changed during
     // instantiation of the LayerTree.
     store: {},


### PR DESCRIPTION
This caches the legend images as dataURLs in an internal lookup, so the images only have to be queried at the first activation of the legend graphic in the tree.

@geographika Could you please give it a try in an application with a large amount of layers in order to test if this brings a performance boost for the layer tree? TIA! 

Relates to #274