### PR TITLE
Add custom object to featuresupdated event with modification details

### DIFF
--- a/app/controller/button/DigitizeButtonController.js
+++ b/app/controller/button/DigitizeButtonController.js
@@ -771,7 +771,7 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
             var originalSolverPoints = me.getSolverPoints();
             var originalLength = 0;
 
-            // get the original solver points
+            // get the original solver points before they are removed
             var resultSource = me.resultLayer.getSource();
             // remove all features from the current active group
             var allFeatures = me.resultLayer.getSource().getFeatures();
@@ -784,7 +784,7 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
             // add the new features for the current active group
             resultSource.addFeatures(features);
 
-            // now get the new solver points to see which points have been modified
+            // now get the new solver points once they have been added
             var newSolverPoints = me.getSolverPoints();
             var newLength = 0;
 

--- a/app/controller/button/DigitizeButtonController.js
+++ b/app/controller/button/DigitizeButtonController.js
@@ -551,7 +551,7 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
      */
     onCircleSelectApply: function (feat) {
         var me = this;
-        var evt = {feature: feat};
+        var evt = { feature: feat };
         me.handleDrawEnd(evt);
         me.removeCircleSelectToolbar();
         me.drawInteraction.setActive(true);
@@ -641,7 +641,7 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
         // unit of the projection. In order to convert it into a geoJSON, we have
         // to convert the circle to a polygon first.
         var circleAsPolygon = new ol.geom.Polygon.fromCircle(feat.getGeometry());
-        var polygonAsFeature = new ol.Feature({geometry: circleAsPolygon});
+        var polygonAsFeature = new ol.Feature({ geometry: circleAsPolygon });
 
         return this.getNetByPolygon(polygonAsFeature);
     },
@@ -767,19 +767,43 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
     handleFinalResult: function (features) {
         if (features) {
             var me = this;
+
+            var originalSolverPoints = me.getSolverPoints();
+            var originalLength = 0;
+
+            // get the original solver points
             var resultSource = me.resultLayer.getSource();
             // remove all features from the current active group
             var allFeatures = me.resultLayer.getSource().getFeatures();
             Ext.each(allFeatures, function (f) {
                 if (f.get('group') === me.activeGroupIdx) {
+                    originalLength += f.get('length') ? f.get('length') : 0;
                     resultSource.removeFeature(f);
                 }
             });
             // add the new features for the current active group
             resultSource.addFeatures(features);
+
+            // now get the new solver points to see which points have been modified
+            var newSolverPoints = me.getSolverPoints();
+            var newLength = 0;
+
+            Ext.each(features, function (f) {
+                newLength += f.get('length') ? f.get('length') : 0;
+            });
+
+            var modifications = {
+                originalLength: originalLength,
+                newLength: newLength,
+                originalSolverPoints: originalSolverPoints,
+                newSolverPoints: newSolverPoints
+            };
+
             // fire a custom event from the source so a listener can be added once
             // all features have been added/removed
-            resultSource.dispatchEvent('featuresupdated');
+            // the event object includes a custom modifications object containing
+            // details of before and after the solve
+            resultSource.dispatchEvent({ type: 'featuresupdated', modifications: modifications });
 
             // The response from the API, parsed as OpenLayers features, will be
             // fired here and the event can be used application-wide to access


### PR DESCRIPTION
The custom `featuresupdated` event now includes a `modifications` object which returns the original length prior to the solve, and the new length (to be able to make comparisons), and also the original solver points and new solver points. This allows listeners to see if the start or end moved (and also any of the other points between). 

Example of checking if a point has moved:

```
var modified = false;
// measures can be different on successive calls without moving
// due to floating point / accuracy
// e.g. 456.20598813959714 !== 456.2058558695877
if (p1.get('edge_id') !== p2.get('edge_id') ||
    Math.round(p1.get('measure_along')) !== Math.round(p2.get('measure_along'))) {
    modified = true;
}
```