### PR TITLE
Restore Minimizable window before closing

### DIFF
--- a/app/controller/window/MinimizableWindow.js
+++ b/app/controller/window/MinimizableWindow.js
@@ -7,10 +7,16 @@ Ext.define('CpsiMapview.controller.window.MinimizableWindow', {
     alias: 'controller.cmv_minimizable_window',
 
     /**
-     * Create a hook for derived classes to add additional onClose
-     * functionality
+     * When closing the window in code make
+     * sure that the window is restored first so
+     * no orphaned toolbar window buttons are left behind
      */
-    onClose: Ext.emptyFn,
+    onClose: function () {
+        var me = this;
+        // trigger the restoreFromWindow to remove any associated toolbar
+        // button if the window is minimised
+        me.onShow();
+    },
 
     /**
      * Sets the window invisible and calls the addMinimizedWindow event


### PR DESCRIPTION
Trigger the restoreFromWindow to remove any associated toolbar button if the window is minimized.
If not an orphaned button remains that causes JS errors when clicked. 

This error was noticed when running https://github.com/compassinformatics/cpsi-mapview/blob/6447240404553f0fe66d9f0134eb8cecc69ac3fd/app/controller/button/StreetViewTool.js#L155