### PR TITLE
FileGrid buttons binding improved (buttons can be hidden)

### DIFF
--- a/app/view/fileupload/FileGrid.js
+++ b/app/view/fileupload/FileGrid.js
@@ -61,7 +61,10 @@ Ext.define('CpsiMapview.view.fileupload.FileGrid',
                 xtype: 'cmv_itemdeleter',
                 itemId: 'itemDeleter',
                 avoidConfirmationRequest: false,
-                deleteItemRequiredRole: this.deleteItemRequiredRole
+                deleteItemRequiredRole: this.deleteItemRequiredRole,
+                bind: {
+                    hidden: '{hideDeleteFileButton}'
+                }
             }
         ],
         tbar: [
@@ -81,7 +84,8 @@ Ext.define('CpsiMapview.view.fileupload.FileGrid',
                 },
                 bind: {
                     disabled: '{currentRecord.phantom}',
-                    tooltip:'Associate a File with the {parentType} - files can only be added after the {parentType} has been saved'
+                    tooltip:'Associate a File with the {parentType} - files can only be added after the {parentType} has been saved',
+                    hidden: '{hideAddFileButton}'
                 }
             }
         ]


### PR DESCRIPTION
In case the grid is included in a readonly form, add and remove buttons can easily be hidden via binding