### PR TITLE
Make style switcher usable in LayerTree context menu

### DIFF
--- a/app/data/model/LayerTreeNode.js
+++ b/app/data/model/LayerTreeNode.js
@@ -26,6 +26,41 @@ Ext.define('CpsiMapview.data.model.LayerTreeNode', {
             name: '__toggleMode',
             type: 'string',
             defaultValue: 'ol3'
+        },
+        {
+            // overwrite the text property to add custom behaviour
+            name: 'text',
+            type: 'string',
+            persist: false,
+            convert: function(v, record) {
+                if (!v) {
+                    // folders / LayerGroups
+                    var layerGroup = record.getOlLayer();
+                    if (layerGroup) {
+                        return record.getOlLayer().get('name');
+                    }
+                }
+
+                // add layer style to node text if we have the style chooser
+                // in the context menu and not as direct item under the node
+                var layerTree = Ext.ComponentQuery.query('cmv_layertree')[0];
+                if (layerTree && layerTree.styleSwitcherBelowNode === false) {
+
+                    var olLayer = record.getOlLayer();
+                    if (olLayer && olLayer.get('activatedStyle')) {
+                        // get activate style
+                        var activeStyle = olLayer.get('activatedStyle');
+                        var styleTitle = CpsiMapview.util.Style.getLayerStyleTitle(activeStyle, olLayer);
+                        // apply node name + style name
+                        var treeNodeConf = olLayer.get('_origTreeConf');
+                        if (treeNodeConf && treeNodeConf.text && styleTitle) {
+                            return treeNodeConf.text + ' (' + styleTitle + ')';
+                        }
+                    }
+                }
+
+                return v;
+            }
         }
     ],
 

