### PR TITLE
File upload fixed

### DIFF
--- a/app/view/fileupload/FileUploadWindow.js
+++ b/app/view/fileupload/FileUploadWindow.js
@@ -32,20 +32,20 @@ Ext.define('CpsiMapview.view.fileupload.FileUploadWindow', {
                     xtype: 'textfield',
                     name: 'documentName',
                     itemId: 'documentName',
-                    fieldLabel: 'Name',
+                    fieldLabel: 'Name*',
                     emptyText: 'Enter a name for the document...'
                 },
                 {
                     xtype: 'textfield',
                     name: 'documentDescription',
                     itemId: 'documentDescription',
-                    fieldLabel: 'Description',
+                    fieldLabel: 'Description*',
                     emptyText: 'Enter a description for the document...'
                 },
                 {
                     xtype: 'fileuploadfield',
                     emptyText: 'Select a file',
-                    fieldLabel: 'Document',
+                    fieldLabel: 'Document*',
                     name: 'filePath',
                     itemId: 'filePath',
                     buttonConfig: {

--- a/app/view/fileupload/FileUploadWindowController.js
+++ b/app/view/fileupload/FileUploadWindowController.js
@@ -69,7 +69,7 @@ Ext.define('CpsiMapview.view.fileupload.FileUploadWindowController', {
                     // after it was successfully associated
                     // with the parent object. This record can then be added to a store
                     var newFiledata = {
-                        attachementId: action.result.data.attachmentId,
+                        attachmentId: action.result.data.attachmentId,
                         name: name,
                         description: descrip,
                         extension: 'Extension',


### PR DESCRIPTION
Fixed a typo that prevented the attachments from being downloaded immediately after the upload. Also 'asterisks' added to fields label to highlight mandatory fields.