### PR TITLE
Allow 'Select by Shape' button to be hidden

### DIFF
--- a/app/model/grid/Grid.js
+++ b/app/model/grid/Grid.js
@@ -17,7 +17,9 @@ Ext.define('CpsiMapview.model.grid.Grid', {
     data: {
         vectorLayerKey: null,
         wmsLayerKey: null,
-        gridStoreType: null
+        gridStoreType: null,
+        // when isSpatialGrid is set to false the 'Select by Shape' button will be hidden
+        isSpatialGrid: true
     },
 
     formulas: {

--- a/app/view/grid/Grid.js
+++ b/app/view/grid/Grid.js
@@ -117,6 +117,9 @@ Ext.define('CpsiMapview.view.grid.Grid', {
             triggerWfsRequest: false,
             displayPermanently: true,
             glyph: 'xf044@FontAwesome',
+            bind: {
+                hidden: '{!isSpatialGrid}'
+            },
             listeners: {
                 'cmv-spatial-query-filter': 'onSpatialFilter'
             }


### PR DESCRIPTION
Adds a new configurable setting on the view model. Useful when using WFS grids without geometries. 