### PR TITLE
Allow styles to be configured on button

### DIFF
--- a/app/controller/button/DigitizeButtonController.js
+++ b/app/controller/button/DigitizeButtonController.js
@@ -111,7 +111,8 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
             } else {
                 me.drawLayer = new ol.layer.Vector({
                     source: new ol.source.Vector(),
-                    displayInLayerSwitcher: false
+                    displayInLayerSwitcher: false,
+                    style: view.getDrawLayerStyle()
                 });
                 me.map.addLayer(me.drawLayer);
             }
@@ -789,24 +790,8 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
             return rec.get('geometry').getType() !== 'Point';
         });
 
-        var selectStyle = new ol.style.Style({
-            image: new ol.style.Circle({
-                radius: 5,
-                fill: new ol.style.Fill({
-                    color: 'red'
-                }),
-                stroke: new ol.style.Stroke({
-                    color: 'red'
-                })
-            }),
-            width: 2,
-            fill: new ol.style.Fill({
-                color: 'red'
-            }),
-            stroke: new ol.style.Stroke({
-                color: 'red'
-            })
-        });
+        var view = me.getView();
+        var selectStyle = view.getResultLayerSelectStyle();
 
         if (me.win) {
             me.win.destroy();

--- a/app/view/button/DigitizeButton.js
+++ b/app/view/button/DigitizeButton.js
@@ -43,7 +43,7 @@ Ext.define('CpsiMapview.view.button.DigitizeButton', {
         multi: false,
 
         /**
-         * URL needs to be set on instanciation of button
+         * URL needs to be set on instantiation of button
          */
         apiUrl: null,
 
@@ -71,6 +71,45 @@ Ext.define('CpsiMapview.view.button.DigitizeButton', {
             }),
             stroke: new ol.style.Stroke({
                 color: 'orange'
+            })
+        }),
+
+        /**
+        * The default style to use when features are selected
+        * in the result layer
+        */
+        drawLayerStyle: new ol.style.Style({
+            image: new ol.style.Circle({
+                radius: 5,
+                fill: new ol.style.Fill({
+                    color: 'red'
+                }),
+                stroke: new ol.style.Stroke({
+                    color: 'red'
+                })
+            })
+        }),
+
+        /**
+         * The default style to use when features are selected
+         * in the result layer
+         */
+        resultLayerSelectStyle: new ol.style.Style({
+            image: new ol.style.Circle({
+                radius: 5,
+                fill: new ol.style.Fill({
+                    color: 'red'
+                }),
+                stroke: new ol.style.Stroke({
+                    color: 'red'
+                })
+            }),
+            width: 2,
+            fill: new ol.style.Fill({
+                color: 'red'
+            }),
+            stroke: new ol.style.Stroke({
+                color: 'red'
             })
         }),
 


### PR DESCRIPTION
The draw layer style and results selection style can now both be set when configuring the button, rather than hard-coded in the controller