--- a/app/data/model/LayerTreeNode.js
+++ b/app/data/model/LayerTreeNode.js
@@ -28,7 +28,7 @@ Ext.define('CpsiMapview.data.model.LayerTreeNode', {
             defaultValue: 'ol3'
         },
         {
-            // overwrite the text property to add custom behaviour
+            // overwrite the text property to add custom behavior
             name: 'text',
             type: 'string',
             persist: false,
@@ -48,7 +48,7 @@ Ext.define('CpsiMapview.data.model.LayerTreeNode', {
 
                     var olLayer = record.getOlLayer();
                     if (olLayer && olLayer.get('activatedStyle')) {
-                        // get activate style
+                        // get activated layer style
                         var activeStyle = olLayer.get('activatedStyle');
                         var styleTitle = CpsiMapview.util.Style.getLayerStyleTitle(activeStyle, olLayer);
                         // apply node name + style name

--- a/app/util/Style.js
+++ b/app/util/Style.js
@@ -15,7 +15,7 @@ Ext.define('CpsiMapview.util.Style', {
      * types we return the input value.
      *
      * @param  {String} layerStyle The style name to get the label for
-     * @param  {ol.layer.Base} layerStyle The layer to get style label for
+     * @param  {ol.layer.Base} layer The layer to get style label for
      * @return {String} Human readable label
      */
     getLayerStyleLabel: function (layerStyle, layer) {
@@ -34,7 +34,7 @@ Ext.define('CpsiMapview.util.Style', {
      * style label (by #getLayerStyleLabel) is returned.
      *
      * @param  {String} layerStyle The style name to get the title for
-     * @param  {ol.layer.Base} layerStyle The layer to get style title for
+     * @param  {ol.layer.Base} layer The layer to get style title for
      * @return {String}            Human readable title
      */
     getLayerStyleTitle: function (layerStyleName, layer) {

--- a/app/util/Style.js
+++ b/app/util/Style.js
@@ -1,0 +1,62 @@
+/**
+ * Util class for style related functions.
+ *
+ * @class CpsiMapview.util.Style
+ */
+Ext.define('CpsiMapview.util.Style', {
+    alternateClassName: 'StyleUtil',
+    requires: [],
+
+    singleton: true,
+
+    /**
+     * Returns the human readable label for the given layer style.
+     * If WFS or VT we remove the '_' and the .xml file ending. For other layer
+     * types we return the input value.
+     *
+     * @param  {String} layerStyle The style name to get the label for
+     * @param  {ol.layer.Base} layerStyle The layer to get style label for
+     * @return {String} Human readable label
+     */
+    getLayerStyleLabel: function (layerStyle, layer) {
+        if (layer.get('isWfs') || layer.get('isVt')) {
+            // remove _ and the .xml file ending
+            var legendUtil = CpsiMapview.util.Legend;
+            return legendUtil.getWmsStyleFromSldFile(layerStyle);
+        } else {
+            return layerStyle;
+        }
+    },
+
+    /**
+     * Returns the human readable title for the given layer style.
+     * Either the explicit title property of the style config or the derived
+     * style label (by #getLayerStyleLabel) is returned.
+     *
+     * @param  {String} layerStyle The style name to get the title for
+     * @param  {ol.layer.Base} layerStyle The layer to get style title for
+     * @return {String}            Human readable title
+     */
+    getLayerStyleTitle: function (layerStyleName, layer) {
+        var me = CpsiMapview.util.Style;
+        var layerStyles = layer.get('styles');
+        var layerTitle = null;
+
+        Ext.each(layerStyles, function (layerStyle) {
+            // get the relevant style definition
+            if (layerStyle === layerStyleName ||
+                layerStyle.name === layerStyleName) {
+                if (layerStyle['title'] && layerStyle['name']) {
+                    // has title property
+                    layerTitle = layerStyle['title'];
+                } else {
+                    // does not have title property
+                    // title generated from style name
+                    layerTitle = me.getLayerStyleLabel(layerStyle, layer);
+                }
+            }
+        });
+
+        return layerTitle;
+    }
+});

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -121,6 +121,16 @@ Ext.define('CpsiMapview.view.LayerTree', {
     },
 
     /**
+     * Refreshes the rendering of the tree layer node text for the given layer.
+     *
+     * @param {ol.layer.Base} layer The layer to update the node text
+     */
+    refreshLayerNodeText: function (layer) {
+        var node = this.getNodeForLayer(layer);
+        node.set('text', node.get('text'));
+    },
+
+    /**
      * Gets the layer node UI for the given layer.
      *
      * @param  {ol.layer.Base} layer The layer to update in the tree

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -49,7 +49,7 @@ Ext.define('CpsiMapview.view.LayerTree', {
         /**
          * Steers if the style switcher radio groups are directly rendered under
          * the corresponding layer tree node (`true`) or if they are provided in
-         * the context menu.
+         * the context menu (`false`).
          * @cfg
          */
         styleSwitcherBelowNode: false
@@ -77,8 +77,7 @@ Ext.define('CpsiMapview.view.LayerTree', {
                 flex: 1,
                 plugins: [{
                     ptype: 'cmv_basic_tree_column_legend'
-                },
-                {
+                }, {
                     ptype: 'cmv_tree_column_context_menu',
                     menuItems: [
                         'cmv_menuitem_layerrefresh',
@@ -93,13 +92,18 @@ Ext.define('CpsiMapview.view.LayerTree', {
         ]
     },
 
+    /**
+     * @private
+     */
     initComponent: function () {
         var me = this;
 
-        // add plugin or context menu item to show style switcher radio groups
+        // decide where to render style switcher radio groups
         if (me.styleSwitcherBelowNode) {
+            // add plugin to render style switcher permanently below tree nodes
             me.columns.items[0].plugins.push({ptype: 'cmv_tree_column_style_switcher'});
         } else {
+            // add context menu item showing the style switcher
             Ext.each(me.columns.items[0].plugins, function (plugin) {
                 if (plugin.ptype === 'cmv_tree_column_context_menu') {
                     plugin.menuItems.push('cmv_menuitem_layer_styleswitcher');
@@ -121,7 +125,7 @@ Ext.define('CpsiMapview.view.LayerTree', {
     },
 
     /**
-     * Refreshes the rendering of the tree layer node text for the given layer.
+     * Refreshes the rendering of the layer tree node text for the given layer.
      *
      * @param {ol.layer.Base} layer The layer to update the node text
      */

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -12,6 +12,7 @@ Ext.define('CpsiMapview.view.LayerTree', {
         'CpsiMapview.view.menuitem.LayerLabels',
         'CpsiMapview.view.menuitem.LayerOpacity',
         'CpsiMapview.view.menuitem.LayerGrid',
+        'CpsiMapview.view.menuitem.LayerStyleSwitcher',
         'CpsiMapview.plugin.TreeColumnStyleSwitcher',
         'CpsiMapview.controller.LayerTreeController',
         'CpsiMapview.view.window.MinimizableWindow',
@@ -43,7 +44,15 @@ Ext.define('CpsiMapview.view.LayerTree', {
             items: [{
                 xtype: 'cmv_add_wms_form'
             }]
-        }
+        },
+
+        /**
+         * Steers if the style switcher radio groups are directly rendered under
+         * the corresponding layer tree node (`true`) or if they are provided in
+         * the context menu.
+         * @cfg
+         */
+        styleSwitcherBelowNode: false
     },
     hideHeaders: true,
     lines: false,
@@ -68,9 +77,8 @@ Ext.define('CpsiMapview.view.LayerTree', {
                 flex: 1,
                 plugins: [{
                     ptype: 'cmv_basic_tree_column_legend'
-                }, {
-                    ptype: 'cmv_tree_column_style_switcher'
-                }, {
+                },
+                {
                     ptype: 'cmv_tree_column_context_menu',
                     menuItems: [
                         'cmv_menuitem_layerrefresh',
@@ -83,6 +91,23 @@ Ext.define('CpsiMapview.view.LayerTree', {
                 }]
             }
         ]
+    },
+
+    initComponent: function () {
+        var me = this;
+
+        // add plugin or context menu item to show style switcher radio groups
+        if (me.styleSwitcherBelowNode) {
+            me.columns.items[0].plugins.push({ptype: 'cmv_tree_column_style_switcher'});
+        } else {
+            Ext.each(me.columns.items[0].plugins, function (plugin) {
+                if (plugin.ptype === 'cmv_tree_column_context_menu') {
+                    plugin.menuItems.push('cmv_menuitem_layer_styleswitcher');
+                }
+            });
+        }
+
+        me.callParent(arguments);
     },
 
     /**

--- a/app/view/layer/StyleSwitcherRadioGroup.js
+++ b/app/view/layer/StyleSwitcherRadioGroup.js
@@ -34,6 +34,7 @@ Ext.define('CpsiMapview.view.layer.StyleSwitcherRadioGroup', {
      */
     initComponent: function () {
         var me = this;
+        var styleUtil = CpsiMapview.util.Style;
         var radioButtons = [];
         var layerStyles = me.layer.get('styles');
         var salt = Math.random();
@@ -52,7 +53,7 @@ Ext.define('CpsiMapview.view.layer.StyleSwitcherRadioGroup', {
             } else {
                 // does not have title property
                 // title generated from stlye name
-                layerTitle = me.getLayerStyleLabel(layerStyle);
+                layerTitle = styleUtil.getLayerStyleLabel(layerStyle, me.layer);
                 layerName = layerStyle;
             }
 
@@ -72,24 +73,6 @@ Ext.define('CpsiMapview.view.layer.StyleSwitcherRadioGroup', {
         me.items = radioButtons;
 
         me.callParent();
-    },
-
-    /**
-     * Returns the human readable label for the given style.
-     * If WFS or VT we remove the '_' and the .xml file ending. For other layer types
-     * we return the input value.
-     *
-     * @param  {String} layerStyle The style name to get the label for
-     * @return {String}            Human readable label
-     */
-    getLayerStyleLabel: function (layerStyle) {
-        if (this.layer.get('isWfs') || this.layer.get('isVt')) {
-            // remove _ and the .xml file ending
-            var legendUtil = CpsiMapview.util.Legend;
-            return legendUtil.getWmsStyleFromSldFile(layerStyle);
-        } else {
-            return layerStyle;
-        }
     },
 
     /**

--- a/app/view/layer/StyleSwitcherRadioGroup.js
+++ b/app/view/layer/StyleSwitcherRadioGroup.js
@@ -30,6 +30,14 @@ Ext.define('CpsiMapview.view.layer.StyleSwitcherRadioGroup', {
     },
 
     /**
+     * Flag indicating if this radio group is directly rendered below the
+     * corresponding layer tree node (`true`) or within the context menu
+     * (`false`).
+     * @cfg
+     */
+    renderedBelowTreeNode: true,
+
+    /**
      * @private
      */
     initComponent: function () {
@@ -73,6 +81,11 @@ Ext.define('CpsiMapview.view.layer.StyleSwitcherRadioGroup', {
         me.items = radioButtons;
 
         me.callParent();
+
+        if (me.renderedBelowTreeNode === false) {
+            // adjust layout for usage in menu item
+            me.setStyle('paddingLeft', '5px');
+        }
     },
 
     /**
@@ -102,6 +115,7 @@ Ext.define('CpsiMapview.view.layer.StyleSwitcherRadioGroup', {
      */
     onStyleChange: function (radioBtn, newVal) {
         var me = this;
+        var styleUtil = CpsiMapview.util.Style;
 
         if (newVal === true) {
             var layer = me.layer;
@@ -161,6 +175,9 @@ Ext.define('CpsiMapview.view.layer.StyleSwitcherRadioGroup', {
             } else {
                 Ext.Logger.info('Layer type not supported in StyleSwitcherRadioGroup');
             }
+
+            var styleTitle = styleUtil.getLayerStyleTitle(newStyle, layer);
+            me.fireEvent('cmv-layer-style-change', me, newStyle, styleTitle, layer);
         }
     }
 });

--- a/app/view/menuitem/LayerStyleSwitcher.js
+++ b/app/view/menuitem/LayerStyleSwitcher.js
@@ -1,0 +1,68 @@
+/**
+ * MenuItem to show ...
+ *
+ * @class CpsiMapview.view.menuitem.LayerStyleSwitcher
+ */
+Ext.define('CpsiMapview.view.menuitem.LayerStyleSwitcher', {
+    extend: 'Ext.menu.Item',
+    xtype: 'cmv_menuitem_layer_styleswitcher',
+    requires: [],
+
+    /**
+     * The connected layer for this item.
+     *
+     * @cfg {ol.layer.Base}
+     */
+    layer: null,
+
+    /**
+     * Text shown in this MenuItem
+     * @cfg {String}
+     */
+    text: 'Styles',
+
+
+    /**
+     * @private
+     */
+    initComponent: function () {
+        var me = this;
+        var allow = false;
+
+        if (me.layer) {
+            allow = me.layer.get('styles');
+        }
+
+        if (allow) {
+            var radioGroup = Ext.create('CpsiMapview.view.layer.StyleSwitcherRadioGroup', {
+                layer: me.layer,
+                renderedBelowTreeNode: false,
+                listeners: {
+                    'cmv-layer-style-change': me.onLayerStyleChange
+                }
+            });
+
+            me.menu = {
+                plain: true,
+                items: [radioGroup]
+            };
+        }
+
+        me.callParent();
+
+        me.setHidden(!allow);
+    },
+
+    /**
+     * Handler for 'cmv-layer-style-change' event of the underlying
+     * StyleSwitcherRadioGroup.
+     *
+     * @param {CpsiMapview.view.layer.StyleSwitcherRadioGroup} radioGrp
+     * @param {String} newStyle Style name (foo_bar.xml)
+     * @param {String} newStyleTitle Style title (human readable - 'My Style')
+     * @param {ol.layer.Base} layer The layer where the style changed
+     */
+    onLayerStyleChange: function () {
+        // TODO react on changed style
+    }
+});

--- a/app/view/menuitem/LayerStyleSwitcher.js
+++ b/app/view/menuitem/LayerStyleSwitcher.js
@@ -1,5 +1,5 @@
 /**
- * MenuItem to show ...
+ * MenuItem to show a radio group in order to switch the style for the layer.
  *
  * @class CpsiMapview.view.menuitem.LayerStyleSwitcher
  */

--- a/app/view/menuitem/LayerStyleSwitcher.js
+++ b/app/view/menuitem/LayerStyleSwitcher.js
@@ -62,7 +62,10 @@ Ext.define('CpsiMapview.view.menuitem.LayerStyleSwitcher', {
      * @param {String} newStyleTitle Style title (human readable - 'My Style')
      * @param {ol.layer.Base} layer The layer where the style changed
      */
-    onLayerStyleChange: function () {
-        // TODO react on changed style
+    onLayerStyleChange: function (radioGrp, newStyle, newStyleTitle, layer) {
+        var layerTree = Ext.ComponentQuery.query('cmv_layertree')[0];
+        if (layerTree) {
+            layerTree.refreshLayerNodeText(layer);
+        }
     }
 });

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -158,12 +158,12 @@
       "styles": [
         {
           "name": "Test_Gas.xml",
-          "title": "Test GAS",
+          "title": "Gas Style",
           "label": "Test_Gas_label.xml"
         },
         {
           "name": "Test_Alternative_Gas_Style.xml",
-          "title": "CUSTOM TITLE",
+          "title": "Another Style",
           "label": "Test_Alternative_Gas_Style_label.xml"
         }
       ],


### PR DESCRIPTION
This makes the RadioGroup to switch between styles (normally rendered under the corresponding layer tree node) usable in the context menu of the tree node. By setting the config property `styleSwitcherBelowNode` to false for the LayerTree will force the rendering in the context menu. Setting it to `true` (default) will enforce the old behavior.

This is related to #274 since this should bring better perfomance for the LayerTree since the radios are not rendered directly at the node and the update frequency should be lower. Also should improve the jumping behavior as reported in #287.   

This also ensures that the activated style is shown next to the layer name in the layer tree node for the case that the style switcher is only available in the context menu and not permanently visible.

![304-style-radio-ctx-menu](https://user-images.githubusercontent.com/1185547/96874512-79609000-1476-11eb-891b-fc8ca383e460.gif)

Closes #304.