### PR TITLE
Fix disappearing switchlayer and its text in layer tree

### DIFF
--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -1021,20 +1021,23 @@ Ext.define('CpsiMapview.factory.Layer', {
                     newLayer.set('activatedStyle', activeStyle);
                     // setting a layer will trigger legend creations etc. so make sure activeStyle is set prior to this
 
-                    // `overlayCollection.setAt(0, newLayer)` causes
-                    // strange errors for some unknown reason.
-                    // `setAt` at other indexes as `0` seem to work fine.
-                    // In case of `setAt(0, ... )`, the change seems
-                    // to be forwarded to the treeStore but the change
-                    // does not apply to the overlayCollection itself.
-                    // Or maybe the change is temporarily applied,
-                    // but immediately reverted afterwards.
+                    // `overlayCollection.setAt(0, newLayer)` causes strange
+                    // errors for some unknown reason. `setAt` at other indexes
+                    // as `0` seem to work fine. In case of `setAt(0, ... )`,
+                    // the change seems to be forwarded to the treeStore but
+                    // the change does not apply to the overlayCollection
+                    // itself. Or maybe the change is temporarily applied, but
+                    // immediately reverted afterwards.
                     // this is a workaround
                     overlayCollection.insertAt(index + 1, newLayer);
                     overlayCollection.removeAt(index);
 
-                    LayerFactory.updateLayerTreeForSwitchLayers();
+                    // the configuration for the tree node got lost during the
+                    // switch. We add them again.
+                    var treePanel = Ext.ComponentQuery.query('treepanel')[0];
+                    treePanel.getController().applyTreeConfigsToOlLayer(newLayer, origTreeNodeConf);
 
+                    LayerFactory.updateLayerTreeForSwitchLayers();
                 }
             }
 

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -1020,7 +1020,19 @@ Ext.define('CpsiMapview.factory.Layer', {
 
                     newLayer.set('activatedStyle', activeStyle);
                     // setting a layer will trigger legend creations etc. so make sure activeStyle is set prior to this
-                    overlayCollection.setAt(index, newLayer);
+
+                    // `overlayCollection.setAt(0, newLayer)` causes
+                    // strange errors for some unknown reason.
+                    // `setAt` at other indexes as `0` seem to work fine.
+                    // In case of `setAt(0, ... )`, the change seems
+                    // to be forwarded to the treeStore but the change
+                    // does not apply to the overlayCollection itself.
+                    // Or maybe the change is temporarily applied,
+                    // but immediately reverted afterwards.
+                    // this is a workaround
+                    overlayCollection.insertAt(index + 1, newLayer);
+                    overlayCollection.removeAt(index);
+
                     LayerFactory.updateLayerTreeForSwitchLayers();
 
                 }


### PR DESCRIPTION
fixes  #390 

This PR fixes two bugs of the switchlayer:

Scenario 1 "Switchlayer disappears":
- a switch layer is "last" in a group of the layer tree - this means it has the position `0` in the `ol.Collection`
- when the group is expanded, after switch of the layer, something removes this layer from its  `ol.Collection` but still keeps the reference in the treeStore
- replacing `setAt()` with `insertAt()/removeAt()` fixes the problem

Scenario 2 "missing text in layer tree":
- a switch layer is in a collapsed group
- the map resolution changes so that the switch layer changes
- its group in the layer tree is expanded
- then the name of the layer is not displayed anymore
- the problem is solved by re-adding the layer configuration its node in the treeStore

@geographika could you test this fix in one of your sample applications? So we can be sure it actually works in other settings as well. Further refactoring will be done in a follow-up PR