### PR TITLE
Feature Attribute Grouping Plugin

### DIFF
--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -118,6 +118,8 @@ Ext.define('CpsiMapview.factory.Layer', {
             mapLayer.set('opacitySlider', allowOpacitySlider);
             // the xtype of any associated grid
             mapLayer.set('gridXType', layerConf.gridXType);
+            // attribute grouping config
+            mapLayer.set('grouping', layerConf.grouping);
         }
 
         return mapLayer;

--- a/app/plugin/FeatureAttributeGrouping.js
+++ b/app/plugin/FeatureAttributeGrouping.js
@@ -3,51 +3,116 @@ Ext.define('CpsiMapview.plugin.FeatureAttributeGrouping', {
     alias: 'plugin.cmv_feature_attribute_grouping',
     pluginId: 'cmv_feature_attribute_grouping',
 
+    /**
+     * can have the values 'move' or 'click'
+     */
+    startGroupingEvent: 'move',
+
+    /**
+     * can have the values 'move', 'click' or 'context'
+     * @property {string}
+     */
+    endGroupingEvent: 'move',
+
     initGrouping: function (mapCmp, olMap) {
         var me = this;
 
-        var groupingLayer = new ol.layer.Vector({
+        this.mapCmp = mapCmp;
+        this.olMap = olMap;
+
+        this.layer = new ol.layer.Vector({
             source: new ol.source.Vector(),
             map: olMap
         });
 
-        function clearSource() {
-            groupingLayer.getSource().clear();
+        var group = function (evt) {
+            me.startGrouping(evt);
+        };
+        var ungroup = function () {
+            me.endGrouping();
+        };
+
+        if (this.startGroupingEvent === 'move') {
+            mapCmp.on('pointerrest', group);
+        } else if (this.startGroupingEvent === 'click') {
+            olMap.on('singleclick', group);
         }
 
-        mapCmp.on('pointerrest', function (evt) {
-            olMap.forEachFeatureAtPixel(evt.pixel, function (feature, layer) {
-                var grouping = layer.get('grouping');
-
-                clearSource();
-                groupingLayer.setStyle(me.getStyle(grouping.color));
-
-                var features = layer.getSource().getFeatures()
-                    .filter(function (other) {
-                        return other.get(grouping.attribute) === feature.get(grouping.attribute);
-                    });
-
-                groupingLayer.getSource().addFeatures(features);
-            }, {
-                layerFilter: function (layer) {
-                    return layer.get('grouping');
-                }
+        if (this.endGroupingEvent === 'move') {
+            mapCmp.on('pointerrestout', ungroup);
+            olMap.on('pointermove', ungroup);
+        } else if (this.endGroupingEvent === 'click') {
+            olMap.on('singleclick', ungroup);
+        } else if (this.endGroupingEvent === 'context') {
+            olMap.getViewport().addEventListener('contextmenu', function (e) {
+                me.showContext(e);
             });
-        });
-
-        mapCmp.on('pointerrestout', clearSource);
-        olMap.on('pointermove', clearSource);
+        }
     },
 
-    getStyle: function (color) {
+    startGrouping: function (evt) {
+        var me = this;
+
+        this.olMap.forEachFeatureAtPixel(evt.pixel, function (feature, layer) {
+            me.endGrouping();
+
+            var grouping = layer.get('grouping');
+
+            me.layer.setStyle(me.getStyle(grouping));
+
+            var features = layer.getSource().getFeatures()
+                .filter(function (other) {
+                    return other.get(grouping.attribute) === feature.get(grouping.attribute);
+                });
+
+            me.layer.getSource().addFeatures(features);
+            me.groupingActive = true;
+        }, {
+            layerFilter: function (layer) {
+                return layer.get('grouping');
+            }
+        });
+    },
+
+    endGrouping: function () {
+        this.layer.getSource().clear();
+        this.groupingActive = false;
+    },
+
+    getStyle: function (grouping) {
         return new ol.style.Style({
             image: new ol.style.Circle({
                 radius: 10,
                 stroke: new ol.style.Stroke({
-                    color: color,
-                    width: 2
+                    color: grouping.strokeColor,
+                    width: grouping.strokeWidth
                 })
+            }),
+            stroke: new ol.style.Stroke({
+                color: grouping.strokeColor,
+                width: grouping.strokeWidth
             })
         });
+    },
+
+    showContext: function (e) {
+        var me = this;
+
+        if (this.groupingActive) {
+            e.preventDefault();
+
+            var menu = Ext.create('Ext.menu.Menu', {
+                width: 160,
+                plain: true,
+                renderTo: Ext.getBody(),
+                items: [{
+                    text: 'Clear attribute grouping',
+                    handler: function () {
+                        me.endGrouping();
+                    }
+                }]
+            });
+            menu.showAt(e.x, e.y);
+        }
     }
 });

--- a/app/plugin/FeatureAttributeGrouping.js
+++ b/app/plugin/FeatureAttributeGrouping.js
@@ -1,0 +1,53 @@
+Ext.define('CpsiMapview.plugin.FeatureAttributeGrouping', {
+    extend: 'Ext.plugin.Abstract',
+    alias: 'plugin.cmv_feature_attribute_grouping',
+    pluginId: 'cmv_feature_attribute_grouping',
+
+    initGrouping: function (mapCmp, olMap) {
+        var me = this;
+
+        var groupingLayer = new ol.layer.Vector({
+            source: new ol.source.Vector(),
+            map: olMap
+        });
+
+        function clearSource() {
+            groupingLayer.getSource().clear();
+        }
+
+        mapCmp.on('pointerrest', function (evt) {
+            olMap.forEachFeatureAtPixel(evt.pixel, function (feature, layer) {
+                var grouping = layer.get('grouping');
+
+                clearSource();
+                groupingLayer.setStyle(me.getStyle(grouping.color));
+
+                var features = layer.getSource().getFeatures()
+                    .filter(function (other) {
+                        return other.get(grouping.attribute) === feature.get(grouping.attribute);
+                    });
+
+                groupingLayer.getSource().addFeatures(features);
+            }, {
+                layerFilter: function (layer) {
+                    return layer.get('grouping');
+                }
+            });
+        });
+
+        mapCmp.on('pointerrestout', clearSource);
+        olMap.on('pointermove', clearSource);
+    },
+
+    getStyle: function (color) {
+        return new ol.style.Style({
+            image: new ol.style.Circle({
+                radius: 10,
+                stroke: new ol.style.Stroke({
+                    color: color,
+                    width: 2
+                })
+            })
+        });
+    }
+});

--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -15,7 +15,8 @@ Ext.define('CpsiMapview.view.main.Map', {
         'CpsiMapview.controller.panel.TimeSlider',
         'CpsiMapview.controller.MapController',
 
-        'BasiGX.util.Projection'
+        'BasiGX.util.Projection',
+        'CpsiMapview.plugin.FeatureAttributeGrouping'
     ],
 
     layout: 'fit',
@@ -56,6 +57,12 @@ Ext.define('CpsiMapview.view.main.Map', {
     }, {
         xtype: 'cmv_minimized_windows_toolbar'
     }],
+
+    plugins: [
+        {
+            ptype: 'cmv_feature_attribute_grouping'
+        }
+    ],
 
     /**
      * Enables a click handler on the map which fires an event
@@ -284,6 +291,9 @@ Ext.define('CpsiMapview.view.main.Map', {
         }
 
         Ext.GlobalEvents.fireEvent('cmv-mapready', me);
+
+        var grouping = this.getPlugin('cmv_feature_attribute_grouping');
+        grouping.initGrouping(me.mapCmp, me.olMap);
     },
 
     /**

--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -60,7 +60,9 @@ Ext.define('CpsiMapview.view.main.Map', {
 
     plugins: [
         {
-            ptype: 'cmv_feature_attribute_grouping'
+            ptype: 'cmv_feature_attribute_grouping',
+            startGroupingEvent: 'click',
+            endGroupingEvent: 'context'
         }
     ],
 


### PR DESCRIPTION
This is implemented reacting to the hover event and has only a very basic styling option (color).

This is maybe a good point to get some feedback @geographika

Configuration is done in the `default.json` in the layer object like this:

```
"grouping": {
    "attribute": "some-attribute",
    "color": "green"
}
```

Starting this grouping on hovering has two disadvantages, though:
* the highlight is removed when the mouse is moved or if implemented differently as soon as another feature is hovered.
* It can interfere with the get feature info (the picture below)

What styling options are needed apart from color?

It is to mention that this grouping would out of the box not work with clustered layers.

![Peek 2020-09-30 15-20](https://user-images.githubusercontent.com/8100558/94690804-d57d3c00-0330-11eb-8cff-43efb46f546f.gif)
![grouping+gfi](https://user-images.githubusercontent.com/8100558/94690818-d910c300-0330-11eb-8b73-5844ffda4a13.jpg)

