### PR TITLE
Fix switch layer legend caching

### DIFF
--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -1018,9 +1018,9 @@ Ext.define('CpsiMapview.factory.Layer', {
                         Ext.Logger.info('Layer type not supported in StyleSwitcherRadioGroup');
                     }
 
-                    overlayCollection.setAt(index, newLayer);
                     newLayer.set('activatedStyle', activeStyle);
-
+                    // setting a layer will trigger legend creations etc. so make sure activeStyle is set prior to this
+                    overlayCollection.setAt(index, newLayer);
                     LayerFactory.updateLayerTreeForSwitchLayers();
 
                 }

--- a/app/plugin/BasicTreeColumnLegends.js
+++ b/app/plugin/BasicTreeColumnLegends.js
@@ -54,14 +54,14 @@ Ext.define('CpsiMapview.plugin.BasicTreeColumnLegends', {
             if (layer.getSource && layer.getSource().getParams) {
                 var styles = layer.getSource().getParams().STYLES;
                 if (styles) {
-                    layerKey += styles.toUpperCase();
+                    layerKey += '_' +  styles.toUpperCase();
                 }
             } else {
                 // for WFS we also use the WMS legend so make sure we create a cache
                 // key for these or it will always use just the layerKey
                 var activatedStyle = layer.get('activatedStyle');
                 if (activatedStyle) {
-                    layerKey += LegendUtil.getWmsStyleFromSldFile(activatedStyle);
+                    layerKey += '_' + LegendUtil.getWmsStyleFromSldFile(activatedStyle).toUpperCase();
                 }
             }
 
@@ -90,7 +90,7 @@ Ext.define('CpsiMapview.plugin.BasicTreeColumnLegends', {
 
                 // check if there is an ongoing loading for the legend of this layer
                 // since getLegendHtml is executed several times for one refresh due to
-                // unkwon reasons
+                // unknown reasons
                 // Flag set / reset in LegendUtil.getLegendImgHtmlTpl
                 var isLoading = LegendUtil['legendLoading_' + layerKey];
                 if (isLoading) {

--- a/app/view/layer/StyleSwitcherRadioGroup.js
+++ b/app/view/layer/StyleSwitcherRadioGroup.js
@@ -90,7 +90,7 @@ Ext.define('CpsiMapview.view.layer.StyleSwitcherRadioGroup', {
 
     /**
      * Detects the checked state of the given style name based on the layer's
-     * current acive style (property 'activatedStyle').
+     * current active style (property 'activatedStyle').
      *
      * @param  {String} sldStyle The style name to get the checked state for
      * @return {Boolean}         Checked state


### PR DESCRIPTION
TLDR: When resolution changes for a switch layer the incorrect legend was cached.

Moving from WFS to WMS, the old layer key was used as the new one had not been set. Then `getLegendHtml` in `CpsiMapview.plugin.BasicTreeColumnLegends` would use the old key with the new URL causing the wrong legend to be cached with the image. Simply ensuring the layerKey is set prior to this fixes the issue. 

Pull request also includes:
- changing cache keys to include an underscore for readibility
- typo fix