### PR TITLE
Ensure map tools are re-enabled when buttons are destroyed

### DIFF
--- a/app/controller/button/DigitizeButtonController.js
+++ b/app/controller/button/DigitizeButtonController.js
@@ -727,22 +727,33 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
      * Remove the interaction when this component gets destroyed
      */
     onBeforeDestroy: function () {
-        if (this.drawInteraction) {
-            this.map.removeInteraction(this.drawInteraction);
-        }
-        if (this.modifyInteraction) {
-            this.map.removeInteraction(this.modifyInteraction);
-        }
-        if (this.drawLayer) {
-            this.map.removeLayer(this.drawLayer);
-        }
-        if (this.resultLayer) {
-            this.map.removeLayer(this.resultLayer);
+
+        var me = this;
+        var btn = me.getView();
+
+        // detoggle button
+        me.onToggle(btn, false);
+
+        if (me.drawInteraction) {
+            me.map.removeInteraction(me.drawInteraction);
         }
 
-        if (this.circleToolbar) {
-            this.circleToolbar.destroy();
+        if (me.modifyInteraction) {
+            me.map.removeInteraction(me.modifyInteraction);
         }
+
+        if (me.drawLayer) {
+            me.map.removeLayer(me.drawLayer);
+        }
+
+        if (me.resultLayer) {
+            me.map.removeLayer(me.resultLayer);
+        }
+
+        if (me.circleToolbar) {
+            me.circleToolbar.destroy();
+        }
+
     },
 
     /**

--- a/app/controller/button/FeatureSelectionButtonController.js
+++ b/app/controller/button/FeatureSelectionButtonController.js
@@ -230,6 +230,14 @@ Ext.define('CpsiMapview.controller.button.FeatureSelectionButtonController', {
         }
         // sets the ID filter in the grid
         view.fireEvent('cmv-id-filter-set', extInFilter);
+    },
+
+    onBeforeDestroy: function () {
+        var me = this;
+        var btn = me.getView();
+
+        // detoggle button
+        me.onBtnToggle(btn, false);
     }
 
 });

--- a/app/controller/button/StreetViewTool.js
+++ b/app/controller/button/StreetViewTool.js
@@ -171,13 +171,13 @@ Ext.define('CpsiMapview.controller.button.StreetViewTool', {
      */
     onBeforeDestroy: function () {
         var me = this;
-        var view = me.getView();
+        var btn = me.getView();
 
         // detoggle button, forces clearing layer
-        me.onToggle(view, false);
+        me.onToggle(btn, false);
         // remove GMaps events
         me.unregisterGmapsEvents();
-        // cleanup window
+        // clean-up window
         if (me.streetViewWin) {
             me.streetViewWin.close();
             me.streetViewWin = null;

--- a/app/view/button/SpatialQueryButton.js
+++ b/app/view/button/SpatialQueryButton.js
@@ -144,6 +144,7 @@ Ext.define('CpsiMapview.view.button.SpatialQueryButton', {
         clearAssociatedPermanentLayer: 'onClearAssociatedPermanentLayer',
         hideAssociatedPermanentLayer: 'onHideAssociatedPermanentLayer',
         showAssociatedPermanentLayer: 'onShowAssociatedPermanentLayer',
+        beforedestroy: 'onBeforeDestroy'
     },
 
     bind: {
@@ -155,14 +156,6 @@ Ext.define('CpsiMapview.view.button.SpatialQueryButton', {
     *
     * @cfg {Boolean} triggerWfsRequest Whether or not to trigger a Wfs GetFeatures request
     */
-    triggerWfsRequest: true,
-
-    /**
-     * Initializes this component
-     */
-    initComponent: function () {
-        var me = this;
-        me.callParent();
-    }
+    triggerWfsRequest: true
 
 });


### PR DESCRIPTION
Call the de-toggle methods in the `onBeforeDestroy` handler to ensure `defaultClickEnabled` is set back to `true` when buttons are destroyed when their parent forms are destroyed. 