### PR TITLE
Add StreetView icon layer root map if no overlay group is provided

### DIFF
--- a/app/controller/button/StreetViewTool.js
+++ b/app/controller/button/StreetViewTool.js
@@ -134,6 +134,8 @@ Ext.define('CpsiMapview.controller.button.StreetViewTool', {
         var overlayLayers;
         if (overlayGroup) {
             overlayLayers = overlayGroup.getLayers();
+        } else{
+            overlayLayers = me.map.getLayers();
         }
 
         if (pressed) {


### PR DESCRIPTION
If `layerGroupName` is not set the icon layer is never added to the map and is not displayed. This pull request adds it directly to the map in this case. 

```js
            {
                xtype: 'cmv_streetview_tool',
                toggleGroup: 'map',
                layerGroupName: 'Layers' // no longer required if adding directly to map and hiding from the layer true
            }]
```