### PR TITLE
Add cls 'cpsi-tree-node-baselayer' to base layer tree configs

### DIFF
--- a/resources/data/layers/tree.json
+++ b/resources/data/layers/tree.json
@@ -114,14 +114,14 @@
             "leaf": true,
             "text": "OpenStreetMap",
             "qtip": "An OpenStreetMap based background layer",
-            "iconCls": "map"
+            "cls": "cpsi-tree-node-baselayer"
           },
           {
             "id": "GREY_BACKGROUND",
             "leaf": true,
             "text": "Grey Background",
             "qtip": "This is the background layer",
-            "iconCls": "map"
+            "cls": "cpsi-tree-node-baselayer"
           }
         ]
       }


### PR DESCRIPTION
Adds `"cls": "cpsi-tree-node-baselayer"` to the tree configurations of the BaseLayers, so the application looks as before (follow-up for #294).