### PR TITLE
Allow the Add WMS Window to be configured

### DIFF
--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -291,13 +291,24 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
         var me = this;
 
         if (pressed) {
-            this.addWmsWindow = Ext.create(me.getView().addWmsWindowConfig);
+            if (!this.addWmsWindow) {
+                this.addWmsWindow = Ext.create(me.getView().addWmsWindowConfig);
+                this.addWmsWindow.on('hide', function () {
+                    button.setPressed(false);
+                });
+            }
             this.addWmsWindow.show();
-            this.addWmsWindow.on('close', function () {
-                button.setPressed(false);
-                me.addWmsWindow = null;
-            });
+
         } else if (this.addWmsWindow) {
+            this.addWmsWindow.hide();
+        }
+    },
+
+   /**
+   * Destroy any associated windows when this component gets destroyed
+   */
+    onBeforeDestroy: function () {
+        if (this.addWmsWindow) {
             this.addWmsWindow.destroy();
             this.addWmsWindow = null;
         }

--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -6,9 +6,7 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
     requires: [
         'BasiGX.util.Map',
         'BasiGX.util.Layer',
-        'CpsiMapview.data.model.LayerTreeNode',
-        'CpsiMapview.view.window.MinimizableWindow',
-        'CpsiMapview.view.addWms.AddWmsForm'
+        'CpsiMapview.data.model.LayerTreeNode'
     ],
 
 
@@ -293,13 +291,7 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
         var me = this;
 
         if (pressed) {
-            this.addWmsWindow = Ext.create('CpsiMapview.view.window.MinimizableWindow', {
-                items: [
-                    {
-                        xtype: 'cmv_add_wms_form'
-                    }
-                ],
-            });
+            this.addWmsWindow = Ext.create(me.getView().addWmsWindowConfig);
             this.addWmsWindow.show();
             this.addWmsWindow.on('close', function () {
                 button.setPressed(false);

--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -304,9 +304,9 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
         }
     },
 
-   /**
-   * Destroy any associated windows when this component gets destroyed
-   */
+    /**
+    * Destroy any associated windows when this component gets destroyed
+    */
     onBeforeDestroy: function () {
         if (this.addWmsWindow) {
             this.addWmsWindow.destroy();

--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -293,14 +293,14 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
         if (pressed) {
             if (!this.addWmsWindow) {
                 this.addWmsWindow = Ext.create(me.getView().addWmsWindowConfig);
-                this.addWmsWindow.on('hide', function () {
+                this.addWmsWindow.on('close', function () {
                     button.setPressed(false);
                 });
             }
             this.addWmsWindow.show();
 
         } else if (this.addWmsWindow) {
-            this.addWmsWindow.hide();
+            this.addWmsWindow.close();
         }
     },
 

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -35,6 +35,7 @@ Ext.define('CpsiMapview.view.LayerTree', {
         addWmsWindowConfig: {
             xtype: 'cmv_minimizable_window',
             title: 'Add External Map Layer',
+            closeAction: 'hide',
             items: [{
                 xtype: 'cmv_add_wms_form'
             }]

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -13,7 +13,9 @@ Ext.define('CpsiMapview.view.LayerTree', {
         'CpsiMapview.view.menuitem.LayerOpacity',
         'CpsiMapview.view.menuitem.LayerGrid',
         'CpsiMapview.plugin.TreeColumnStyleSwitcher',
-        'CpsiMapview.controller.LayerTreeController'
+        'CpsiMapview.controller.LayerTreeController',
+        'CpsiMapview.view.window.MinimizableWindow',
+        'CpsiMapview.view.addWms.AddWmsForm'
     ],
 
     controller: 'cmv_layertree',
@@ -24,6 +26,19 @@ Ext.define('CpsiMapview.view.LayerTree', {
     rootVisible: false,
     viewConfig: {
         plugins: { ptype: 'treeviewdragdrop' }
+    },
+    config: {
+        /**
+        * The window configuration used for the Add WMS button
+        * Any xtypes used should be added to the requires property
+        */
+        addWmsWindowConfig: {
+            xtype: 'cmv_minimizable_window',
+            title: 'Add External Map Layer',
+            items: [{
+                xtype: 'cmv_add_wms_form'
+            }]
+        }
     },
     hideHeaders: true,
     lines: false,

--- a/app/view/addWms/AddWmsForm.js
+++ b/app/view/addWms/AddWmsForm.js
@@ -3,6 +3,8 @@ Ext.define('CpsiMapview.view.addWms.AddWmsForm', {
 
     xtype: 'cmv_add_wms_form',
 
+    requires: ['CpsiMapview.controller.addWms.AddWmsFormController'],
+
     viewModel: {
         data: {
             queryParamsFieldSetTitle: 'Request parameters',


### PR DESCRIPTION
This pull request has a few changes following integration into a large application. 

1. Makes the config for the Add WMS window cofigurable on the LayerTree view. As this is where the xtypes are set I also moved the requirements for the default `cmv_minimizable_window` and `cmv_add_wms_form` here. 
2. Adds a missing controller requires (JS errors otherwise) - `CpsiMapview.controller.addWms.AddWmsFormController`

Applications using the mapview library can then fully configure the Add WMS window from the LayerTree:

```js
    addWmsWindowConfig: {
        xtype: 'cmv_minimizable_window',
        title: 'Add External Map Layer',
        items: [{
            xtype: 'cmv_add_wms_form',
            width: 400,
            wmsBaseUrls: [
                'http://gis.epa.ie/geoserver/wms',
                'https://ows.terrestris.de/osm/service',
            ]
        }]
    }
```

3. Makes the form hidden rather than destroyed when closing. If destroyed then a new folder is added to the layer tree each time the form is reopened and a layer added as `this.layerGroup` is null each time a new `CpsiMapview.controller.addWms.AddWmsFormController` is created. 