### PR TITLE
Deactivate Spatial Tool on Close rather than Hide

### DIFF
--- a/app/view/menuitem/LayerGrid.js
+++ b/app/view/menuitem/LayerGrid.js
@@ -83,7 +83,10 @@ Ext.define('CpsiMapview.view.menuitem.LayerGrid', {
                     xtype: gridXType
                 }],
                 listeners: {
-                    hide: function () {
+                    minimize: Ext.emptyFn,
+                    close: function () {
+                        // hide the spatial tool only when closed rather than when
+                        // minimising the window
                         var me = this;
                         var queryButton = me.down('cmv_spatial_query_button');
                         if (queryButton !== null) {


### PR DESCRIPTION
Allow the spatial selection tool to remain active when the window is minimised rather than closed. 