### PR TITLE
Fix WFS layer switching cache

### DIFF
--- a/app/plugin/BasicTreeColumnLegends.js
+++ b/app/plugin/BasicTreeColumnLegends.js
@@ -56,6 +56,13 @@ Ext.define('CpsiMapview.plugin.BasicTreeColumnLegends', {
                 if (styles) {
                     layerKey += styles.toUpperCase();
                 }
+            } else {
+                // for WFS we also use the WMS legend so make sure we create a cache
+                // key for these or it will always use just the layerKey
+                var activatedStyle = layer.get('activatedStyle');
+                if (activatedStyle) {
+                    layerKey += LegendUtil.getWmsStyleFromSldFile(activatedStyle);
+                }
             }
 
             var legendUrl = layer.get('legendUrl');


### PR DESCRIPTION
When switching styles on a WFS/vector layer, the legend is cached with just the layer name as it has no `layer.getSource().getParams` like a WMS layer. 
The same legend is then used for all styles when switching. 
This pull request checks for an `activatedStyle` (set by the switcher) and then uses this in addition to the layer name to set the cache key. 