### PR TITLE
WMS GetFeatureInfoWindow

### DIFF
--- a/app/controller/MapController.js
+++ b/app/controller/MapController.js
@@ -50,5 +50,9 @@ Ext.define('CpsiMapview.controller.MapController', {
             btn.getViewModel().get('lineMeasureTooltip') :
             btn.getViewModel().get('polygonMeasureAreaTooltip');
         btn.tooltipStr = tTipStr;
-    }
+        btn.on('toggle', function (_, pressed) {
+            var map = BasiGX.util.Map.getMapComponent().map;
+            map.set('defaultClickEnabled', !pressed);
+        });
+    },
 });

--- a/app/controller/button/DigitizeButtonController.js
+++ b/app/controller/button/DigitizeButtonController.js
@@ -160,6 +160,7 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
             if (me.getView().getUseContextMenu()) {
                 me.map.getViewport().addEventListener('contextmenu', me.contextHandler);
             }
+            me.map.set('defaultClickEnabled', false);
         } else {
             if (type === 'Polygon') {
                 me.modifyInteraction.setActive(false);
@@ -181,6 +182,7 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
                 me.activeGroupIdx = 0;
                 me.contextMenuGroupsCounter = 0;
             }
+            me.map.set('defaultClickEnabled', true);
         }
     },
 

--- a/app/controller/button/DigitizeButtonController.js
+++ b/app/controller/button/DigitizeButtonController.js
@@ -160,7 +160,10 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
             if (me.getView().getUseContextMenu()) {
                 me.map.getViewport().addEventListener('contextmenu', me.contextHandler);
             }
