### PR TITLE
Add metadata plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,15 @@ module.exports = {
         "LegendUtil": false,
         "GeoStylerSLDParser": false,
         "GeoStylerOpenlayersParser": false,
-        "google": false
+        "google": false,
+        "XLink_1_0": false,
+        "ISO19139_GMD_20060504": false,
+        "ISO19139_GCO_20060504": false,
+        "ISO19139_GTS_20060504": false,
+        "ISO19139_GSS_20060504": false,
+        "ISO19139_GSR_20060504": false,
+        "GML_3_2_0": false,
+        "Jsonix": false
     },
     "parserOptions": {
         "ecmaVersion": 5

--- a/app.json
+++ b/app.json
@@ -253,6 +253,24 @@
       "path": "https://cdn.jsdelivr.net/gh/highsource/w3c-schemas@1.4.0/scripts/lib/XLink_1_0.js"
     },
     {
+        "path": "https://cdn.jsdelivr.net/gh/highsource/ogc-schemas@2.6.1/scripts/lib/ISO19139_GSS_20060504.js"
+    },
+    {
+        "path": "https://cdn.jsdelivr.net/gh/highsource/ogc-schemas@2.6.1/scripts/lib/ISO19139_GSR_20060504.js"
+    },
+    {
+        "path": "https://cdn.jsdelivr.net/gh/highsource/ogc-schemas@2.6.1/scripts/lib/ISO19139_GTS_20060504.js"
+    },
+    {
+        "path": "https://cdn.jsdelivr.net/gh/highsource/ogc-schemas@2.6.1/scripts/lib/ISO19139_GMD_20060504.js"
+    },
+    {
+        "path": "https://cdn.jsdelivr.net/gh/highsource/ogc-schemas@2.6.1/scripts/lib/ISO19139_GCO_20060504.js"
+    },
+    {
+        "path": "https://cdn.jsdelivr.net/gh/highsource/ogc-schemas@2.6.1/scripts/lib/GML_3_2_0.js"
+    },
+    {
       "path": "https://maps.googleapis.com/maps/api/js?v=3.36&key=INSERT_YOUR_API_KEY_HERE",
       "remote": true
     },

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -261,7 +261,9 @@ Ext.define('CpsiMapview.factory.Layer', {
             isNumericDependent: Ext.isDefined(layerConf.numericitem), // TODO docs
             isWms: true, // TODO docs
             styles: layerConf.styles, // TODO docs
-            activatedStyle: activatedStyle
+            activatedStyle: activatedStyle,
+            url: layerConf.url,
+            layers: olSourceConf.params.LAYERS
         };
         olLayerConf = Ext.apply(olLayerConf, olLayerProps);
 

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -708,7 +708,9 @@ Ext.define('CpsiMapview.factory.Layer', {
             stylesBaseUrl: layerConf.stylesBaseUrl || '',
             toolTipConfig: layerConf.tooltipsConfig,
             sldUrl: layerConf.sldUrl,
-            sldUrlLabel: layerConf.sldUrlLabel
+            sldUrlLabel: layerConf.sldUrlLabel,
+            baseurl: layerConf.baseurl,
+            layerIdentificationName: layerConf.layerIdentificationName
         };
         olLayerConf = Ext.apply(olLayerConf, olLayerProps);
 

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -118,6 +118,8 @@ Ext.define('CpsiMapview.factory.Layer', {
             mapLayer.set('featureInfoWindow', layerConf.featureInfoWindow);
             // attribute grouping config
             mapLayer.set('grouping', layerConf.grouping);
+            // if layer has metadata
+            mapLayer.set('hasMetadata', layerConf.hasMetadata);
         }
 
         return mapLayer;

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -76,7 +76,8 @@ Ext.define('CpsiMapview.view.LayerTree', {
                         'cmv_menuitem_layerrefresh',
                         'cmv_menuitem_layerlabels',
                         'cmv_menuitem_layeropacity',
-                        'cmv_menuitem_layergrid'
+                        'cmv_menuitem_layergrid',
+                        'cmv_menuitem_layermetadata'
                     ]
                 }, {
                     ptype: 'cmv_tree_inresolutionrange'

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -12,6 +12,7 @@ Ext.define('CpsiMapview.view.LayerTree', {
         'CpsiMapview.view.menuitem.LayerLabels',
         'CpsiMapview.view.menuitem.LayerOpacity',
         'CpsiMapview.view.menuitem.LayerGrid',
+        'CpsiMapview.view.menuitem.LayerMetadata',
         'CpsiMapview.plugin.TreeColumnStyleSwitcher',
         'CpsiMapview.controller.LayerTreeController',
         'CpsiMapview.view.window.MinimizableWindow',

--- a/app/view/menuitem/LayerMetadata.js
+++ b/app/view/menuitem/LayerMetadata.js
@@ -1,0 +1,173 @@
+/**
+ * MenuItem to show a metadata window for a layer
+ *
+ * @class CpsiMapview.view.menuitem.LayerMetadata
+ */
+Ext.define('CpsiMapview.view.menuitem.LayerMetadata', {
+    extend: 'Ext.menu.Item',
+    xtype: 'cmv_menuitem_layermetadata',
+    requires: [
+        'CpsiMapview.util.Layer'
+    ],
+
+    /**
+     * The connected layer for this item.
+     *
+     * @cfg {ol.layer.Base}
+     */
+    layer: null,
+
+    /**
+     * Text shown in this MenuItem
+     * @cfg {String}
+     */
+    text: 'Metadata',
+
+    /**
+     * @private
+     */
+    initComponent: function () {
+        var me = this;
+
+        me.handler = me.handlerFunc;
+
+        me.callParent();
+    },
+
+    /**
+     * Executed when this menu item is clicked.
+     * Opens a window with metadata for the connected layer.
+     */
+    handlerFunc: function () {
+        var me = this;
+
+        /**
+         * Helper function to notify user
+         * that metadata is not availble
+         */
+        function alert_no_metadata(){
+            alert('No metadata available.');
+        }
+
+        // retrive layername for different types of layers
+        var layerName;
+        if(me.layer.get('isWfs')){
+            layerName = me.layer.get('featureType');
+        }
+        else if(me.layer.get('isWms')){
+            layerName = me.layer.get('layers');
+        }
+        else{
+            // Currently only metadata from WMS and WFS can be received
+            // because other layers do not come from MapServer
+            // VectorTiles are an exception: the config does
+            // not provide easy access to name and baseurl
+            alert_no_metadata();
+
+            return;
+        }
+
+        // build url to Metadata XML
+        var baseurl = me.layer.get('url');
+        var requestUrl = baseurl + '&REQUEST=GetMetadata' + '&layer=' + layerName;
+
+        Ext.Ajax.request({
+            url: requestUrl,
+            success: function (response) {
+
+                var xmlText = response.responseText;
+                var schemas =[
+                    ISO19139_GMD_20060504,
+                    ISO19139_GCO_20060504,
+                    ISO19139_GTS_20060504,
+                    ISO19139_GSS_20060504,
+                    ISO19139_GSR_20060504,
+                    GML_3_2_0,
+                    XLink_1_0
+                ];
+
+                // convert XML to JSON
+                var context = new Jsonix.Context(schemas);
+                var unmarshaller = context.createUnmarshaller();
+
+                // handle case if XML is not formated as expected
+                try{
+                    var jsonMetadata = unmarshaller.unmarshalString(xmlText);
+
+                    // extract required properties
+                    var relevantObj = jsonMetadata.value.identificationInfo[0].abstractMDIdentification.value;
+
+                    var source = {};
+
+                    // citation
+                    var citationObj = relevantObj.citation.ciCitation.title.characterString;
+                    if(citationObj){
+                        var citation = citationObj.value;
+                        source['title'] = citation;
+                    }
+
+                    // abstract
+                    var abstractObj = relevantObj._abstract.characterString;
+                    if(abstractObj){
+                        var abstract = abstractObj.value;
+                        source['abstract'] = abstract;
+                    }
+                    // keywords
+                    var keywordString = '';
+                    var keywordsObj = relevantObj.descriptiveKeywords;
+                    if(keywordsObj){
+                        var rawKeywords = keywordsObj[0].mdKeywords.keyword;
+                        // convert keywords to comma separated string
+                        Ext.each(rawKeywords, function(item){
+                            var extractedKeyWord = item.characterString.value;
+                            if(keywordString !== ''){
+                                keywordString = keywordString + ', ';
+                            }
+                            keywordString = keywordString + extractedKeyWord;
+                        }
+                        );
+                        source['keywords'] = keywordString;
+                    }
+
+                    // case no metadata could be extracted
+                    if(Ext.Object.isEmpty(source)){
+                        alert_no_metadata();
+                    }
+                    // metadata is fine and can be displayed
+                    else{
+                        var windowTitle = 'Metadata '+ me.layer.get('name');
+
+                        // check if window already exists
+                        // identified by window title
+                        var existingMetadataWindow = Ext.ComponentQuery.query('window[title="' + windowTitle + '"]');
+
+                        var window;
+                        if(existingMetadataWindow.length > 0){
+                            // use existing window
+                            window = existingMetadataWindow[0];
+                        }
+                        else {
+                            window = Ext.create('CpsiMapview.view.window.MinimizableWindow', {
+                                title: windowTitle,
+                                width: 400,
+                                layout: 'fit',
+                                constrain: true,
+                                items: [{
+                                    xtype: 'propertygrid',
+                                    source: source
+                                }]
+                            });
+                        }
+                        window.show();
+                    }
+                }
+                catch(err) {
+                    alert_no_metadata();
+                }
+            },
+            failure: function() {
+                alert_no_metadata();
+            }
+        });
+    }
+});

--- a/app/view/menuitem/LayerMetadata.js
+++ b/app/view/menuitem/LayerMetadata.js
@@ -51,11 +51,18 @@ Ext.define('CpsiMapview.view.menuitem.LayerMetadata', {
 
         // retrive layername for different types of layers
         var layerName;
+        var baseurl;
         if(me.layer.get('isWfs')){
             layerName = me.layer.get('featureType');
+            baseurl = me.layer.get('url');
         }
         else if(me.layer.get('isWms')){
             layerName = me.layer.get('layers');
+            baseurl = me.layer.get('url');
+        }
+        else if(me.layer.get('isVt')){
+            layerName = me.layer.get('layerIdentificationName');
+            baseurl = me.layer.get('baseurl');
         }
         else{
             // Currently only metadata from WMS and WFS can be received
@@ -67,7 +74,6 @@ Ext.define('CpsiMapview.view.menuitem.LayerMetadata', {
         }
 
         // build url to Metadata XML
-        var baseurl = me.layer.get('url');
         var requestUrl = baseurl + '&REQUEST=GetMetadata' + '&layer=' + layerName;
 
         Ext.Ajax.request({

--- a/app/view/menuitem/LayerMetadata.js
+++ b/app/view/menuitem/LayerMetadata.js
@@ -31,7 +31,15 @@ Ext.define('CpsiMapview.view.menuitem.LayerMetadata', {
 
         me.handler = me.handlerFunc;
 
+        var hasMetadata = false;
+        if (me.layer) {
+            hasMetadata = me.layer.get('hasMetadata');
+        }
+
         me.callParent();
+
+        me.setHidden(!hasMetadata);
+
     },
 
     /**
@@ -126,7 +134,7 @@ Ext.define('CpsiMapview.view.menuitem.LayerMetadata', {
                     }
                     // metadata is fine and can be displayed
                     else{
-                        var windowTitle = 'Metadata '+ me.layer.get('name');
+                        var windowTitle = me.layer.get('name') + ' Metadata' ;
 
                         // check if window already exists
                         // identified by window title

--- a/app/view/menuitem/LayerMetadata.js
+++ b/app/view/menuitem/LayerMetadata.js
@@ -174,6 +174,6 @@ Ext.define('CpsiMapview.view.menuitem.LayerMetadata', {
     * Notifies user that metadata is not availble
     */
     alertNoMetadata: function(){
-        alert('No metadata available.');
+        Ext.Msg.alert('Info', 'Metadata is not available.');
     }
 });

--- a/app/view/menuitem/LayerMetadata.js
+++ b/app/view/menuitem/LayerMetadata.js
@@ -37,9 +37,7 @@ Ext.define('CpsiMapview.view.menuitem.LayerMetadata', {
         }
 
         me.callParent();
-
         me.setHidden(!hasMetadata);
-
     },
 
     /**

--- a/app/view/menuitem/LayerMetadata.js
+++ b/app/view/menuitem/LayerMetadata.js
@@ -41,14 +41,6 @@ Ext.define('CpsiMapview.view.menuitem.LayerMetadata', {
     handlerFunc: function () {
         var me = this;
 
-        /**
-         * Helper function to notify user
-         * that metadata is not availble
-         */
-        function alert_no_metadata(){
-            alert('No metadata available.');
-        }
-
         // retrive layername for different types of layers
         var layerName;
         if(me.layer.get('isWfs')){
@@ -62,8 +54,7 @@ Ext.define('CpsiMapview.view.menuitem.LayerMetadata', {
             // because other layers do not come from MapServer
             // VectorTiles are an exception: the config does
             // not provide easy access to name and baseurl
-            alert_no_metadata();
-
+            me.alertNoMetadata();
             return;
         }
 
@@ -131,7 +122,7 @@ Ext.define('CpsiMapview.view.menuitem.LayerMetadata', {
 
                     // case no metadata could be extracted
                     if(Ext.Object.isEmpty(source)){
-                        alert_no_metadata();
+                        me.alertNoMetadata();
                     }
                     // metadata is fine and can be displayed
                     else{
@@ -162,12 +153,19 @@ Ext.define('CpsiMapview.view.menuitem.LayerMetadata', {
                     }
                 }
                 catch(err) {
-                    alert_no_metadata();
+                    me.alertNoMetadata();
                 }
             },
             failure: function() {
-                alert_no_metadata();
+                me.alertNoMetadata();
             }
         });
+    },
+
+    /**
+    * Notifies user that metadata is not availble
+    */
+    alertNoMetadata: function(){
+        alert('No metadata available.');
     }
 });

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -297,6 +297,8 @@
       "layerKey": "WATERWAYS_VTWMS",
       "url": "https://w08-mapserver.compass.ie/mapserver/?map=/MapServer/apps/mapview-demo/example.map&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=true&LAYERS=waterways&TILED=false&CRS=EPSG%3A3857&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&STYLES=Waterways&FORMAT=mvt",
       "hasMetadata": true,
+      "baseurl": "https://w08-mapserver.compass.ie/mapserver/?map=/MapServer/apps/mapview-demo/example.map&",
+      "layerIdentificationName": "waterways",
       "openLayers": {
         "visibility": false
       },

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -207,6 +207,7 @@
         {
           "layerType": "wms",
           "layerKey": "WATERBODY_SWITCH_LAYER_FAR",
+          "hasMetadata": true,
           "serverOptions": {
             "layers": "waterbodies"
           },
@@ -222,6 +223,7 @@
         {
           "layerType": "wfs",
           "layerKey": "WATERBODY_SWITCH_LAYER_CLOSE",
+          "hasMetadata": true,
           "geometryProperty": "msGeometry",
           "featureType": "waterbodies",
           "noCluster": true,
@@ -255,6 +257,7 @@
       "layerKey": "BOREHOLE_WFS",
       "geometryProperty": "msGeometry",
       "featureType": "Boreholes",
+      "hasMetadata": true,
       "openLayers": {
         "opacity": 0.9,
         "visibility": false
@@ -266,6 +269,8 @@
     {
       "layerType": "wms",
       "layerKey": "BOREHOLE_WMS",
+      "featureType": "Boreholes",
+      "hasMetadata": true,
       "serverOptions": {
         "layers": "Boreholes",
         "version": "1.3.0"
@@ -291,6 +296,7 @@
       "layerType": "vtwms",
       "layerKey": "WATERWAYS_VTWMS",
       "url": "https://w08-mapserver.compass.ie/mapserver/?map=/MapServer/apps/mapview-demo/example.map&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=true&LAYERS=waterways&TILED=false&CRS=EPSG%3A3857&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&STYLES=Waterways&FORMAT=mvt",
+      "hasMetadata": true,
       "openLayers": {
         "visibility": false
       },
@@ -320,6 +326,7 @@
       "layerKey": "RUINS_WFS",
       "geometryProperty": "msGeometry",
       "featureType": "ruins",
+      "hasMetadata": true,
       "sldUrl": "https://w08-mapserver.compass.ie/mapserver/?map=/MapServer/apps/mapview-demo/example.map&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&LAYERS=ruins",
       "tooltipsConfig": [
         {


### PR DESCRIPTION
resolves #240 

It shows the "Metadata" option for all layers, like specified in the description. 

However, metadata can only be retrieved for WMS and WFS layers from MapServer. 

Metadata for Vectortiles could also be possible, but the layername and the baseurl are difficult to extract, since they are not separetely added in the config file (like for WMS and WFS). Both layername and baseurl could of course be extracted from the connection-url:
`https://w08-mapserver.compass.ie/mapserver/?map=/MapServer/apps/mapview-demo/example.map&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=true&LAYERS=waterways&TILED=false&CRS=EPSG%3A3857&WIDTH={width}&HEIGHT={height}&BBOX={bbox}&STYLES=Waterways&FORMAT=mvt`
However, it might be more elegant and consistent to provide the layername and the baseurl directly in the config file. 

If no metadata is available, an alert window is shown. This is probably not the behavior you would like for long term.
@geographika what is your preferred way to display "no metadata"? 