### PR TITLE
Fire restore event before parent window is destroyed in CpsiMapview.plugin.ExpandPanel

### DIFF
--- a/app/plugin/ExpandPanel.js
+++ b/app/plugin/ExpandPanel.js
@@ -85,11 +85,15 @@ Ext.define('CpsiMapview.plugin.ExpandPanel', {
         var cmp = this.getCmp();
 
         me.parentPanel.insert(me.positionInParentPanel, cmp);
-        this.maxedWin.close();
-
         me.maxTool.show();
 
         cmp.fireEvent('restore', cmp);
         me.parentPanel.fireEvent('restore', cmp);
+
+        setTimeout(function () {
+            me.maxedWin.close();
+        }, 0);
+
+
     }
 });

--- a/app/plugin/ExpandPanel.js
+++ b/app/plugin/ExpandPanel.js
@@ -54,7 +54,6 @@ Ext.define('CpsiMapview.plugin.ExpandPanel', {
         me.maxedWin = Ext.create('Ext.window.Window', {
             maximized: true,
             closable: false,
-            modal: true,
             tools: [
                 {
                     type: 'restore',


### PR DESCRIPTION
The parent window appearing through the expanded window seems to be caused by the menu keeping a reference to its initial parent and not by #336 (which has been rolled back).

Resetting the menu on the button after the expander panel has been created and also on the restore (using `expand` and `restore` gets around the issue:

```
        var destroyMenu = false;
        menuButton.setMenu(menuButton.getMenu(), destroyMenu);
```

However on the `restore` event we need to make sure the expand window has not yet been destroyed or there are errors relating to resetting the z-indexes - hence destroying the window once the event has been fired. 