### PR TITLE
Fix IE11 "null" displaying on measure strings

### DIFF
--- a/app/controller/MapController.js
+++ b/app/controller/MapController.js
@@ -41,6 +41,10 @@ Ext.define('CpsiMapview.controller.MapController', {
      * @param {Ext.button.Button} btn The measure button
      */
     initializeMeasureBtn: function (btn) {
+
+        // avoid showing "null" in IE11 by setting to an empty string
+        btn.getViewModel().set('clickToDrawText', '');
+
         btn.setBind({
             text: '{measureTooltext}',
             tooltip: btn.measureType === 'line' ? '{lineMeasureTooltip}' :


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/490840/110668850-08730800-81cc-11eb-99e0-827556e06b60.png)
