### PR TITLE
Cache legends based on layer plus STYLE

### DIFF
--- a/app/plugin/BasicTreeColumnLegends.js
+++ b/app/plugin/BasicTreeColumnLegends.js
@@ -48,6 +48,16 @@ Ext.define('CpsiMapview.plugin.BasicTreeColumnLegends', {
             var staticMe = CpsiMapview.plugin.BasicTreeColumnLegends;
             var layer = rec.data;
             var layerKey = layer.get('layerKey');
+
+            // a layer can have different legends for different styles
+            // ensure each of these are cached
+            if (layer.getSource) {
+                var styles = layer.getSource().getParams().STYLES;
+                if (styles) {
+                    layerKey += styles.toUpperCase();
+                }
+            }
+
             var legendUrl = layer.get('legendUrl');
             var w = layer.get('legendWidth');
             var h = layer.get('legendHeight');


### PR DESCRIPTION
Relates to #284 - currently legends are cached per layer, but individual WMS STYLEs can have different legends. This pull request caches at the LAYER/STYLE level. 