### PR TITLE
Update OpenLayers config options

### DIFF
--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -814,10 +814,6 @@ Ext.define('CpsiMapview.factory.Layer', {
             visible: ol2Conf.visibility,
             maxResolution: maxRes,
             minResolution: minRes
-            // no OL >=v3 pendant mapped yet
-            // numZoomLevels: ol2Conf.numZoomLevels,
-            // zoomOffset: ol2Conf.zoomOffset,
-            // resolutions: ol2Conf.resolutions
         };
         return olProps;
     },

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -812,6 +812,7 @@ Ext.define('CpsiMapview.factory.Layer', {
         var olProps = {
             opacity: ol2Conf.opacity,
             visible: ol2Conf.visibility,
+            extent: ol2Conf.extent, // undefined if not set
             maxResolution: maxRes,
             minResolution: minRes
         };

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -13,7 +13,6 @@
     "osm": {
       "isBaseLayer": true,
       "openLayers": {
-        "numZoomLevels": 20,
         "opacity": 0.7,
         "visibility": false
       }
@@ -72,11 +71,9 @@
       },
       "openLayers": {
         "maxResolution": 1222.99245234375,
-        "numZoomLevels": 12,
         "opacity": 0.7,
         "projection": "EPSG:900913",
-        "visibility": false,
-        "zoomOffset": 7
+        "visibility": false
       }
     },
     {
@@ -89,11 +86,9 @@
       },
       "openLayers": {
         "maxResolution": 1222.99245234375,
-        "numZoomLevels": 12,
         "opacity": 0.7,
         "projection": "EPSG:900913",
-        "visibility": false,
-        "zoomOffset": 7
+        "visibility": false
       }
     },
     {
@@ -106,11 +101,9 @@
       },
       "openLayers": {
         "maxResolution": 1222.99245234375,
-        "numZoomLevels": 12,
         "opacity": 0.7,
         "projection": "EPSG:900913",
-        "visibility": false,
-        "zoomOffset": 7
+        "visibility": false
       }
     },
     {
@@ -123,11 +116,9 @@
       },
       "openLayers": {
         "maxResolution": 1222.99245234375,
-        "numZoomLevels": 12,
         "opacity": 0.7,
         "projection": "EPSG:900913",
-        "visibility": false,
-        "zoomOffset": 7
+        "visibility": false
       }
     },
     {
@@ -143,7 +134,6 @@
       "noCluster": true,
       "openLayers": {
         "maxResolution": 1222.99245234375,
-        "numZoomLevels": 12,
         "opacity": 0.7,
         "projection": "EPSG:900913",
         "visibility": false
@@ -193,7 +183,6 @@
       ],
       "openLayers": {
         "maxResolution": 1222.99245234375,
-        "numZoomLevels": 12,
         "opacity": 0.7,
         "projection": "EPSG:900913",
         "visibility": false


### PR DESCRIPTION
Remove references to legacy OL2 properties - `numZoomLevels`, `zoomOffset`, and `resolutions`, and add in an `extent` option. 