### PR TITLE
Login form validation modified

### DIFF
--- a/app/controller/form/Login.js
+++ b/app/controller/form/Login.js
@@ -12,8 +12,15 @@ Ext.define('CpsiMapview.controller.form.Login', {
         }
     },
 
-    onLoginClick: function () {
-        this.attemptLogin();
+    onLoginClick: function (btn, e, eOpts) {
+        var form = btn.up('form');
+        var valid = true;
+        Ext.each(form.down('textfield'), function(field) {
+            valid = valid && !Ext.isEmpty(field.value);
+        });
+        if (valid) {
+            this.attemptLogin();
+        }
     },
 
     /**

--- a/app/view/form/Login.js
+++ b/app/view/form/Login.js
@@ -42,7 +42,6 @@ Ext.define('CpsiMapview.view.form.Login', {
             html: '<a href="/ManagementTool/Account/ForgotPassword" target="_blank">Forgotten Password?</a>'
         }, '->', {
             text: 'Login',
-            formBind: true,
             listeners: {
                 click: 'onLoginClick'
             }


### PR DESCRIPTION
Some users experienced an issue where the password manager of their browser would fill in the credentials for them, but the UI wouldn't react properly since no "event" (typing) actually occurred on the form, hence the native validation wouldn't kick in and the "Login" button wouldn't be enabled for them.