### PR TITLE
Avoid layer tree updates for layers not in tree

### DIFF
--- a/app/data/model/LayerTreeNode.js
+++ b/app/data/model/LayerTreeNode.js
@@ -21,7 +21,26 @@ Ext.define('CpsiMapview.data.model.LayerTreeNode', {
             convert: function(v, record) {
                 return record.getOlLayerProp(record.descriptionTitleProperty, '') || record.get('text');
             }
+        },
+        {
+            name: '__toggleMode',
+            type: 'string',
+            defaultValue: 'ol3'
         }
-    ]
+    ],
 
+    /**
+     * Only toggle checkboxes if the layer is in the layer tree
+     * This avoids a costly refresh of the entire tree
+     * @param {any} evt
+     */
+    onLayerVisibleChange: function (evt) {
+        var layer = evt.target;
+
+        if (layer.get('displayInLayerSwitcher') !== false) {
+            if (!this.__updating) {
+                this.set('checked', layer.get('visible'));
+            }
+        }
+    }
 });


### PR DESCRIPTION
This pull request avoids setting the `checked` property on a layer which is not visible in the layer tree - this avoids an unnecessary redraw of the tree. 

It also makes the `CpsiMapview.data.model.LayerTreeNode` use the `ol3` `__toggleMode` by default - avoiding keeping parent checkboxes and children in synch, but also avoiding redrawing nodes. 
*Unsure if this has a major performance impact*. 