### PR TITLE
Move tree related configs to tree.json

### DIFF
--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -99,21 +99,12 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
                     node.addCls('cpsi-tree-node-baselayer');
                 }
 
-                // expand configured folders in this tree
-                if (data.leaf !== true && node.getOlLayer()) {
-                    var origFolderConf = node.getOlLayer().get('_origTreeConf');
-                    if (origFolderConf) {
-                        node.set('expanded', origFolderConf.expanded);
-                    }
+                // apply properties for tree node from corresponding tree-conf
+                if (node.getOlLayer()) {
+                    var origTreeNodeConf = node.getOlLayer().get('_origTreeConf') || {};
+                    me.applyTreeConfigsToNode(node, origTreeNodeConf);
                 }
 
-                // apply the text for tree node from corresponding tree-conf
-                if (node.getOlLayer()) {
-                    var origLeafConf = node.getOlLayer().get('_origTreeConf');
-                    if (origLeafConf) {
-                        node.set('text', origLeafConf.text);
-                    }
-                }
             });
 
             // inform subscribers that LayerTree is ready
@@ -250,6 +241,20 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
         olLayer.set('descTitle', treeNodeConf.text);
         // changes the icon in the layer tree leaf
         olLayer.set('iconCls', treeNodeConf.iconCls);
+    },
+
+    /**
+     * Applies the values from the tree layer config to the given
+     * tree node instance.
+     *
+     * @param {Ext.data.NodeInterface} node The tree node to apply tree conf values to
+     * @param {Object} treeNodeConf The tree node layer config JSON
+     */
+    applyTreeConfigsToNode: function (node, treeNodeConf) {
+        node.set('text', treeNodeConf.text);
+
+        // expand configured folders in this tree
+        node.set('expanded', treeNodeConf.expanded);
     }
 
 });

--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -99,17 +99,22 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
                     node.addCls('cpsi-tree-node-baselayer');
                 }
 
+                // expand configured folders in this tree
+                if (data.leaf !== true && node.getOlLayer()) {
+                    var origFolderConf = node.getOlLayer().get('_origTreeConf');
+                    if (origFolderConf) {
+                        node.set('expanded', origFolderConf.expanded);
+                    }
+                }
+
                 // apply the text for tree node from corresponding tree-conf
                 if (node.getOlLayer()) {
-                    var origTreeConf = node.getOlLayer().get('_origTreeConf');
-                    if (origTreeConf) {
-                        node.set('text', origTreeConf.text);
+                    var origLeafConf = node.getOlLayer().get('_origTreeConf');
+                    if (origLeafConf) {
+                        node.set('text', origLeafConf.text);
                     }
                 }
             });
-
-            // expand all folders in this tree
-            me.getView().expandAll();
 
             // inform subscribers that LayerTree is ready
             me.getView().fireEvent('cmv-init-layertree', me);
@@ -199,6 +204,9 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
                     layers: [],
                 });
 
+                // preserve the original tree JSON config to re-use it later on
+                layerGroup.set('_origTreeConf', child);
+
                 var parentLayers = parentGroup.getLayers();
                 parentLayers.insertAt(0, layerGroup);
 
@@ -212,6 +220,9 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
                     // apply tree config to OL layer
                     // needed since the LayerTreeNode model derives them from OL layer
                     me.applyTreeConfigsToOlLayer(mapLyr, child);
+
+                    // preserve the original tree JSON config to re-use it later on
+                    mapLyr.set('_origTreeConf', child);
 
                     // add OL layer to parent OL LayerGroup
                     parentGroup.getLayers().insertAt(0, mapLyr);
@@ -239,9 +250,6 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
         olLayer.set('descTitle', treeNodeConf.text);
         // changes the icon in the layer tree leaf
         olLayer.set('iconCls', treeNodeConf.iconCls);
-
-        // preserve the original tree JSON config to re-use it later on
-        olLayer.set('_origTreeConf', treeNodeConf);
     }
 
 });

--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -261,6 +261,13 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
 
         // expand configured folders in this tree
         node.set('expanded', treeNodeConf.expanded);
+
+        // hide checkbox on tree node if configured
+        // setting checked to undefined has no effect since GeoExt.data.model.LayerTreeNode
+        // overwrites this with the layer's visibility.
+        if (treeNodeConf.checked === false) {
+            node.addCls('cpsi-tree-no-checkbox');
+        }
     }
 
 });

