### PR TITLE
Add a Help Icon to Windows

### DIFF
--- a/app/controller/window/MinimizableWindow.js
+++ b/app/controller/window/MinimizableWindow.js
@@ -61,5 +61,29 @@ Ext.define('CpsiMapview.controller.window.MinimizableWindow', {
                 minimizeTo.fireEvent('restoreFromWindow', me.getView());
             }
         }
+    },
+
+    /**
+     * Opens any associated helpUrl in a new browser tab
+     * If the URL does not start with 'http' then an application
+     * rootHelpUrl is appended to the URL if present
+     * */
+    onHelp: function () {
+
+        var me = this;
+        var url = me.getViewModel().get('helpUrl');
+        var rootUrl = Ext.getApplication().rootHelpUrl;
+
+        if (rootUrl && (Ext.String.startsWith(url, 'http') === false)){
+            url = rootUrl + url;
+        }
+
+        var win = window.open(url, 'mapview-help'); // use '_blank' if we want a new window each time
+
+        if (!win) {
+            Ext.Msg.alert('Pop-up Blocked', 'The help page was blocked from opening. Please allow pop-ups for this site.');
+        } else {
+            win.focus();
+        }
     }
 });

--- a/app/controller/window/MinimizableWindow.js
+++ b/app/controller/window/MinimizableWindow.js
@@ -73,6 +73,10 @@ Ext.define('CpsiMapview.controller.window.MinimizableWindow', {
         var me = this;
         var url = me.getViewModel().get('helpUrl');
 
+        if (!url) {
+            return;
+        }
+
         // TODO unsure why Ext.getApplication is sometimes undefined
         var app = Ext.getApplication ? Ext.getApplication() : Ext.app.Application.instance;
         var rootUrl = app.rootHelpUrl;

--- a/app/controller/window/MinimizableWindow.js
+++ b/app/controller/window/MinimizableWindow.js
@@ -72,7 +72,10 @@ Ext.define('CpsiMapview.controller.window.MinimizableWindow', {
 
         var me = this;
         var url = me.getViewModel().get('helpUrl');
-        var rootUrl = Ext.getApplication().rootHelpUrl;
+
+        // TODO unsure why Ext.getApplication is sometimes undefined
+        var app = Ext.getApplication ? Ext.getApplication() : Ext.app.Application.instance;
+        var rootUrl = app.rootHelpUrl;
 
         if (rootUrl && (Ext.String.startsWith(url, 'http') === false)){
             url = rootUrl + url;

--- a/app/model/window/MinimizableWindow.js
+++ b/app/model/window/MinimizableWindow.js
@@ -1,0 +1,10 @@
+Ext.define('CpsiMapview.model.window.MinimizableWindow', {
+    extend: 'Ext.app.ViewModel',
+
+    alias: 'viewmodel.cmv_minimizable_window',
+
+    data: {
+        // any associated help URL should be overridden in inherited viewmodels
+        helpUrl: ''
+    }
+});

--- a/app/util/ApplicationMixin.js
+++ b/app/util/ApplicationMixin.js
@@ -30,6 +30,9 @@ Ext.define('CpsiMapview.util.ApplicationMixin', {
     // URLs to ignore for errors
     excludedUrls: [],
 
+    // URL to use as the root for any window helpUrl
+    rootHelpUrl: '',
+
     tokenName: 'cookietoken',
 
     errorCode: {

--- a/app/view/grid/ExampleGrid.js
+++ b/app/view/grid/ExampleGrid.js
@@ -53,7 +53,8 @@ Ext.define('CpsiMapview.view.grid.ExampleGridModel', {
     data: {
         vectorLayerKey: 'RUINS_WFS',
         gridStoreType: 'GridExample',
-        gridLayerName: 'GridExampleLayer' // TODO this is duplicated in layerOptions above
+        gridLayerName: 'GridExampleLayer', // TODO this is duplicated in layerOptions above
+        helpUrl: 'https://github.com/compassinformatics/cpsi-mapview/blob/master/app/view/grid/ExampleGrid.js'
     }
 });
 

--- a/app/view/menuitem/LayerGrid.js
+++ b/app/view/menuitem/LayerGrid.js
@@ -107,6 +107,12 @@ Ext.define('CpsiMapview.view.menuitem.LayerGrid', {
                 }
             });
             gridWindow = Ext.create('CpsiMapview.view.window.MinimizableWindow', windowConfig);
+
+            // copy any ViewModel properties from the grid on to its containing window
+            // this allows helpUrl to be set at the grid level
+            var gridViewModelData = gridWindow.down(gridXType).getViewModel().getData();
+            // use apply rather than applyIf otherwise the default empty helpUrl is not overwritten
+            Ext.apply(gridWindow.getViewModel().getData(), gridViewModelData);
         }
         gridWindow.show();
     }

--- a/app/view/window/MinimizableWindow.js
+++ b/app/view/window/MinimizableWindow.js
@@ -12,10 +12,13 @@ Ext.define('CpsiMapview.view.window.MinimizableWindow', {
     xtype: 'cmv_minimizable_window',
 
     requires: [
-        'CpsiMapview.controller.window.MinimizableWindow'
+        'CpsiMapview.controller.window.MinimizableWindow',
+        'CpsiMapview.model.window.MinimizableWindow'
     ],
 
     controller: 'cmv_minimizable_window',
+
+    viewModel: 'cmv_minimizable_window',
 
     constrainHeader: true, // constrain header within the viewport
 
@@ -36,6 +39,15 @@ Ext.define('CpsiMapview.view.window.MinimizableWindow', {
     minimizeTo: null,
 
     resizeHandles: 's w nw se sw', // don't add a resizer to the top-right (n e ne) as it blocks the close button
+
+    tools: [{
+        type: 'help',
+        tooltip: 'Get Help',
+        callback: 'onHelp',
+        bind: {
+            hidden: '{!helpUrl}'
+        }
+    }],
 
     listeners: {
         minimize: 'onMinimize',


### PR DESCRIPTION
This pull request adds a Help tool to windows with a helpUrl set in their viewModel. 
For custom grids VM properties are applied to their auto-generated container windows. 
