### PR TITLE
Prevent multiple resolution change events

### DIFF
--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -152,7 +152,7 @@ Ext.define('CpsiMapview.factory.Layer', {
     },
 
     /**
-     * Creates an layer which renders shows a WMS for small scales and a WFS
+     * Creates a layer which renders a WMS for small scales and a WFS
      * for large scales as sub layer.
      *
      * @param  {Object} layerConf The configuration object for this layer
@@ -914,10 +914,10 @@ Ext.define('CpsiMapview.factory.Layer', {
      * Loops through all layers, identifies switch layers
      * and replaces them if required
      *
-     * @param {ol.Object.Event} evt The event which contains the view.
+     * @param {Number} resolution The new resolution
      */
-    handleSwitchLayerOnResolutionChange: function(evt) {
-        var resolution = evt.target.getResolution();
+    handleSwitchLayerOnResolutionChange: function(resolution) {
+
         var layerCollection = BasiGX.util.Map.getMapComponent().getMap().getLayers();
 
         LayerFactory.checkSwitchLayersRecursively(layerCollection, resolution);

--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -84,6 +84,15 @@ Ext.define('CpsiMapview.view.main.Map', {
      */
     roundPermalinkCoords: true,
 
+
+    /**
+     * Remembers the last resolution before change.
+     * Necessary for detecting resolution change events.
+     * @property {Number}
+     * @private
+     */
+    lastResolution: null,
+
     /**
      * @event cmv-mapclick
      * Fires when the OL map is clicked.
@@ -282,9 +291,20 @@ Ext.define('CpsiMapview.view.main.Map', {
                 me.fireEvent('cmv-map-pointermove');
             });
 
-            // listener that checks the resolution and changes the switch layer if required
-            me.olMap.getView().on('change:resolution',
-                LayerFactory.handleSwitchLayerOnResolutionChange);
+            // event for resolution change
+            // we intentionally do not use the 'change:resolution',
+            // because it fires too often
+            // (see https://github.com/openlayers/openlayers/issues/7402)
+            me.olMap.on('moveend', function (evt) {
+                var targetResolution = evt.target.getView().getResolution();
+                if (targetResolution === me.lastResolution) {
+                    // resolution has not changed
+                    return;
+                }
+                me.lastResolution = targetResolution;
+                LayerFactory.handleSwitchLayerOnResolutionChange(targetResolution);
+            }
+            );
         }
 
         if (me.enablePermalink) {


### PR DESCRIPTION
This PR reduces the number of unnecessary fired events. 

Before during a zoom in the map, multiple (~ 5) `change:resolution` events were fired. This is a known behavior of OpenLayers (see https://github.com/openlayers/openlayers/issues/7402).

The fix is to use a `moveend` event. This, however, also fires on map-pan events. To prevent them, we check if the resolution has actually changed, otherwise we return.

Now, a zoom on the map fires only one event, like one would expect. This fix should be beneficial for the performance of the app.