-            me.map.set('defaultClickEnabled', false);
+            // if another digitize button is pressed then this would come before the onToggle of the other button
+            setTimeout(function () {
+                me.map.set('defaultClickEnabled', false);
+            }, 0);
         } else {
             if (type === 'Polygon') {
                 me.modifyInteraction.setActive(false);

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -114,6 +114,8 @@ Ext.define('CpsiMapview.factory.Layer', {
             mapLayer.set('opacitySlider', allowOpacitySlider);
             // the xtype of any associated grid
             mapLayer.set('gridXType', layerConf.gridXType);
+            // if layer should show a feature info window
+            mapLayer.set('featureInfoWindow', layerConf.featureInfoWindow);
             // attribute grouping config
             mapLayer.set('grouping', layerConf.grouping);
         }

--- a/app/plugin/FeatureInfoWindow.js
+++ b/app/plugin/FeatureInfoWindow.js
@@ -1,0 +1,142 @@
+Ext.define('CpsiMapview.plugin.FeatureInfoWindow', {
+    extend: 'Ext.plugin.Abstract',
+    alias: 'plugin.cmv_feature_info_window',
+    pluginId: 'cmv_feature_info_window',
+
+    requires: [
+        'Ext.window.Window',
+        'BasiGX.util.Map'
+    ],
+
+    init: function () {
+        var me = this;
+
+        var mapComp = BasiGX.util.Map.getMapComponent();
+        var map = mapComp.getMap();
+
+        map.on('singleclick', function (evt) {
+            var layers = [];
+            var resolution = map.getView().getResolution();
+            var projection = map.getView().getProjection();
+            map.forEachLayerAtPixel(evt.pixel, function (layer) {
+                layers.push(layer);
+            }, undefined, function (layer) {
+                return layer.get('featureInfoWindow');
+            });
+
+            if (layers.length) {
+                var window = me.showFeatureInfo(map, evt);
+
+                layers.forEach(function (layer) {
+                    var url = layer.getSource().getGetFeatureInfoUrl(evt.coordinate, resolution, projection, {
+                        INFO_FORMAT: 'geojson'
+                    });
+
+                    Ext.Ajax.request({
+                        url: url
+                    }).then(function (response) {
+                        var featureCollection = JSON.parse(response.responseText);
+                        window.add(me.createFeatureCollectionPanel(featureCollection));
+                    });
+                });
+            } else {
+                if (me.highlightSource) {
+                    me.highlightSource.clear();
+                }
+                if (me.window) {
+                    me.window.destroy();
+                }
+            }
+        });
+    },
+
+    showFeatureInfo: function (map, evt) {
+        var me = this;
+
+        if (!this.highlightSource) {
+            this.highlightSource = new ol.source.Vector();
+            new ol.layer.Vector({
+                source: this.highlightSource,
+                style: new ol.style.Style({
+                    image: new ol.style.Circle({
+                        radius: 5,
+                        stroke: new ol.style.Stroke({
+                            color: 'red',
+                            width: 2
+                        })
+                    })
+                }),
+                map: map
+            });
+        } else {
+            this.highlightSource.clear();
+        }
+
+        var feature = new ol.Feature(new ol.geom.Point(evt.coordinate));
+        this.highlightSource.addFeature(feature);
+
+        if (this.window) {
+            this.window.destroy();
+        }
+
+        this.window = Ext.create('Ext.window.Window', {
+            layout: {
+                type: 'accordion',
+                titleCollapse: false,
+                animate: true
+            },
+            width: 300
+        });
+        this.window.show();
+
+        this.window.on('close', function () {
+            me.highlightSource.clear();
+        });
+
+        return this.window;
+    },
+
+    createFeatureCollectionPanel: function (featureCollection) {
+        var me = this;
+
+        return Ext.create('Ext.panel.Panel', {
+            title: featureCollection.name,
+            items: featureCollection.features.map(function (geojsonFeature) {
+                return me.createFeatureGrid(geojsonFeature);
+            })
+        });
+    },
+
+    createFeatureGrid: function (geoJsonFeature) {
+        var props = geoJsonFeature.properties;
+
+        var data = Object.keys(props)
+            .filter(function (key) {
+                return key !== 'geometry';
+            })
+            .map(function (key) {
+                return {
+                    key: key,
+                    value: props[key]
+                };
+            });
+
+        var store = Ext.create('Ext.data.Store', {
+            data: data
+        });
+
+        return Ext.create('Ext.grid.Panel', {
+            store: store,
+            columns: [
+                {
+                    dataIndex: 'key'
+                },
+                {
+                    dataIndex: 'value'
+                }
+            ],
+            scrollable: true,
+            layout: 'fit'
+        });
+    }
+});

--- a/app/plugin/FeatureInfoWindow.js
+++ b/app/plugin/FeatureInfoWindow.js
@@ -38,12 +38,12 @@ Ext.define('CpsiMapview.plugin.FeatureInfoWindow', {
             return layer.get('featureInfoWindow');
         });
 
-        var window = me.openFeatureInfoWindow(map, evt);
+        var win = me.openFeatureInfoWindow(map, evt);
 
         if (layers.length <= 1) {
-            window.setLayout('fit');
+            win.setLayout('fit');
         } else {
-            window.setLayout({
+            win.setLayout({
                 type: 'accordion',
                 titleCollapse: false,
                 animate: true
@@ -51,7 +51,7 @@ Ext.define('CpsiMapview.plugin.FeatureInfoWindow', {
         }
 
         if (layers.length === 0) {
-            window.add(Ext.create('Ext.Component', {
+            win.add(Ext.create('Ext.Component', {
                 html: '<span>No results found</span>'
             }));
         } else {
@@ -64,8 +64,9 @@ Ext.define('CpsiMapview.plugin.FeatureInfoWindow', {
                     url: url
                 }).then(function (response) {
                     var features = format.readFeatures(response.responseText);
-                    window.add(me.createFeaturePanels(mapComp, layer, features));
+                    win.add(me.createFeaturePanels(mapComp, layer, features));
                 }).then(undefined, function (error) {
+                    Ext.log(error);
                     console.error(error);
                 });
             });
@@ -101,7 +102,10 @@ Ext.define('CpsiMapview.plugin.FeatureInfoWindow', {
             this.window.removeAll(true);
         } else {
             this.window = Ext.create('CpsiMapview.view.window.MinimizableWindow', {
-                width: 400
+                width: 400,
+                layout: {
+                    type: 'accordion'
+                }
             });
 
             this.window.on('close', function () {

--- a/app/plugin/FeatureInfoWindow.js
+++ b/app/plugin/FeatureInfoWindow.js
@@ -9,7 +9,7 @@ Ext.define('CpsiMapview.plugin.FeatureInfoWindow', {
     pluginId: 'cmv_feature_info_window',
 
     requires: [
-        'Ext.Component',
+        'Ext.panel.Panel',
         'CpsiMapview.view.window.MinimizableWindow',
         'BasiGX.view.grid.FeaturePropertyGrid',
         'BasiGX.util.Map'
@@ -61,18 +61,18 @@ Ext.define('CpsiMapview.plugin.FeatureInfoWindow', {
         var win = me.openFeatureInfoWindow();
 
         if (layers.length <= 1) {
-            win.setLayout('fit');
+            win.getLayout().setConfig({
+                hideCollapseTool: true
+            });
         } else {
-            win.setLayout({
-                type: 'accordion',
-                titleCollapse: false,
-                animate: true
+            win.getLayout().setConfig({
+                hideCollapseTool: false
             });
         }
 
         if (layers.length === 0) {
-            win.add(Ext.create('Ext.Component', {
-                html: '<span>No results found</span>'
+            win.add(Ext.create('Ext.panel.Panel', {
+                title: 'No results found'
             }));
         } else {
             layers.forEach(function (layer) {
@@ -137,7 +137,9 @@ Ext.define('CpsiMapview.plugin.FeatureInfoWindow', {
                 title: 'Feature Information',
                 width: 400,
                 layout: {
-                    type: 'accordion'
+                    type: 'accordion',
+                    titleCollapse: false,
+                    animate: true
                 }
             });
 

--- a/app/plugin/FeatureInfoWindow.js
+++ b/app/plugin/FeatureInfoWindow.js
@@ -104,6 +104,7 @@ Ext.define('CpsiMapview.plugin.FeatureInfoWindow', {
             this.window.removeAll(true);
         } else {
             this.window = Ext.create('CpsiMapview.view.window.MinimizableWindow', {
+                title: 'Feature Information',
                 width: 400,
                 layout: {
                     type: 'accordion'

--- a/app/plugin/FeatureInfoWindow.js
+++ b/app/plugin/FeatureInfoWindow.js
@@ -17,7 +17,9 @@ Ext.define('CpsiMapview.plugin.FeatureInfoWindow', {
         var map = mapComp.getMap();
 
         map.on('singleclick', function (evt) {
-            me.requestFeatureInfos(mapComp, evt);
+            if (map.get('defaultClickEnabled')) {
+                me.requestFeatureInfos(mapComp, evt);
+            }
         });
     },
 

--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -24,12 +24,6 @@ Ext.define('CpsiMapview.view.main.Map', {
 
     controller: 'cmv_map',
 
-    plugins: [
-        {
-            ptype: 'cmv_feature_info_window'
-        }
-    ],
-
     dockedItems: [{
         xtype: 'cmv_maptools',
         dock: 'top',
@@ -70,6 +64,9 @@ Ext.define('CpsiMapview.view.main.Map', {
             ptype: 'cmv_feature_attribute_grouping',
             startGroupingEvent: 'click',
             endGroupingEvent: 'context'
+        },
+        {
+            ptype: 'cmv_feature_info_window'
         }
     ],
 

--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -299,7 +299,11 @@ Ext.define('CpsiMapview.view.main.Map', {
         Ext.GlobalEvents.fireEvent('cmv-mapready', me);
 
         var grouping = this.getPlugin('cmv_feature_attribute_grouping');
-        grouping.initGrouping(me.mapCmp, me.olMap);
+        if (grouping) {
+            grouping.initGrouping(me.mapCmp, me.olMap);
+        }
+
+        me.olMap.set('defaultClickEnabled', true);
     },
 
     /**

--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -14,6 +14,7 @@ Ext.define('CpsiMapview.view.main.Map', {
         'CpsiMapview.view.toolbar.MinimizedWindows',
         'CpsiMapview.controller.panel.TimeSlider',
         'CpsiMapview.controller.MapController',
+        'CpsiMapview.plugin.FeatureInfoWindow',
 
         'BasiGX.util.Projection',
         'CpsiMapview.plugin.FeatureAttributeGrouping'
@@ -22,6 +23,12 @@ Ext.define('CpsiMapview.view.main.Map', {
     layout: 'fit',
 
     controller: 'cmv_map',
+
+    plugins: [
+        {
+            ptype: 'cmv_feature_info_window'
+        }
+    ],
 
     dockedItems: [{
         xtype: 'cmv_maptools',

--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -52,6 +52,11 @@ Ext.define('CpsiMapview.view.main.Map', {
                 zoom: 8
             })
         }),
+        plugins: [
+            {
+                ptype: 'cmv_feature_info_window'
+            }
+        ],
         listeners: {
             afterrender: 'afterMapRender'
         }
@@ -64,9 +69,6 @@ Ext.define('CpsiMapview.view.main.Map', {
             ptype: 'cmv_feature_attribute_grouping',
             startGroupingEvent: 'click',
             endGroupingEvent: 'context'
-        },
-        {
-            ptype: 'cmv_feature_info_window'
         }
     ],
 

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -21,6 +21,7 @@
     "wms": {
       "isBaseLayer": false,
       "isDefaultBaseLayer": false,
+      "featureInfoWindow": true,
       "url": "https://w08-mapserver.compass.ie/mapserver/?map=/MapServer/apps/mapview-demo/example.map&",
       "serverOptions": {
         "version": "1.3.0"


### PR DESCRIPTION
Resolves #251

This is still missing some documentation but can already be tested. It can be added as a plugin to the Map component:
```
    plugins: [
        {
            ptype: 'cmv_feature_info_window'
        }
    ],
```

Only layers will be queried, that have the property `featureInfoWindow` set to `true` in the `default.json`.

It looks like this:

![Peek 2020-10-12 15-10](https://user-images.githubusercontent.com/8100558/95756548-351b0600-0ca6-11eb-8ea4-98f2bc50ac15.gif)
