### PR TITLE
Ensure only a single polygon is created and sent to server

### DIFF
--- a/app/controller/button/DigitizeButtonController.js
+++ b/app/controller/button/DigitizeButtonController.js
@@ -455,7 +455,7 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
                 Ext.each(features, function (feat) {
                     // api will respond with non unique ids, which
                     // will collide with OpenLayers feature ids not
-                    // being unique. Thats why we delete it here.
+                    // being unique. That's why we delete it here.
                     delete feat.id;
                     // set the current active group as property
                     feat.properties.group = me.activeGroupIdx;
@@ -472,14 +472,21 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
                 me.resultLayer.getSource().addFeatures(olFeatsForActiveGroup);
 
                 var drawSource = me.drawLayer.getSource();
+                var featureCount = drawSource.getFeatures().length;
+
                 if (view.getClearDrawnFeature()) {
                     drawSource.clear();
-                } else if (drawSource.getFeatures().length > 1) {
-                    // keep the last drawn feature and remove the first (older) one
-                    drawSource.removeFeature(drawSource.getFeatures()[0]);
+                } else if (featureCount > 1) {
+                    // keep the last drawn feature and remove any older ones
+                    var reverse = true;
+                    Ext.each(drawSource.getFeatures(), function (feat, index) {
+                        if (index < (featureCount -1)) {
+                            drawSource.removeFeature(drawSource.getFeatures()[index]);
+                        }
+                    }, me, reverse);
                 }
                 // The response from the API, parsed as OpenLayers features, will be
-                // fired here and the event can be used applicationwide to access
+                // fired here and the event can be used application-wide to access
                 // and handle the feature response.
                 me.getView().fireEvent('responseFeatures', olFeatsForActiveGroup);
             } else {

--- a/app/controller/button/DigitizeButtonController.js
+++ b/app/controller/button/DigitizeButtonController.js
@@ -477,13 +477,9 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
                 if (view.getClearDrawnFeature()) {
                     drawSource.clear();
                 } else if (featureCount > 1) {
-                    // keep the last drawn feature and remove any older ones
-                    var reverse = true;
-                    Ext.each(drawSource.getFeatures(), function (feat, index) {
-                        if (index < (featureCount -1)) {
-                            drawSource.removeFeature(drawSource.getFeatures()[index]);
-                        }
-                    }, me, reverse);
+                    // keep the last drawn feature and remove the oldest one
+                    // it seems that the a half-completed draw polygon can consist of multiple features
+                    drawSource.removeFeature(drawSource.getFeatures()[0]);
                 }
                 // The response from the API, parsed as OpenLayers features, will be
                 // fired here and the event can be used application-wide to access

--- a/app/field/Feature.js
+++ b/app/field/Feature.js
@@ -33,7 +33,10 @@ Ext.define('CpsiMapview.field.Feature', {
             // to ensure the model is not marked as dirty
             var originalDirtyState = rec.dirty;
             rec.beginEdit();
-            featureStore.layer.getSource().addFeatures(features);
+            var layerSource = featureStore.layer.getSource();
+            // remove any previous features when loading or reloading the model
+            layerSource.clear();
+            layerSource.addFeatures(features);
             rec.endEdit();
 
             //<debug>

--- a/app/field/Polygon.js
+++ b/app/field/Polygon.js
@@ -30,9 +30,14 @@ Ext.define('CpsiMapview.field.Polygon', {
         var feats, gj = null;
 
         feats = polygonLayer.getSource().getFeatures();
-        if (feats.length === 1) {
+
+        if (feats.length >= 1) {
+
+            if (feats.length > 1) {
+                Ext.log.warn('Multiple polygons found in the polygon feature layer');
+            }
             var writer = new ol.format.GeoJSON();
-            var geom = feats[0].getGeometry();
+            var geom = feats[feats.length -1].getGeometry(); // get the last created feature
             if (geom.getType() === 'Circle') {
                 // ol.geom.Circle is not supported
                 // in GeoJSON https://stackoverflow.com/questions/16942697/geojson-circles-supported-or-not


### PR DESCRIPTION
Only a single polygon should be used to select features. 
If multi-polygons are still created then add a warning and send the most recently created to the server. 
Some `DigitizeButtonController` typo updates while debugging multiple polygons. 
