### PR TITLE
enableTextSelection on grid by default

### DIFF
--- a/app/view/grid/Grid.js
+++ b/app/view/grid/Grid.js
@@ -46,7 +46,8 @@ Ext.define('CpsiMapview.view.grid.Grid', {
     },
 
     viewConfig: {  //this config is passed to the view
-        loadingText: 'Loading records'
+        loadingText: 'Loading records',
+        enableTextSelection: true
         //loadMask: {
         //    msg: 'Loading records' // TODO not sure why this isn't applied to the loadMask
         //}


### PR DESCRIPTION
Still feels slightly "clunky" as it is useful to double-click to select text, but then this also trigges the rowdblclick event. 