--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -251,6 +251,12 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
      * @param {Object} treeNodeConf The tree node layer config JSON
      */
     applyTreeConfigsToNode: function (node, treeNodeConf) {
+        node.set('cls', treeNodeConf.cls);
+        node.set('expandable', Ext.isDefined(treeNodeConf.expandable) ? treeNodeConf.expandable : true);
+        node.set('glyph', treeNodeConf.glyph);
+        node.set('icon', treeNodeConf.icon);
+        node.set('qshowDelay', treeNodeConf.qshowDelay);
+
         node.set('text', treeNodeConf.text);
 
         // expand configured folders in this tree

--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -189,8 +189,10 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
         var me = this;
         // go over all passed in tree childs nodes
         Ext.each(treeNodeChilds, function (child) {
+            // respect "isLeaf" for legacy reasons (but recommended using "leaf")
+            var isLeaf = Ext.isDefined(child.isLeaf) ? child.isLeaf : child.leaf;
             // layer groups --> folders in tree
-            if (child.isLeaf !== true) {
+            if (isLeaf !== true) {
                 // create empty layer group for this level
                 var layerGroup = new ol.layer.Group({
                     name: child.title,

--- a/app/data/model/LayerTreeNode.js
+++ b/app/data/model/LayerTreeNode.js
@@ -1,0 +1,27 @@
+/**
+ * The CPSI MapView layer tree node class used by the stores used in trees.
+ *
+ * @class CpsiMapview.data.model.LayerTreeNode
+ */
+Ext.define('CpsiMapview.data.model.LayerTreeNode', {
+    extend: 'GeoExt.data.model.LayerTreeNode',
+
+    /**
+     * The layer property that will be used to hold a title for the description of the model in views.
+     *
+     * @cfg {String}
+     */
+    descriptionTitleProperty: 'descTitle',
+
+    fields: [
+        {
+            name: 'qtitle',
+            type: 'string',
+            persist: false,
+            convert: function(v, record) {
+                return record.getOlLayerProp(record.descriptionTitleProperty, '') || record.get('text');
+            }
+        }
+    ]
+
+});

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -104,10 +104,6 @@ Ext.define('CpsiMapview.factory.Layer', {
             mapLayer.set('legendWidth', layerConf.legendWidth);
             mapLayer.set('layerKey', layerConf.layerKey);
 
-            // this gets transformed to qtip on the layer tree node
-            mapLayer.set('description', layerConf.qtip);
-            // changes the icon in the layer tree leaf
-            mapLayer.set('iconCls', layerConf.iconCls);
             // indicator if a refresh option is offered in layer context menu
             var allowRefresh = layerConf.refreshLayerOption !== false;
             mapLayer.set('refreshLayerOption', allowRefresh);

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -99,7 +99,6 @@
       "layerType": "wms",
       "layerKey": "OSM_WMS3",
       "helpPage": "OSM",
-      "iconCls": "map",
       "url": "https://ows.terrestris.de/osm-gray/service",
       "serverOptions": {
         "layers": "OSM-WMS"

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -50,28 +50,55 @@
     {
       "layerType": "xyz",
       "layerKey": "GREY_BACKGROUND",
-      "iconCls": "map",
       "isDefaultBaseLayer": false,
-      "text": "Grey Background",
-      "url": "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}",
-      "qtip": "This is the background layer"
+      "url": "https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}"
     },
     {
       "layerType": "osm",
       "layerKey": "OSM_BACKGROUND",
       "helpPage": "OSM",
-      "iconCls": "map",
       "isDefaultBaseLayer": true,
-      "text": "OpenStreetMap",
       "legendUrl": "https://a.tile.openstreetmap.org/9/244/166.png",
       "legendHeight": 100
     },
     {
       "layerType": "wms",
-      "text": "A WMS",
       "layerKey": "OSM_WMS",
       "helpPage": "OSM",
-      "qtip": "An OSM based WMS layer",
+      "url": "https://ows.terrestris.de/osm-gray/service",
+      "serverOptions": {
+        "layers": "OSM-WMS"
+      },
+      "openLayers": {
+        "maxResolution": 1222.99245234375,
+        "numZoomLevels": 12,
+        "opacity": 0.7,
+        "projection": "EPSG:900913",
+        "visibility": false,
+        "zoomOffset": 7
+      }
+    },
+    {
+      "layerType": "wms",
+      "layerKey": "OSM_WMS2",
+      "helpPage": "OSM",
+      "url": "https://ows.terrestris.de/osm-gray/service",
+      "serverOptions": {
+        "layers": "OSM-WMS"
+      },
+      "openLayers": {
+        "maxResolution": 1222.99245234375,
+        "numZoomLevels": 12,
+        "opacity": 0.7,
+        "projection": "EPSG:900913",
+        "visibility": false,
+        "zoomOffset": 7
+      }
+    },
+    {
+      "layerType": "wms",
+      "layerKey": "OSM_WMS3",
+      "helpPage": "OSM",
       "iconCls": "map",
       "url": "https://ows.terrestris.de/osm-gray/service",
       "serverOptions": {
@@ -87,10 +114,25 @@
       }
     },
     {
+      "layerType": "wms",
+      "layerKey": "OSM_WMS4",
+      "helpPage": "OSM",
+      "url": "https://ows.terrestris.de/osm-gray/service",
+      "serverOptions": {
+        "layers": "OSM-WMS"
+      },
+      "openLayers": {
+        "maxResolution": 1222.99245234375,
+        "numZoomLevels": 12,
+        "opacity": 0.7,
+        "projection": "EPSG:900913",
+        "visibility": false,
+        "zoomOffset": 7
+      }
+    },
+    {
       "layerType": "wfs",
-      "text": "Country WFS",
       "layerKey": "COUNTRY_WFS",
-      "qtip": "An OSM based WFS layer",
       "url": "https://ows.terrestris.de/geoserver/osm/wfs",
       "featureType": "osm:osm-country-borders",
       "geomFieldName": "geometry",
@@ -109,7 +151,6 @@
     },
     {
       "layerType": "wfs",
-      "text": "GAS WFS",
       "layerKey": "GAS_WFS",
       "url": "https://ows.terrestris.de/geoserver/osm/wfs",
       "legendUrl": "https://ows.terrestris.de/geoserver/osm/wfs?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetLegendGraphic&FORMAT=image%2Fpng&TRANSPARENT=TRUE&SLD_VERSION=1.1.0&LAYER=osm:osm-fuel&STYLE=",
@@ -165,7 +206,6 @@
       "layers": [
         {
           "layerType": "wms",
-          "text": "Waterbody Switch Layer (far)",
           "layerKey": "WATERBODY_SWITCH_LAYER_FAR",
           "serverOptions": {
             "layers": "waterbodies"
@@ -181,7 +221,6 @@
         },
         {
           "layerType": "wfs",
-          "text": "Waterbody Switch Layer (close)",
           "layerKey": "WATERBODY_SWITCH_LAYER_CLOSE",
           "geometryProperty": "msGeometry",
           "featureType": "waterbodies",
@@ -213,8 +252,6 @@
     },
     {
       "layerType": "wfs",
-      "text": "Borehole WFS (Time)",
-      "qtip": "Filter records with the timeslider control",
       "layerKey": "BOREHOLE_WFS",
       "geometryProperty": "msGeometry",
       "featureType": "Boreholes",
@@ -228,7 +265,6 @@
     },
     {
       "layerType": "wms",
-      "text": "Borehole WMS",
       "layerKey": "BOREHOLE_WMS",
       "serverOptions": {
         "layers": "Boreholes",
@@ -253,7 +289,6 @@
     },
     {
       "layerType": "vtwms",
-      "text": "Waterways VT WMS",
       "layerKey": "WATERWAYS_VTWMS",
       "url": "https://w08-mapserver.compass.ie/mapserver/?map=/MapServer/apps/mapview-demo/example.map&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=true&LAYERS=waterways&TILED=false&CRS=EPSG%3A3857&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&STYLES=Waterways&FORMAT=mvt",
       "openLayers": {
@@ -281,8 +316,6 @@
     },
     {
       "layerType": "wfs",
-      "text": "Ruins",
-      "qtip": "Right-click for a layer grid",
       "gridXType": "cmv_examplegrid",
       "layerKey": "RUINS_WFS",
       "geometryProperty": "msGeometry",

--- a/resources/data/layers/tree.json
+++ b/resources/data/layers/tree.json
@@ -7,87 +7,87 @@
       "children": [
         {
           "id": "LIGHT_UNIT_MVT",
-          "isLeaf": true
+          "leaf": true
         },
         {
           "id": "RUINS_WFS",
-          "isLeaf": true,
+          "leaf": true,
           "text": "Ruins",
           "qtip": "Right-click for a layer grid"
         },
         {
           "id": "LIGHT_UNIT_WFS",
-          "isLeaf": true
+          "leaf": true
         },
         {
           "id": "BOREHOLE_WMS",
-          "isLeaf": true,
+          "leaf": true,
           "text": "Borehole WMS"
         },
         {
           "id": "BOREHOLE_WFS",
-          "isLeaf": true,
+          "leaf": true,
           "text": "Borehole WFS (Time)",
           "qtip": "Filter records with the timeslider control"
         },
         {
           "id": "TIME_WFS_PROXY",
-          "isLeaf": true
+          "leaf": true
         },
         {
           "id": "WORKS_EXPORT_WMS_PROXY",
-          "isLeaf": true
+          "leaf": true
         },
         {
           "id": "LIGHT_UNIT_SWITCH_LAYER_FAR",
-          "isLeaf": true
+          "leaf": true
         },
         {
           "id": "WATERBODY_SWITCH_LAYER_FAR",
-          "isLeaf": true,
+          "leaf": true,
           "text": "Waterbody Switch Layer (far)"
         },
         {
           "id": "WATERBODY_SWITCH_LAYER_CLOSE",
-          "isLeaf": true,
+          "leaf": true,
           "text": "Waterbody Switch Layer (close)"
         },
         {
           "id": "WATERWAYS_VTWMS",
-          "isLeaf": true,
+          "leaf": true,
           "text": "Waterways VT WMS"
         },
         {
           "id": "GAS_WFS",
-          "isLeaf": true,
+          "leaf": true,
           "text": "GAS WFS"
         },
         {
           "id": "COUNTRY_WFS",
-          "isLeaf": true,
+          "leaf": true,
           "text": "Country WFS",
           "qtip": "An OSM based WFS layer"
         },
         {
           "id": "OSM_WMS",
-          "isLeaf": true,
-          "text": "kalle",
+          "leaf": true,
+          "text": "OSM WMS",
           "qtip": "An OSM based WMS layer",
           "iconCls": "map"
         },
         {
           "id": "OSM_WMS2",
-          "isLeaf": true,
+          "leaf": true,
           "text": "A WMS 2"
         },
         {
           "id": "OSM_WMS3",
-          "isLeaf": true,
+          "leaf": true,
           "text": "A WMS 3"
         },
         {
           "id": "OSM_WMS4",
-          "isLeaf": true,
+          "leaf": true,
           "text": "A WMS 4"
         }
       ]
@@ -98,14 +98,14 @@
       "children": [
         {
           "id": "OSM_BACKGROUND",
-          "isLeaf": true,
+          "leaf": true,
           "text": "OpenStreetMap",
           "qtip": "An OpenStreetMap based background layer",
           "iconCls": "map"
         },
         {
           "id": "GREY_BACKGROUND",
-          "isLeaf": true,
+          "leaf": true,
           "text": "Grey Background",
           "qtip": "This is the background layer",
           "iconCls": "map"

--- a/resources/data/layers/tree.json
+++ b/resources/data/layers/tree.json
@@ -5,6 +5,7 @@
       "id": "overlay-folder",
       "title": "Layers",
       "expanded": true,
+      "checked": false,
       "children": [
         {
           "id": "LIGHT_UNIT_MVT",

--- a/resources/data/layers/tree.json
+++ b/resources/data/layers/tree.json
@@ -11,7 +11,9 @@
         },
         {
           "id": "RUINS_WFS",
-          "isLeaf": true
+          "isLeaf": true,
+          "text": "Ruins",
+          "qtip": "Right-click for a layer grid"
         },
         {
           "id": "LIGHT_UNIT_WFS",
@@ -19,11 +21,14 @@
         },
         {
           "id": "BOREHOLE_WMS",
-          "isLeaf": true
+          "isLeaf": true,
+          "text": "Borehole WMS"
         },
         {
           "id": "BOREHOLE_WFS",
-          "isLeaf": true
+          "isLeaf": true,
+          "text": "Borehole WFS (Time)",
+          "qtip": "Filter records with the timeslider control"
         },
         {
           "id": "TIME_WFS_PROXY",
@@ -39,27 +44,51 @@
         },
         {
           "id": "WATERBODY_SWITCH_LAYER_FAR",
-          "isLeaf": true
+          "isLeaf": true,
+          "text": "Waterbody Switch Layer (far)"
         },
         {
           "id": "WATERBODY_SWITCH_LAYER_CLOSE",
-          "isLeaf": true
+          "isLeaf": true,
+          "text": "Waterbody Switch Layer (close)"
         },
         {
           "id": "WATERWAYS_VTWMS",
-          "isLeaf": true
+          "isLeaf": true,
+          "text": "Waterways VT WMS"
         },
         {
           "id": "GAS_WFS",
-          "isLeaf": true
+          "isLeaf": true,
+          "text": "GAS WFS"
         },
         {
           "id": "COUNTRY_WFS",
-          "isLeaf": true
+          "isLeaf": true,
+          "text": "Country WFS",
+          "qtip": "An OSM based WFS layer"
         },
         {
           "id": "OSM_WMS",
-          "isLeaf": true
+          "isLeaf": true,
+          "text": "kalle",
+          "qtip": "An OSM based WMS layer",
+          "iconCls": "map"
+        },
+        {
+          "id": "OSM_WMS2",
+          "isLeaf": true,
+          "text": "A WMS 2"
+        },
+        {
+          "id": "OSM_WMS3",
+          "isLeaf": true,
+          "text": "A WMS 3"
+        },
+        {
+          "id": "OSM_WMS4",
+          "isLeaf": true,
+          "text": "A WMS 4"
         }
       ]
     },
@@ -69,11 +98,17 @@
       "children": [
         {
           "id": "OSM_BACKGROUND",
-          "isLeaf": true
+          "isLeaf": true,
+          "text": "OpenStreetMap",
+          "qtip": "An OpenStreetMap based background layer",
+          "iconCls": "map"
         },
         {
           "id": "GREY_BACKGROUND",
-          "isLeaf": true
+          "isLeaf": true,
+          "text": "Grey Background",
+          "qtip": "This is the background layer",
+          "iconCls": "map"
         }
       ]
     }

--- a/resources/data/layers/tree.json
+++ b/resources/data/layers/tree.json
@@ -4,6 +4,7 @@
     {
       "id": "overlay-folder",
       "title": "Layers",
+      "expanded": true,
       "children": [
         {
           "id": "LIGHT_UNIT_MVT",
@@ -20,15 +21,21 @@
           "leaf": true
         },
         {
-          "id": "BOREHOLE_WMS",
-          "leaf": true,
-          "text": "Borehole WMS"
-        },
-        {
-          "id": "BOREHOLE_WFS",
-          "leaf": true,
-          "text": "Borehole WFS (Time)",
-          "qtip": "Filter records with the timeslider control"
+          "title": "Borehole",
+          "expanded": false,
+          "children": [
+            {
+              "id": "BOREHOLE_WMS",
+              "leaf": true,
+              "text": "Borehole WMS"
+            },
+            {
+              "id": "BOREHOLE_WFS",
+              "leaf": true,
+              "text": "Borehole WFS (Time)",
+              "qtip": "Filter records with the timeslider control"
+            }
+          ]
         },
         {
           "id": "TIME_WFS_PROXY",
@@ -95,6 +102,7 @@
     {
       "id": "base-folder",
       "title": "Base Layers",
+      "expanded": true,
       "children": [
         {
           "id": "OSM_BACKGROUND",

--- a/sass/src/view/LayerTree.scss
+++ b/sass/src/view/LayerTree.scss
@@ -14,3 +14,9 @@
         background-image: url(images/form/radio.png);
     }
 }
+
+.cpsi-tree-no-checkbox {
+    .x-tree-checkbox {
+        display: none;
+    }
+}


### PR DESCRIPTION
This PR moves tree UI related configurations options, such as `'text'`, `'qtip'` or `'iconCls'` to the tree JSON file (`tree.json`).

**Caution**: Merging this needs adaption of existing configuration files for apps based on CPSI-MapView:

- `'text'`, `'qtip'` or `'iconCls'` fields have to be moved to the tree.json file
- `'isLeaf'` property in tree.json is now `'leaf'` ('isLeaf' accepted for legacy reasons) 
- folders in tree.json need an `'expanded'` property set to true in case they should be expanded on startup 

See resources/data/layers/tree.json as a working example.
