### PR TITLE
Ensure tree node text is updated for switch layer

### DIFF
--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -939,6 +939,13 @@ Ext.define('CpsiMapview.factory.Layer', {
                 // store filters for either layer type so they can be retrieved when switching
                 newLayerSource.set('additionalFilters', filters);
 
+                // add original tree config (from tree.json) to new layer
+                var origTreeNodeConf = newLayer.get('_origTreeConf');
+                if (!origTreeNodeConf) {
+                    origTreeNodeConf = CpsiMapview.controller.LayerTreeController.getTreeNodeConf(newLayer.get('layerKey'));
+                    newLayer.set('_origTreeConf', origTreeNodeConf);
+                }
+
                 if (newLayer.get('isWms')) {
 
                     activeStyle = LegendUtil.getWmsStyleFromSldFile(activeStyle);
@@ -1029,7 +1036,11 @@ Ext.define('CpsiMapview.factory.Layer', {
             var switchConf = node.getOlLayer().get('switchConfiguration');
 
             // only change for switch layers
-            if(switchConf){
+            if(switchConf) {
+                // apply tree node text from tree config
+                var origTreeNodeConf = node.getOlLayer().get('_origTreeConf');
+                node.set('text', origTreeNodeConf.text);
+                // trigger UI updates (e.g. tree node plugins)
                 node.triggerUIUpdate();
             }
         });


### PR DESCRIPTION
This ensures that for an exchanged switch layer the correct text (layer name) will be shown in the tree node.

Follow-up for #289 as detected in #319. 