### PR TITLE
Style tree node on initialisation

### DIFF
--- a/app/plugin/TreeColumnInResolutionRange.js
+++ b/app/plugin/TreeColumnInResolutionRange.js
@@ -57,7 +57,7 @@ Ext.define('CpsiMapview.plugin.TreeColumnInResolutionRange', {
 
     /**
      * When resolution changes in map: update tree nodes if needed
-     * @param {ol.View } mapView The OL map view
+     * @param {ol.View} mapView The OL map view
      */
     updateTreeNode: function (mapView) {
         var me = this;

--- a/app/plugin/TreeColumnInResolutionRange.js
+++ b/app/plugin/TreeColumnInResolutionRange.js
@@ -28,7 +28,15 @@ Ext.define('CpsiMapview.plugin.TreeColumnInResolutionRange', {
         mapComponent.getStore().setChangeLayerFilterFn(me.changeLayerFilterFn);
 
         var map = mapComponent.getMap();
-        map.getView().on('change:resolution', me.onChangeResolution, me);
+        var mapView = map.getView();
+
+        mapView.on('change:resolution', function() {
+            me.updateTreeNode(mapView);
+        });
+
+        me.cmp.up('treepanel').on('cmv-init-layertree', function () {
+            me.updateTreeNode(mapView);
+        });
 
         me.cmp.up('treepanel').on('boxready', function (tp) {
             if (tp.getStore().count()) {
@@ -49,11 +57,10 @@ Ext.define('CpsiMapview.plugin.TreeColumnInResolutionRange', {
 
     /**
      * When resolution changes in map: update tree nodes if needed
-     * @param {ol.Object.Event} evt The openlayers event
+     * @param {ol.View } mapView The OL map view
      */
-    onChangeResolution: function (evt) {
+    updateTreeNode: function (mapView) {
         var me = this;
-        var mapView = evt.target;
         var unit = mapView.getProjection().getUnits();
         var resolution = mapView.getResolution();
         var treepanel = me.cmp.up('treepanel');


### PR DESCRIPTION
This PR styles the the layer tree nodes once they are created. Before the layer tree nodes where only styled on resolution change.

Fixes #398 