### PR TITLE
Only show Gazetteer dropdown when text is entered

### DIFF
--- a/app/view/combo/Gazetteer.js
+++ b/app/view/combo/Gazetteer.js
@@ -46,14 +46,22 @@ Ext.define('CpsiMapview.view.combo.Gazetteer', {
             })
         });
 
-        me.on('beforequery', function () {
-            var val = this.getRawValue();
-            var url = me.url + encodeURIComponent(val.trim());
-            me.getStore().getProxy().setUrl(url);
-        });
-
-        me.on('afterrender', function () {
-            me.locationLayer.set('displayInLayerSwitcher', false);
+        me.on({
+            beforequery: function () {
+                var val = this.getRawValue();
+                if (val) {
+                    // only trigger a request if text has been entered
+                    var url = me.url + encodeURIComponent(val.trim());
+                    me.getStore().getProxy().setUrl(url);
+                    return true;
+                } else {
+                    return false;
+                }
+            },
+            afterrender: function () {
+                // don't display the layer in the layer tree
+                me.locationLayer.set('displayInLayerSwitcher', false);
+            }
         });
 
         me.callParent();
@@ -67,7 +75,7 @@ Ext.define('CpsiMapview.view.combo.Gazetteer', {
      * @param  {Ext.data.Model} rec The data record containing raw data
      * @return {ol.Extent}          The created ol.Extent
      */
-    convertToExtent: function(v, rec) {
+    convertToExtent: function (v, rec) {
         var minx = rec.get('minX3857');
         var miny = rec.get('minY3857');
         var maxx = rec.get('maxX3857');

--- a/app/view/combo/Gazetteer.js
+++ b/app/view/combo/Gazetteer.js
@@ -46,9 +46,20 @@ Ext.define('CpsiMapview.view.combo.Gazetteer', {
             })
         });
 
+        me.callParent();
+
         me.on({
             beforequery: function () {
                 var val = this.getRawValue();
+                // set a key on the layer using the unique id of the combo
+                me.locationLayer.set('layerKey', me.id);
+                if (Ext.isEmpty(BasiGX.util.Layer.getLayersBy('layerKey', me.id))) {
+                    // if the layer is not yet in the map then add it
+                    if (me.map) {
+                        me.map.addLayer(me.locationLayer);
+                    }
+                }
+
                 if (val) {
                     // only trigger a request if text has been entered
                     var url = me.url + encodeURIComponent(val.trim());
@@ -64,7 +75,6 @@ Ext.define('CpsiMapview.view.combo.Gazetteer', {
             }
         });
 
-        me.callParent();
     },
 
     /**


### PR DESCRIPTION
Avoid an empty loading store when clicking the dropdown arrow.

![image](https://user-images.githubusercontent.com/490840/101743861-1af57c80-3acb-11eb-9b17-2eddf17472c8.png)
