### PR TITLE
Add missing onClearSort function to grid controller

### DIFF
--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -448,6 +448,17 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
     },
 
     /**
+    * Clear any sorters on the store
+    */
+    onClearSort: function () {
+        var me = this;
+        var grid = me.getView();
+        var store = grid.getStore();
+        store.getSorters().clear();
+        store.reload();
+    },
+
+    /**
     * Clear both the grid filters and any spatial filter.
     * This will cause the store to reload.
     *


### PR DESCRIPTION
This was referenced in the grid view but never implemented:

https://github.com/compassinformatics/cpsi-mapview/blob/3722bb3bd5cb3397816c4e4fba6ab5f4b596dd42/app/view/grid/Grid.js#L109

Removes any sorting on the WFSStore. 