### PR TITLE
Expander ExtJS bug workaround

### DIFF
--- a/app/plugin/ExpandPanel.js
+++ b/app/plugin/ExpandPanel.js
@@ -54,7 +54,9 @@ Ext.define('CpsiMapview.plugin.ExpandPanel', {
         me.maxedWin = Ext.create('Ext.window.Window', {
             maximized: true,
             closable: false,
-
+            // the empty config object this avoids occasional errors mentioned 
+            // in https://forum.sencha.com/forum/showthread.php?469880-Cannot-read-property-viewModel-of-null
+            config: {},
             tools: [
                 {
                     type: 'restore',

--- a/app/plugin/ExpandPanel.js
+++ b/app/plugin/ExpandPanel.js
@@ -54,7 +54,7 @@ Ext.define('CpsiMapview.plugin.ExpandPanel', {
         me.maxedWin = Ext.create('Ext.window.Window', {
             maximized: true,
             closable: false,
-            // the empty config object this avoids occasional errors mentioned 
+            // the empty config object this avoids occasional errors mentioned
             // in https://forum.sencha.com/forum/showthread.php?469880-Cannot-read-property-viewModel-of-null
             config: {},
             tools: [


### PR DESCRIPTION
Add empty config as workaround for Cannot read property viewModel of null. 

See https://forum.sencha.com/forum/showthread.php?469880-Cannot-read-property-viewModel-of-null
Creating an empty config object on the window prevents this error. 