### PR TITLE
Use cmv-mapclick for handling feature info clicks

### DIFF
--- a/app/plugin/FeatureInfoWindow.js
+++ b/app/plugin/FeatureInfoWindow.js
@@ -25,11 +25,12 @@ Ext.define('CpsiMapview.plugin.FeatureInfoWindow', {
         var me = this;
 
         var mapComp = me.getCmp();
+        var mapPanel = mapComp.up('cmv_map');
         var map = mapComp.getMap();
 
-        map.on('singleclick', function (evt) {
+        mapPanel.on('cmv-mapclick', function (clickedFeatures, evt) {
             if (map.get('defaultClickEnabled')) {
-                me.requestFeatureInfos(evt);
+                me.requestFeatureInfos(clickedFeatures, evt);
             }
         });
     },
@@ -39,7 +40,7 @@ Ext.define('CpsiMapview.plugin.FeatureInfoWindow', {
      * open a window and display the information
      * @param {ol.MapBrowserEvent} evt
      */
-    requestFeatureInfos: function (evt) {
+    requestFeatureInfos: function (clickedFeatures, evt) {
         var me = this;
 
         var mapComp = me.getCmp();


### PR DESCRIPTION
Switch the `CpsiMapview.plugin.FeatureInfoWindow` plugin from using a map `singleclick` event to using the `cmv-mapclick` event. 
This allows more fine-grained control over when the feature tool is activated. For example a derived application can implement a listener such as:

```js
    listeners: {
        'cmv-mapclick': {
            fn: 'onMapClick',
            options: {
                priority: 500
            }
        }
    },
```

To allow clicking on vector features. The `onMapClick` function can then return `false` to prevent the feature info window from popping up. 
