### PR TITLE
Reuse the Info window, limit its height, and add scrolling

### DIFF
--- a/app/plugin/FeatureInfoWindow.js
+++ b/app/plugin/FeatureInfoWindow.js
@@ -130,8 +130,9 @@ Ext.define('CpsiMapview.plugin.FeatureInfoWindow', {
     openFeatureInfoWindow: function () {
         var me = this;
 
-        // fix the maxHeight of the window to 80% of the viewport height
-        var maxHeight = Ext.getBody().getViewSize().height * 0.8;
+        // set the initial height of the window to 80% of the viewport height
+        // a user is then free to resize as they wish
+        var height = Ext.getBody().getViewSize().height * 0.8;
 
         if (this.window) {
             this.window.removeAll(true);
@@ -140,7 +141,7 @@ Ext.define('CpsiMapview.plugin.FeatureInfoWindow', {
                 title: 'Feature Information',
                 closeAction: 'hide', // reuse the window for all requests so a user can fix the position
                 scollable: true,
-                maxHeight: maxHeight,
+                height: height,
                 width: 400,
                 layout: {
                     type: 'accordion',

--- a/app/plugin/FeatureInfoWindow.js
+++ b/app/plugin/FeatureInfoWindow.js
@@ -130,11 +130,17 @@ Ext.define('CpsiMapview.plugin.FeatureInfoWindow', {
     openFeatureInfoWindow: function () {
         var me = this;
 
+        // fix the maxHeight of the window to 80% of the viewport height
+        var maxHeight = Ext.getBody().getViewSize().height * 0.8;
+
         if (this.window) {
             this.window.removeAll(true);
         } else {
             this.window = Ext.create('CpsiMapview.view.window.MinimizableWindow', {
                 title: 'Feature Information',
+                closeAction: 'hide', // reuse the window for all requests so a user can fix the position
+                scollable: true,
+                maxHeight: maxHeight,
                 width: 400,
                 layout: {
                     type: 'accordion',
@@ -144,7 +150,6 @@ Ext.define('CpsiMapview.plugin.FeatureInfoWindow', {
             });
 
             this.window.on('close', function () {
-                me.window = null;
                 me.highlightSource.clear();
             });
         }


### PR DESCRIPTION
This ensures the form cannot get larger than the window when many fields are returned, and allows the user to position the window without it re-opening it in the centre every time it is closed. 