### PR TITLE
Remove features from layer when records deleted from store

### DIFF
--- a/app/controller/grid/ItemDeleterGridControllerMixin.js
+++ b/app/controller/grid/ItemDeleterGridControllerMixin.js
@@ -1,4 +1,3 @@
-
 /**
  *  To be mixed in to the controller of a grid which uses ItemDeleter
  *  Can be provided with the following custom handlers
@@ -9,8 +8,8 @@
  *  - onRowDeleteSuccess    => do something if the delete succeeded
  *  - onRowDeleteCallback   => do something whether the delete succeeded or failed
  *
- *  - doDelete              => the actual deletion implementation, if the user confirms
- *  - dontDelete            => in case we want to do something when the user doesn't confirim or beforeDelete returns false
+ *  - onRowDelete           => the actual deletion implementation, if the user confirms
+ *  - onRowDeleteCancelled  => in case we want to do something when the user doesn't confirm or beforeDelete returns false
  */
 
 Ext.define('CpsiMapview.controller.grid.ItemDeleterGridControllerMixin', {
@@ -21,8 +20,11 @@ Ext.define('CpsiMapview.controller.grid.ItemDeleterGridControllerMixin', {
     onRowDeleteSuccess: Ext.emptyFn,
     onRowDeleteCallback: Ext.emptyFn,
 
-    // what to do for deleting
-    onRowDelete: function (tableView, rowIndex, colIndex, item, e, record /*, tableRow*/) {
+    /**
+    * Function to run when a user selects to delete a row. Override this as required.
+    */
+    onRowDelete: function (tableView, rowIndex, colIndex, item, e, record) {
+
         record.erase({
             failure: this.onRowDeleteFail,
             success: this.onRowDeleteSuccess,
@@ -30,8 +32,10 @@ Ext.define('CpsiMapview.controller.grid.ItemDeleterGridControllerMixin', {
         });
     },
 
-    // what to do for not deleting (either canceled by user or by business logic)
-    onRowDeleteCanceled: Ext.emptyFn,
+    /**
+    * Function to run when delete is cancelled by the user or by business logic. Override this as required.
+    */
+    onRowDeleteCancelled: Ext.emptyFn,
 
     onDeleteRowClick: function (tableView, rowIndex, colIndex, item, e, record, tableRow) {
         var me = this;
@@ -46,14 +50,14 @@ Ext.define('CpsiMapview.controller.grid.ItemDeleterGridControllerMixin', {
                         if (buttonId == 'yes') {
                             me.onRowDelete(tableView, rowIndex, colIndex, item, e, record, tableRow);
                         } else {
-                            me.onRowDeleteCanceled(tableView, rowIndex, colIndex, item, e, record, tableRow);
+                            me.onRowDeleteCancelled(tableView, rowIndex, colIndex, item, e, record, tableRow);
                         }
                     }
                 );
             }
         }
         else {
-            me.onRowDeleteCanceled(tableView, rowIndex, colIndex, item, e, record, tableRow);
+            me.onRowDeleteCancelled(tableView, rowIndex, colIndex, item, e, record, tableRow);
         }
     }
 

--- a/app/controller/grid/ItemDeleterGridControllerMixin.js
+++ b/app/controller/grid/ItemDeleterGridControllerMixin.js
@@ -4,10 +4,6 @@
  *
  *  - beforeDelete          => if returns "false" deletion is aborted, runs BEFORE the user is asked for confirmation
  *
- *  - onRowDeleteFail       => do something if the delete failed
- *  - onRowDeleteSuccess    => do something if the delete succeeded
- *  - onRowDeleteCallback   => do something whether the delete succeeded or failed
- *
  *  - onRowDelete           => the actual deletion implementation, if the user confirms
  *  - onRowDeleteCancelled  => in case we want to do something when the user doesn't confirm or beforeDelete returns false
  */
@@ -15,7 +11,7 @@
 Ext.define('CpsiMapview.controller.grid.ItemDeleterGridControllerMixin', {
     extend: 'Ext.Mixin',
 
-    beforeDelete: function(/*config*/) {return true;},
+    beforeDelete: function (/*config*/) { return true; },
     onRowDeleteFail: Ext.emptyFn,
     onRowDeleteSuccess: Ext.emptyFn,
     onRowDeleteCallback: Ext.emptyFn,
@@ -24,12 +20,7 @@ Ext.define('CpsiMapview.controller.grid.ItemDeleterGridControllerMixin', {
     * Function to run when a user selects to delete a row. Override this as required.
     */
     onRowDelete: function (tableView, rowIndex, colIndex, item, e, record) {
-
-        record.erase({
-            failure: this.onRowDeleteFail,
-            success: this.onRowDeleteSuccess,
-            callback: this.onRowDeleteCallback
-        });
+        tableView.getStore().remove(record);
     },
 
     /**

--- a/app/model/FeatureStoreMixin.js
+++ b/app/model/FeatureStoreMixin.js
@@ -95,7 +95,7 @@ Ext.define('CpsiMapview.model.FeatureStoreMixin', {
                     var dirty = !me.editing;
                     me.set(field.name, features, { convert: false, dirty: dirty });
                 },
-                clear: function (store) {
+                clear: function () {
                     me.set(field.name, null, { convert: false });
                 },
                 remove: function (store, records) {

--- a/app/model/FeatureStoreMixin.js
+++ b/app/model/FeatureStoreMixin.js
@@ -95,12 +95,21 @@ Ext.define('CpsiMapview.model.FeatureStoreMixin', {
                     var dirty = !me.editing;
                     me.set(field.name, features, { convert: false, dirty: dirty });
                 },
-                clear: function () {
+                clear: function (store) {
                     me.set(field.name, null, { convert: false });
                 },
-                remove: function (store) {
+                remove: function (store, records) {
                     var features = store.getRange(); // get all remaining features
                     me.set(field.name, features, { convert: false });
+                    // currently binding is from layer to store, not store to layer
+                    // manually remove features linked to records removed from the store
+                    // see https://github.com/geoext/geoext3/issues/636
+                    Ext.each(records, function (r) {
+                        var feat = r.getFeature();
+                        if (feat) {
+                            store.layer.getSource().removeFeature(feat);
+                        }
+                    });
                 }
             }
         });


### PR DESCRIPTION
Ensure features associated with a row record are removed from the layer as there is no 2-way binding - see https://github.com/geoext/geoext3/issues/636

Use `remove` rather than `erase` which is for server callbacks, and also causes strange errors in OpenLayers. 

Also some typo fixes in ItemDeleter. 


