### PR TITLE
Layer tree as child group

### DIFF
--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -117,17 +117,6 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
     makeLayerStore: function () {
         var me = this;
 
-        // filter function for LayerTreeStore to hide unwanted layers in tree
-        var layerFilter = function (layerRec) {
-            var layer = layerRec.getOlLayer();
-            if (layer) {
-                // neither displayInLayerSwitcher=false (our flag) nor
-                // bp_displayInLayerSwitcher=false (flag of BasiGX)
-                return layer.get('displayInLayerSwitcher') !== false &&
-                    layer.get('bp_displayInLayerSwitcher') !== false;
-            }
-        };
-
         var treeJsonPromise = me.loadTreeStructure();
         treeJsonPromise.then(function (treeJson) {
             // save defaults for tree nodes from config
@@ -136,12 +125,13 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
             // get the root layer group holding the grouped map layers
             var rootLayerGroup = me.getGroupedLayers(treeJson.treeConfig);
 
-            me.map.setLayerGroup(rootLayerGroup);
+            me.map.set('layerTreeRoot', rootLayerGroup)
+            me.map.getLayers().insertAt(0, rootLayerGroup);
+
             // create a new LayerStore from the grouped layers
             var groupedLayerTreeStore = Ext.create('GeoExt.data.store.LayersTree', {
                 model: 'CpsiMapview.data.model.LayerTreeNode',
-                layerGroup: me.map.getLayerGroup(),
-                filters: layerFilter
+                layerGroup: rootLayerGroup
             });
             me.getView().setStore(groupedLayerTreeStore);
 
@@ -167,8 +157,7 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
                 '- creating flat layer hierarchy as fallback');
 
             var layerTreeStore = Ext.create('GeoExt.data.store.LayersTree', {
-                layerGroup: me.map.getLayerGroup(),
-                filters: layerFilter
+                layerGroup: me.map.get('layerTreeRoot')
             });
 
             me.getView().setStore(layerTreeStore);

--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -125,7 +125,7 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
             // get the root layer group holding the grouped map layers
             var rootLayerGroup = me.getGroupedLayers(treeJson.treeConfig);
 
-            me.map.set('layerTreeRoot', rootLayerGroup)
+            me.map.set('layerTreeRoot', rootLayerGroup);
             me.map.getLayers().insertAt(0, rootLayerGroup);
 
             // create a new LayerStore from the grouped layers
@@ -157,7 +157,7 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
                 '- creating flat layer hierarchy as fallback');
 
             var layerTreeStore = Ext.create('GeoExt.data.store.LayersTree', {
-                layerGroup: me.map.get('layerTreeRoot')
+                layerGroup: me.map.get('layerTreeRoot') || me.map.getLayerGroup()
             });
 
             me.getView().setStore(layerTreeStore);

--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -258,6 +258,7 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
                     mapLyr.set('_origTreeConf', child);
 
                     // add OL layer to parent OL LayerGroup
+                    me.map.removeLayer(mapLyr);
                     parentGroup.getLayers().insertAt(0, mapLyr);
 
                 } else {

--- a/app/controller/button/DigitizeButtonController.js
+++ b/app/controller/button/DigitizeButtonController.js
@@ -302,7 +302,6 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
             } else {
                 me.drawLayer = new ol.layer.Vector({
                     source: new ol.source.Vector(),
-                    displayInLayerSwitcher: false,
                     style: view.getDrawLayerStyle()
                 });
                 me.map.addLayer(me.drawLayer);
@@ -322,7 +321,6 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
             } else {
                 me.resultLayer = new ol.layer.Vector({
                     name: 'resultLayer',
-                    displayInLayerSwitcher: false,
                     source: new ol.source.Vector(),
                     style: view.getResultLayerStyle()
                 });

--- a/app/controller/button/SpatialQueryButton.js
+++ b/app/controller/button/SpatialQueryButton.js
@@ -103,7 +103,6 @@ Ext.define('CpsiMapview.controller.button.SpatialQueryButtonController', {
             me.permanentLayer = new ol.layer.Vector({ source: new ol.source.Vector() });
             me.permanentLayer.set('associatedLayerKey', vectorLayerKey);
             me.permanentLayer.set('isSpatialQueryLayer', true);
-            me.permanentLayer.set('displayInLayerSwitcher', false);
             me.permanentLayer.set('name', vectorLayerKey + '_spatialfilter');
             // connect hide and show to query layer hide and show
             me.connectQueryLayer();

--- a/app/controller/button/StreetViewTool.js
+++ b/app/controller/button/StreetViewTool.js
@@ -107,7 +107,6 @@ Ext.define('CpsiMapview.controller.button.StreetViewTool', {
 
             me.vectorLayer = new ol.layer.Vector({
                 name: me.vectorLayerName,
-                displayInLayerSwitcher: false,
                 source: new ol.source.Vector(),
                 style: style
             });

--- a/app/data/model/LayerTreeNode.js
+++ b/app/data/model/LayerTreeNode.js
@@ -76,10 +76,8 @@ Ext.define('CpsiMapview.data.model.LayerTreeNode', {
     onLayerVisibleChange: function (evt) {
         var layer = evt.target;
 
-        if (layer.get('displayInLayerSwitcher') !== false) {
-            if (!this.__updating) {
-                this.set('checked', layer.get('visible'));
-            }
+        if (!this.__updating) {
+            this.set('checked', layer.get('visible'));
         }
     }
 });

--- a/app/model/FeatureStoreMixin.js
+++ b/app/model/FeatureStoreMixin.js
@@ -75,7 +75,6 @@ Ext.define('CpsiMapview.model.FeatureStoreMixin', {
         var selectStyle = field.createSelectStyle();
 
         var vectorLayer = new ol.layer.Vector({
-            displayInLayerSwitcher: false,
             source: new ol.source.Vector(),
             style: style,
             selectStyle: selectStyle // note selectStyle is a custom property and not a ol.layer.Vector option

--- a/app/store/WfsFeatures.js
+++ b/app/store/WfsFeatures.js
@@ -4,9 +4,6 @@ Ext.define('CpsiMapview.store.WfsFeatures', {
     remoteSort: true,
     passThroughFilter: false,
     remoteFilter: true,
-    layerOptions: {
-        displayInLayerSwitcher: false
-    },
     url: '/mapserver/?',
     version: '2.0.0',
     outputFormat: 'geojson',

--- a/app/view/combo/Gazetteer.js
+++ b/app/view/combo/Gazetteer.js
@@ -65,15 +65,6 @@ Ext.define('CpsiMapview.view.combo.Gazetteer', {
             beforequery: function () {
                 var val = this.getRawValue();
 
-                // set a key on the layer using the unique id of the combo
-                me.locationLayer.set('layerKey', me.id);
-                if (Ext.isEmpty(BasiGX.util.Layer.getLayersBy('layerKey', me.id))) {
-                    // if the layer is not yet in the map then add it
-                    if (me.map) {
-                        me.map.addLayer(me.locationLayer);
-                    }
-                }
-
                 // clear any previous query feature
                 me.removeLocationFeature();
 
@@ -87,8 +78,8 @@ Ext.define('CpsiMapview.view.combo.Gazetteer', {
                 }
             },
             afterrender: function () {
-                // don't display the layer in the layer tree
-                me.locationLayer.set('displayInLayerSwitcher', false);
+                // set a key on the layer using the unique id of the combo
+                me.locationLayer.set('layerKey', me.id);
             }
         });
 

--- a/app/view/grid/ExampleGrid.js
+++ b/app/view/grid/ExampleGrid.js
@@ -37,7 +37,6 @@ Ext.define('CpsiMapview.store.GridExample', {
     model: 'CpsiMapview.model.GridExample',
     typeName: 'ruins',
     layerOptions: {
-        displayInLayerSwitcher: false,
         name: 'GridExampleLayer'
     },
     sorters: [{

--- a/app/view/toolbar/MapTools.js
+++ b/app/view/toolbar/MapTools.js
@@ -166,12 +166,7 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
         // Nominatim based location search
         me.items.push({
             xtype: 'gx_geocoder_combo',
-            map: map,
-            listeners: {
-                afterrender: function (gcCombo) {
-                    gcCombo.locationLayer.set('displayInLayerSwitcher', false);
-                }
-            }
+            map: map
         });
 
         // custom CPSI gazetteer


### PR DESCRIPTION
This PR moves the layer group of the layer tree down one level. This allows for arbitrary layers to be added to the group without them showing up in the tree.

Additionally this makes the `displayInLayerSwitcher` property unnecessary.

Fixes #352