### PR TITLE
Apply default values for tree nodes

### DIFF
--- a/resources/data/layers/tree.json
+++ b/resources/data/layers/tree.json
@@ -1,125 +1,130 @@
 {
-  "id": "root",
-  "children": [
-    {
-      "id": "overlay-folder",
-      "title": "Layers",
-      "expanded": true,
-      "checked": false,
-      "children": [
-        {
-          "id": "LIGHT_UNIT_MVT",
-          "leaf": true
-        },
-        {
-          "id": "RUINS_WFS",
-          "leaf": true,
-          "text": "Ruins",
-          "qtip": "Right-click for a layer grid"
-        },
-        {
-          "id": "LIGHT_UNIT_WFS",
-          "leaf": true
-        },
-        {
-          "title": "Borehole",
-          "expanded": false,
-          "children": [
-            {
-              "id": "BOREHOLE_WMS",
-              "leaf": true,
-              "text": "Borehole WMS"
-            },
-            {
-              "id": "BOREHOLE_WFS",
-              "leaf": true,
-              "text": "Borehole WFS (Time)",
-              "qtip": "Filter records with the timeslider control"
-            }
-          ]
-        },
-        {
-          "id": "TIME_WFS_PROXY",
-          "leaf": true
-        },
-        {
-          "id": "WORKS_EXPORT_WMS_PROXY",
-          "leaf": true
-        },
-        {
-          "id": "LIGHT_UNIT_SWITCH_LAYER_FAR",
-          "leaf": true
-        },
-        {
-          "id": "WATERBODY_SWITCH_LAYER_FAR",
-          "leaf": true,
-          "text": "Waterbody Switch Layer (far)"
-        },
-        {
-          "id": "WATERBODY_SWITCH_LAYER_CLOSE",
-          "leaf": true,
-          "text": "Waterbody Switch Layer (close)"
-        },
-        {
-          "id": "WATERWAYS_VTWMS",
-          "leaf": true,
-          "text": "Waterways VT WMS"
-        },
-        {
-          "id": "GAS_WFS",
-          "leaf": true,
-          "text": "GAS WFS"
-        },
-        {
-          "id": "COUNTRY_WFS",
-          "leaf": true,
-          "text": "Country WFS",
-          "qtip": "An OSM based WFS layer"
-        },
-        {
-          "id": "OSM_WMS",
-          "leaf": true,
-          "text": "OSM WMS",
-          "qtip": "An OSM based WMS layer",
-          "iconCls": "map"
-        },
-        {
-          "id": "OSM_WMS2",
-          "leaf": true,
-          "text": "A WMS 2"
-        },
-        {
-          "id": "OSM_WMS3",
-          "leaf": true,
-          "text": "A WMS 3"
-        },
-        {
-          "id": "OSM_WMS4",
-          "leaf": true,
-          "text": "A WMS 4"
-        }
-      ]
-    },
-    {
-      "id": "base-folder",
-      "title": "Base Layers",
-      "expanded": true,
-      "children": [
-        {
-          "id": "OSM_BACKGROUND",
-          "leaf": true,
-          "text": "OpenStreetMap",
-          "qtip": "An OpenStreetMap based background layer",
-          "iconCls": "map"
-        },
-        {
-          "id": "GREY_BACKGROUND",
-          "leaf": true,
-          "text": "Grey Background",
-          "qtip": "This is the background layer",
-          "iconCls": "map"
-        }
-      ]
-    }
-  ]
+  "defaults": {
+    "general": {}
+  },
+  "treeConfig": {
+    "id": "root",
+    "children": [
+      {
+        "id": "overlay-folder",
+        "title": "Layers",
+        "expanded": true,
+        "checked": false,
+        "children": [
+          {
+            "id": "LIGHT_UNIT_MVT",
+            "leaf": true
+          },
+          {
+            "id": "RUINS_WFS",
+            "leaf": true,
+            "text": "Ruins",
+            "qtip": "Right-click for a layer grid"
+          },
+          {
+            "id": "LIGHT_UNIT_WFS",
+            "leaf": true
+          },
+          {
+            "title": "Borehole",
+            "expanded": false,
+            "children": [
+              {
+                "id": "BOREHOLE_WMS",
+                "leaf": true,
+                "text": "Borehole WMS"
+              },
+              {
+                "id": "BOREHOLE_WFS",
+                "leaf": true,
+                "text": "Borehole WFS (Time)",
+                "qtip": "Filter records with the timeslider control"
+              }
+            ]
+          },
+          {
+            "id": "TIME_WFS_PROXY",
+            "leaf": true
+          },
+          {
+            "id": "WORKS_EXPORT_WMS_PROXY",
+            "leaf": true
+          },
+          {
+            "id": "LIGHT_UNIT_SWITCH_LAYER_FAR",
+            "leaf": true
+          },
+          {
+            "id": "WATERBODY_SWITCH_LAYER_FAR",
+            "leaf": true,
+            "text": "Waterbody Switch Layer (far)"
+          },
+          {
+            "id": "WATERBODY_SWITCH_LAYER_CLOSE",
+            "leaf": true,
+            "text": "Waterbody Switch Layer (close)"
+          },
+          {
+            "id": "WATERWAYS_VTWMS",
+            "leaf": true,
+            "text": "Waterways VT WMS"
+          },
+          {
+            "id": "GAS_WFS",
+            "leaf": true,
+            "text": "GAS WFS"
+          },
+          {
+            "id": "COUNTRY_WFS",
+            "leaf": true,
+            "text": "Country WFS",
+            "qtip": "An OSM based WFS layer"
+          },
+          {
+            "id": "OSM_WMS",
+            "leaf": true,
+            "text": "OSM WMS",
+            "qtip": "An OSM based WMS layer",
+            "iconCls": "map"
+          },
+          {
+            "id": "OSM_WMS2",
+            "leaf": true,
+            "text": "A WMS 2"
+          },
+          {
+            "id": "OSM_WMS3",
+            "leaf": true,
+            "text": "A WMS 3"
+          },
+          {
+            "id": "OSM_WMS4",
+            "leaf": true,
+            "text": "A WMS 4"
+          }
+        ]
+      },
+      {
+        "id": "base-folder",
+        "title": "Base Layers",
+        "expanded": true,
+        "children": [
+          {
+            "id": "OSM_BACKGROUND",
+            "leaf": true,
+            "text": "OpenStreetMap",
+            "qtip": "An OpenStreetMap based background layer",
+            "iconCls": "map"
+          },
+          {
+            "id": "GREY_BACKGROUND",
+            "leaf": true,
+            "text": "Grey Background",
+            "qtip": "This is the background layer",
+            "iconCls": "map"
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
This allows to define a section `"defaults"` > `"general"` having default values for tree node configurations, so duplication of properties can be avoided.

CAUTION: The general structure of tree.json is changed with this PR and needs adaption in existing applications:

before:
```json
{
  "id": "root",
  "children": [
    {
      "id": "overlay-folder",
...
```
after:
```json
{
  "defaults": {
    "general": {}
  },
  "treeConfig": {
    "id": "root",
    "children": [
      {
        "id": "overlay-folder",
...
```
Resolves #291 