### PR TITLE
Allow clickevents on map through empty taskbar

### DIFF
--- a/sass/src/view/main/Main.scss
+++ b/sass/src/view/main/Main.scss
@@ -15,6 +15,10 @@
         border-color: #778899;
         border-width: medium;
     }
+    // disable click events on the empty task bar
+    // this is necessary to controll the map
+    // and map interactions in this area
+    pointer-events: none;
 }
 
 .cmv_minimized_windows_toolbar .x-box-inner {
@@ -23,4 +27,6 @@
 
 .cmv_minimized_windows_toolbar .x-toolbar-item {
     top: auto !important;
+    // re-enable click events only for the buttons
+    pointer-events: auto;
 }

--- a/sass/src/view/main/Main.scss
+++ b/sass/src/view/main/Main.scss
@@ -10,11 +10,6 @@
     // the 'top' property set by Ext, so that our bottom property
     // actually applies.
     top: auto !important;
-    // add an outline around the button
-    .x-toolbar-item {
-        border-color: #778899;
-        border-width: medium;
-    }
     // disable click events on the empty task bar
     // this is necessary to controll the map
     // and map interactions in this area
@@ -29,4 +24,7 @@
     top: auto !important;
     // re-enable click events only for the buttons
     pointer-events: auto;
+    // add an outline around the button
+    border-color: #778899;
+    border-width: medium;
 }


### PR DESCRIPTION
fixes #380 

Map can be controlled through empty taskbar.
The pointer-events on the taskbar are disabled via CSS and re-enabled on the buttons. 

![Peek 2021-05-18 08-44](https://user-images.githubusercontent.com/15704517/118604296-4afd2600-b7b5-11eb-9c8b-ca9414119dfc.gif)
