### PR TITLE
Set Expander window to modal

### DIFF
--- a/app/plugin/ExpandPanel.js
+++ b/app/plugin/ExpandPanel.js
@@ -54,7 +54,7 @@ Ext.define('CpsiMapview.plugin.ExpandPanel', {
         me.maxedWin = Ext.create('Ext.window.Window', {
             maximized: true,
             closable: false,
-
+            modal: true,
             tools: [
                 {
                     type: 'restore',


### PR DESCRIPTION
In some situations* the underlying parent form appears on top of the expanded window. The `modal` setting *seems* to stop this. 

*may be related to using a grid row editor and cancelling or updating the edit after expanding the grid. 