### PR TITLE
Add missing requires and remove baselayer class code

### DIFF
--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -5,7 +5,8 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
 
     requires: [
         'BasiGX.util.Map',
-        'BasiGX.util.Layer'
+        'BasiGX.util.Layer',
+        'CpsiMapview.data.model.LayerTreeNode'
     ],
 
 
@@ -106,11 +107,6 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
             me.getView().setStore(groupedLayerTreeStore);
 
             me.getView().getRootNode().cascade(function (node) {
-                var data = node.getData();
-                if (data.leaf && data.get('isBaseLayer')) {
-                    node.addCls('cpsi-tree-node-baselayer');
-                }
-
                 // apply properties for tree node from corresponding tree-conf
                 if (node.getOlLayer()) {
                     var origTreeNodeConf = node.getOlLayer().get('_origTreeConf') || {};


### PR DESCRIPTION
@chrismayer - a couple of fixes required when integrating with larger application. 

1. Add missing requires. 
2. `isBaseLayer` code removed as can now be set in tree.json (old approach no longer works):

```
          {
            "id": "OSM_BACKGROUND",
            "text": "OpenStreetMap",
            "iconCls": "fa-map",
            "cls": "cpsi-tree-node-baselayer"
          },
```