### PR TITLE
Use constrainHeader for MinimizableWindow

### DIFF
--- a/app/view/window/MinimizableWindow.js
+++ b/app/view/window/MinimizableWindow.js
@@ -17,7 +17,7 @@ Ext.define('CpsiMapview.view.window.MinimizableWindow', {
 
     controller: 'cmv_minimizable_window',
 
-    constrain: true, // constrain within the viewport
+    constrainHeader: true, // constrain header within the viewport
 
     minimizable: true,
 


### PR DESCRIPTION
Only restrict header to viewport by default rather than the full window