### PR TITLE
Only update permalink when the map state changes

### DIFF
--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -326,7 +326,9 @@ Ext.define('CpsiMapview.view.main.Map', {
 
         // update permalink when visible map state changes
         me.permalinkProvider.on('statechange', function (stateProvider, stateId, state) {
-            me.updatePermalink(state);
+            if (stateId === 'cmv_mapstate') {
+                me.updatePermalink(state);
+            }
         });
 
         // restore the view state when navigating through the history, see


### PR DESCRIPTION
Currently any state change triggers the event, and causes the following error as the state object is expected to contain center etc. 

`[E] Error while running task - TypeError: Cannot read property '0' of undefined`
