### PR TITLE
Only set defaultClickEnabled to true if a tool has been activated

### DIFF
--- a/app/controller/button/DigitizeButtonController.js
+++ b/app/controller/button/DigitizeButtonController.js
@@ -198,7 +198,15 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
                 me.map.set('defaultClickEnabled', false);
             }, 0);
         } else {
+            // only reset the defaultClickEnabled on the map if the tool
+            // was already active - as this function is called in onBeforeDestroy
+            // this is not always the case
+            if (me.drawInteraction.getActive() === true) {
+                me.map.set('defaultClickEnabled', true);
+            }
+
             me.drawInteraction.setActive(false);
+
             if (type !== 'Circle') {
                 me.modifyInteraction.setActive(false);
                 me.snapInteraction.setActive(false);
@@ -220,7 +228,6 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
                 me.activeGroupIdx = 0;
                 me.contextMenuGroupsCounter = 0;
             }
-            me.map.set('defaultClickEnabled', true);
         }
     },
 

--- a/app/controller/button/FeatureSelectionButtonController.js
+++ b/app/controller/button/FeatureSelectionButtonController.js
@@ -41,7 +41,7 @@ Ext.define('CpsiMapview.controller.button.FeatureSelectionButtonController', {
         var ownerGrid = this.getView().up('grid');
         if (ownerGrid) {
             // reset FIDs if grid clears its filters
-            ownerGrid.on('cmv-clear-filters', function() {
+            ownerGrid.on('cmv-clear-filters', function () {
                 me.fidsToFilter = [];
             });
         }
@@ -84,14 +84,16 @@ Ext.define('CpsiMapview.controller.button.FeatureSelectionButtonController', {
 
             me.map.on('click', me.onMapClick, me);
         } else {
-            me.modeSelector.hide();
-
-            me.map.un('click', me.onMapClick, me);
 
             setTimeout(function () {
-                // enable default GetFeatureInfo click tool
-                me.map.set('defaultClickEnabled', true);
+                // enable default GetFeatureInfo click tool if it was already active
+                if (me.modeSelector) {
+                    me.map.set('defaultClickEnabled', true);
+                }
             }, 0);
+
+            me.modeSelector.hide();
+            me.map.un('click', me.onMapClick, me);
         }
 
     },
@@ -184,7 +186,7 @@ Ext.define('CpsiMapview.controller.button.FeatureSelectionButtonController', {
 
         // collect all IDs of clicked features
         var clickedFeatureIds = [];
-        me.map.forEachFeatureAtPixel(evt.pixel, function(feature, layer) {
+        me.map.forEachFeatureAtPixel(evt.pixel, function (feature, layer) {
             // add check for correct layer
             if (layer && view.queryLayer && (layer.id === view.queryLayer.id)) {
 
@@ -220,7 +222,7 @@ Ext.define('CpsiMapview.controller.button.FeatureSelectionButtonController', {
         var uniqueFids = Ext.Array.unique(me.fidsToFilter);
         var extInFilter = new Ext.util.Filter({
             property: me.idProperty,
-            value   : uniqueFids,
+            value: uniqueFids,
             operator: 'in'
         });
 

--- a/app/controller/button/SpatialQueryButton.js
+++ b/app/controller/button/SpatialQueryButton.js
@@ -154,8 +154,10 @@ Ext.define('CpsiMapview.controller.button.SpatialQueryButtonController', {
                 view.queryFeatures.on('add', me.getGeometryFromPolygonAndTriggerWfs, me);
             }
         } else {
-            // re-enable any other map tools
-            me.map.set('defaultClickEnabled', true);
+            // re-enable any other map tools if this tool was active
+            if (me.drawQueryInteraction.getActive() === true) {
+                me.map.set('defaultClickEnabled', true);
+            }
 
             me.drawQueryInteraction.setActive(false);
             if (view.displayPermanently) {

--- a/app/controller/button/StreetViewTool.js
+++ b/app/controller/button/StreetViewTool.js
@@ -147,18 +147,21 @@ Ext.define('CpsiMapview.controller.button.StreetViewTool', {
             }, 100);
         } else {
             if (overlayLayers) {
-                overlayLayers.remove(me.vectorLayer);
+                if (overlayLayers.remove(me.vectorLayer)) {
+                    // re-enable any other map tools if the tool had been activated
+                    // we can check this as me.vectorLayer will have been added and remove
+                    // returns a layer when found
+                    setTimeout(function () {
+                        me.map.set('defaultClickEnabled', true);
+                    }, 0);
+                }
             }
+
             // cleanup
             me.vectorLayer.getSource().clear();
             if (me.streetViewWin) {
                 me.streetViewWin.close();
             }
-
-            // re-enable any other map tools
-            setTimeout(function () {
-                me.map.set('defaultClickEnabled', true);
-            }, 0);
         }
 
         // activate / deactivate click


### PR DESCRIPTION
Currently if a button is on a form, and is never activated, if the form is closed then the `defaultClickEnabled` is set back to true, even if another tool is active. 
The feature info tool then becomes active along with another active tool.
This pull request ensures the `defaultClickEnabled` is only set when the tool was actually active to avoid this. 

**TODO** there is still an issue that buttons are in a toggle group so activating one sets `defaultClickEnabled` to true which then triggers the `onToggle` of another button which sets it back to false. 