### PR TITLE
Fix "getLegendHtml" for different styles

### DIFF
--- a/app/plugin/BasicTreeColumnLegends.js
+++ b/app/plugin/BasicTreeColumnLegends.js
@@ -51,7 +51,7 @@ Ext.define('CpsiMapview.plugin.BasicTreeColumnLegends', {
 
             // a layer can have different legends for different styles
             // ensure each of these are cached
-            if (layer.getSource) {
+            if (layer.getSource && layer.getSource().getParams) {
                 var styles = layer.getSource().getParams().STYLES;
                 if (styles) {
                     layerKey += styles.toUpperCase();


### PR DESCRIPTION
This fixes the legend detection and caching for different styles. Executes the caching only for layers with WMS-based sources (since other source types do not have a `getParams` function). Otherwise a lot of warnings show up in the developer console.