### PR TITLE
Update cache keys to clear cache

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,9 @@ steps:
     cacheHitVar: CACHE_RESTORED
   displayName: 'Get Cached ExtJS Framework'
 
-- powershell: Invoke-WebRequest -Uri "http://cdn.sencha.com/ext/gpl/ext-$($env:SENCHA_EXT_VERSION)-gpl.zip" -OutFile "ExtJS.zip"
+# http://cdn.sencha.com/ext/gpl/ext-6.2.0-gpl.zip
+#- powershell: Invoke-WebRequest -Uri "http://cdn.sencha.com/ext/gpl/ext-$($env:SENCHA_EXT_VERSION)-gpl.zip" -OutFile "ExtJS.zip"
+- powershell: Invoke-WebRequest -Uri "http://w08-mapserver.compass.ie/sencha/ext-$($env:SENCHA_EXT_VERSION)-gpl.zip" -OutFile "ExtJS.zip"
   condition: ne(variables.CACHE_RESTORED, 'true')
   displayName: 'Download ExtJS Framework'
 
@@ -53,7 +55,9 @@ steps:
     cacheHitVar: CMD_CACHE_RESTORED
   displayName: 'Get Cached SenchaCmd'
 
-- powershell: Invoke-WebRequest -Uri "http://cdn.sencha.com/cmd/$($env:SENCHA_CMD_VERSION)/jre/SenchaCmd-$($env:SENCHA_CMD_VERSION)-windows-64bit.zip" -OutFile "SenchaCmd.zip"
+# http://cdn.sencha.com/cmd/6.5.2/jre/SenchaCmd-6.5.2-windows-64bit.zip
+#- powershell: Invoke-WebRequest -Uri "http://cdn.sencha.com/cmd/$($env:SENCHA_CMD_VERSION)/jre/SenchaCmd-$($env:SENCHA_CMD_VERSION)-windows-64bit.zip" -OutFile "SenchaCmd.zip"
+- powershell: Invoke-WebRequest -Uri "http://w08-mapserver.compass.ie/sencha/SenchaCmd-$($env:SENCHA_CMD_VERSION)-windows-64bit.zip" -OutFile "SenchaCmd.zip"
   condition: ne(variables.CMD_CACHE_RESTORED, 'true')
   displayName: 'Download SenchaCmd'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,8 +15,7 @@ pool:
 variables:
     SENCHA_EXT_VERSION: '6.2.0'
     SENCHA_CMD_VERSION: '6.5.2'
-    ProgressPreference: 'SilentlyContinue'
-    
+
 # first get the ExtJS framework and unzip it, unless this has already been cached
 steps:
 - task: CacheBeta@1
@@ -27,8 +26,9 @@ steps:
   displayName: 'Get Cached ExtJS Framework'
 
 # http://cdn.sencha.com/ext/gpl/ext-6.2.0-gpl.zip
-#- powershell: Invoke-WebRequest -Uri "http://cdn.sencha.com/ext/gpl/ext-$($env:SENCHA_EXT_VERSION)-gpl.zip" -OutFile "ExtJS.zip"
-- powershell: Invoke-WebRequest -Uri "http://w08-mapserver.compass.ie/sencha/ext-$($env:SENCHA_EXT_VERSION)-gpl.zip" -OutFile "ExtJS.zip"
+- powershell: |
+    $progressPreference = 'silentlyContinue'
+    Invoke-WebRequest -Uri "http://cdn.sencha.com/ext/gpl/ext-$($env:SENCHA_EXT_VERSION)-gpl.zip" -OutFile "ExtJS.zip"
   condition: ne(variables.CACHE_RESTORED, 'true')
   displayName: 'Download ExtJS Framework'
 
@@ -56,8 +56,9 @@ steps:
   displayName: 'Get Cached SenchaCmd'
 
 # http://cdn.sencha.com/cmd/6.5.2/jre/SenchaCmd-6.5.2-windows-64bit.zip
-#- powershell: Invoke-WebRequest -Uri "http://cdn.sencha.com/cmd/$($env:SENCHA_CMD_VERSION)/jre/SenchaCmd-$($env:SENCHA_CMD_VERSION)-windows-64bit.zip" -OutFile "SenchaCmd.zip"
-- powershell: Invoke-WebRequest -Uri "http://w08-mapserver.compass.ie/sencha/SenchaCmd-$($env:SENCHA_CMD_VERSION)-windows-64bit.zip" -OutFile "SenchaCmd.zip"
+- powershell: |
+    $progressPreference = 'silentlyContinue'
+    Invoke-WebRequest -Uri "http://cdn.sencha.com/cmd/$($env:SENCHA_CMD_VERSION)/jre/SenchaCmd-$($env:SENCHA_CMD_VERSION)-windows-64bit.zip" -OutFile "SenchaCmd.zip"
   condition: ne(variables.CMD_CACHE_RESTORED, 'true')
   displayName: 'Download SenchaCmd'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ pool:
 variables:
     SENCHA_EXT_VERSION: '6.2.0'
     SENCHA_CMD_VERSION: '6.5.2'
-    ProgressPreference = 'SilentlyContinue'
+    ProgressPreference: 'SilentlyContinue'
     
 # first get the ExtJS framework and unzip it, unless this has already been cached
 steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,9 +15,9 @@ pool:
 variables:
     SENCHA_EXT_VERSION: '6.2.0'
     SENCHA_CMD_VERSION: '6.5.2'
-
+    ProgressPreference = 'SilentlyContinue'
+    
 # first get the ExtJS framework and unzip it, unless this has already been cached
-
 steps:
 - task: CacheBeta@1
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ variables:
 steps:
 - task: CacheBeta@1
   inputs:
-    key: ext
+    key: ext-6-2-0
     path: $(System.DefaultWorkingDirectory)/ext
     cacheHitVar: CACHE_RESTORED
   displayName: 'Get Cached ExtJS Framework'
@@ -48,7 +48,7 @@ steps:
 
 - task: CacheBeta@1
   inputs:
-    key: sencha-cmd
+    key: sencha-cmd-6-5-2
     path: $(System.DefaultWorkingDirectory)/sencha-cmd
     cacheHitVar: CMD_CACHE_RESTORED
   displayName: 'Get Cached SenchaCmd'


### PR DESCRIPTION
Azure Pipelines keeps failing - possible due to a corrupt zip in the cache
Updating keys should clear the cache (there is no way in the UI according to https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops#can-i-clear-a-cache