### PR TITLE
Configurable preset filters

### DIFF
--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -735,8 +735,8 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
             var operator = filterDef.operator;
 
             if (!columnName || !value || !operator) {
-                console.warn('Preset filter is not properly defined.');
-                console.warn(filterDef);
+                Ext.log.warn('Preset filter is not properly defined.');
+                Ext.log.warn(filterDef);
                 return;
             }
 

--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -16,10 +16,10 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
     ],
 
     /**
-    * The currently active spatial filter for the layer.
-    *
-    * @cfg {Ext.util.Filter} spatialFilter
-    */
+     * The currently active spatial filter for the layer.
+     *
+     * @cfg {Ext.util.Filter} spatialFilter
+     */
     spatialFilter: null,
 
     /**
@@ -276,10 +276,10 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
     },
 
     /**
-    * Hide the loading mask when the store has loaded
-    *
-    * @private
-    */
+     * Hide the loading mask when the store has loaded
+     *
+     * @private
+     */
     onWfsStoreAfterLoad: function (store, features, success) {
 
         var grid = this.getView();
@@ -409,13 +409,13 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
         }
     },
     /**
-    * Enable and disable paging for the grid.
-    * Disabling paging allows all records to be loaded into the
-    * grid for an Excel export. Enabling paging improves load
-    * performance.
-    *
-    * @private
-    */
+     * Enable and disable paging for the grid.
+     * Disabling paging allows all records to be loaded into the
+     * grid for an Excel export. Enabling paging improves load
+     * performance.
+     *
+     * @private
+     */
     togglePaging: function (checkBox, checked) {
 
         var me = this;
@@ -449,10 +449,10 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
     },
 
     /**
-    * Export the current records in the grid to Excel
-    *
-    * @private
-    */
+     * Export the current records in the grid to Excel
+     *
+     * @private
+     */
     exportToExcel: function () {
 
         var me = this;
@@ -479,12 +479,11 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
     },
 
     /**
-    * Whenever columns are shown or hidden update
-    * the WFS propertyName so only data to
-    * be displayed is returned. The idProperty will
-    * always be returned even if the column is hidden.
-    *
-    */
+     * Whenever columns are shown or hidden update
+     * the WFS propertyName so only data to
+     * be displayed is returned. The idProperty will
+     * always be returned even if the column is hidden.
+     */
     getVisibleColumns: function () {
 
         var me = this;
@@ -534,7 +533,6 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
         }
     },
 
-
     /**
      * Hide and show the map layer with the grid
      * Although the layer has no styling we need to hide
@@ -561,16 +559,16 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
     },
 
     /**
-    * Template method for Ext.Component that
-    * can be overridden
-    */
+     * Template method for Ext.Component that
+     * can be overridden
+     */
     onShow: function () {
         this.toggleLayerVisibility(true);
     },
 
     /**
-    * Clear any sorters on the store
-    */
+     * Clear any sorters on the store
+     */
     onClearSort: function () {
         var me = this;
         var grid = me.getView();
@@ -580,11 +578,11 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
     },
 
     /**
-    * Clear both the grid filters and any spatial filter.
-    * This will cause the store to reload.
-    *
-    * @private
-    */
+     * Clear both the grid filters and any spatial filter.
+     * This will cause the store to reload.
+     *
+     * @private
+     */
     clearFilters: function () {
         var me = this;
         var view = me.getView();
@@ -621,12 +619,12 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
     },
 
     /**
-    * If any models associated with the grid are edited
-    * (for example in a child form) then automatically update
-    * the grid and associated layers
-    *
-    * @private
-    */
+     * If any models associated with the grid are edited
+     * (for example in a child form) then automatically update
+     * the grid and associated layers
+     *
+     * @private
+     */
     addChildModelListener: function () {
 
         var me = this;
@@ -647,12 +645,12 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
     },
 
     /**
-    * Dynamically apply a store to the grid based on the gridStoreType
-    * config option. Also set the hidden grid vector layer to be associated
-    * with the cmv_spatial_query_button
-    *
-    * @private
-    */
+     * Dynamically apply a store to the grid based on the gridStoreType
+     * config option. Also set the hidden grid vector layer to be associated
+     * with the cmv_spatial_query_button
+     *
+     * @private
+     */
     initViewModel: function (viewModel) {
 
         var me = this;
@@ -688,5 +686,120 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
         };
 
         viewModel.setStores(stores);
+    },
+
+    /**
+     * Applies preset filters from the configuration
+     * to the grid.
+     */
+    onApplyPresetFilters: function () {
+        var me = this;
+
+        var viewModel = me.getViewModel();
+
+        var wmsLayerKey = viewModel.get('wmsLayerKey');
+        var vectorLayerKey = viewModel.get('vectorLayerKey');
+
+        var layer;
+        if (wmsLayerKey) {
+            layer = me.getLayerByKey(wmsLayerKey);
+        } else if (vectorLayerKey) {
+            layer = me.getLayerByKey(vectorLayerKey);
+        } else {
+            // no layer found
+            return;
+        }
+        var gridFilters = layer.get('gridFilters');
+
+        if (!gridFilters || !Ext.isArray(gridFilters)) {
+            return;
+        }
+
+        var grid = me.getView();
+        if (!grid) {
+            return;
+        }
+        var columnManager = grid.getColumnManager();
+        if (!columnManager) {
+            return;
+        }
+
+        // loop through all provided preset filter definitions
+        Ext.each(gridFilters, function (filterDef) {
+            if (!filterDef || !Ext.isObject(filterDef)) {
+                return;
+            }
+
+            var columnName = filterDef.property;
+            var value = filterDef.value;
+            var operator = filterDef.operator;
+
+            if (!columnName || !value || !operator) {
+                console.warn('Preset filter is not properly defined.');
+                console.warn(filterDef);
+                return;
+            }
+
+            var column = columnManager.getHeaderByDataIndex(columnName);
+            if (!column || !column.filter || !column.filter.type) {
+                return;
+            }
+            var columnType = column.filter.type;
+
+            switch (columnType) {
+                case 'string':
+                    // only equal is supported for string
+                    if (operator !== '=') {
+                        return;
+                    }
+                    if (!column.filter.value) {
+                        column.filter.setValue(value);
+                    }
+                    break;
+                case 'number':
+                    var filterValue = me.createNumberFilterValue(
+                        operator,
+                        value
+                    );
+                    if (!filterValue) {
+                        return;
+                    }
+
+                    if (!column.filter.value) {
+                        column.filter.setValue(filterValue);
+                    }
+                    break;
+                default:
+                    break;
+            }
+        });
+    },
+
+    /**
+     * Create a value object needed for number filters.
+     *
+     * @param {string} operator The userdefined operator. Allowed values: '=', '<' and '>'
+     * @param {number} value The numerical value to compare
+     * @returns {Object} The value object for the filter
+     */
+    createNumberFilterValue: function(operator, value){
+        // translate user defined operators
+        // into operators that are
+        // compatible with number filters
+        var operatorMapping = {
+            '=': 'eq',
+            '>': 'gt',
+            '<': 'lt'
+        };
+        var filterOperator = operatorMapping[operator];
+        if (!filterOperator) {
+            return;
+        }
+
+        // the value for number filters are objects like '{eq: 42}'
+        // we need to create them from the original value and the operator
+        var filterValue = {};
+        filterValue[filterOperator] = value;
+        return filterValue;
     }
 });

--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -769,6 +769,19 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
                         column.filter.setValue(filterValue);
                     }
                     break;
+                case 'list':
+                    // we need to apply the initial config again,
+                    // because otherwise the store with the list-choices
+                    // gets lost
+                    var newFilter = Ext.clone(column.initialConfig.filter);
+
+                    // now we apply the oparator and the value
+                    newFilter.operator = operator;
+                    newFilter.value = value;
+
+                    var plugin = grid.getPlugin('gridfilters');
+                    plugin.addFilter(newFilter);
+                    break;
                 default:
                     break;
             }
@@ -783,9 +796,8 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
      * @returns {Object} The value object for the filter
      */
     createNumberFilterValue: function(operator, value){
-        // translate user defined operators
-        // into operators that are
-        // compatible with number filters
+        // translate user defined operators into operators
+        // that are compatible with number filters
         var operatorMapping = {
             '=': 'eq',
             '>': 'gt',

--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -790,6 +790,7 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
                 case 'string':
                     // only equal is supported for string
                     if (operator !== '=') {
+                        Ext.log.warn('No valid operator provided.');
                         return;
                     }
                     column.filter.setValue(value);
@@ -810,6 +811,11 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
                     // because otherwise the store with the list-choices
                     // gets lost
                     var newFilter = Ext.clone(column.initialConfig.filter);
+
+                    if (operator != 'in'){
+                        Ext.log.warn('No valid operator provided.');
+                        return;
+                    }
 
                     // now we apply the oparator and the value
                     newFilter.operator = operator;
@@ -841,6 +847,7 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
         };
         var filterOperator = operatorMapping[operator];
         if (!filterOperator) {
+            Ext.log.warn('No valid operator provided.');
             return;
         }
 

--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -792,9 +792,7 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
                     if (operator !== '=') {
                         return;
                     }
-                    if (!column.filter.value) {
-                        column.filter.setValue(value);
-                    }
+                    column.filter.setValue(value);
                     break;
                 case 'number':
                     var filterValue = me.createNumberFilterValue(
@@ -805,9 +803,7 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
                         return;
                     }
 
-                    if (!column.filter.value) {
-                        column.filter.setValue(filterValue);
-                    }
+                    column.filter.setValue(filterValue);
                     break;
                 case 'list':
                     // we need to apply the initial config again,

--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -567,6 +567,14 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
     },
 
     /**
+     * Apply preset filters once grid is created
+     */
+    onBoxReady: function () {
+        var me = this;
+        me.onApplyPresetFilters();
+    },
+
+    /**
      * Clear any sorters on the store
      */
     onClearSort: function () {
@@ -757,7 +765,6 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
         }
 
         // loop through all provided preset filter definitions
-        // TODO: ? extract function ?
         Ext.each(gridFilters, function (filterDef) {
             if (!filterDef || !Ext.isObject(filterDef)) {
                 return;

--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -645,21 +645,30 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
     },
 
     /**
+     * @private
+     */
+    initViewModel: function (viewModel) {
+        var me = this;
+
+        me.applyStoreToGrid(viewModel);
+        me.activatePresetFilterButton(viewModel);
+    },
+
+    /**
      * Dynamically apply a store to the grid based on the gridStoreType
      * config option. Also set the hidden grid vector layer to be associated
      * with the cmv_spatial_query_button
      *
-     * @private
+     * @param {Ext.app.ViewModel } viewModel The ViewModel
      */
-    initViewModel: function (viewModel) {
-
+    applyStoreToGrid: function (viewModel) {
         var me = this;
 
         me.addChildModelListener();
 
         var gridStoreType = viewModel.get('gridStoreType');
         var layerName = viewModel.get('gridLayerName');
-        var layerKey = viewModel.get('vectorLayerKey');
+        var vectorLayerKey = viewModel.get('vectorLayerKey');
 
         // TODO check why we can't simply add a {'queryLayerName'} binding in
         // the grid view - already created ?
@@ -668,7 +677,7 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
         spatialQueryButton.setVectorLayerKey(layerName); // this name will have _spatialfilter appended to it
 
         var featureSelectionButton = viewModel.getView().down('cmv_feature_selection_button');
-        featureSelectionButton.setVectorLayerKey(layerKey);
+        featureSelectionButton.setVectorLayerKey(vectorLayerKey);
 
         // dynamically create the store based on the config setting
 
@@ -686,6 +695,29 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
         };
 
         viewModel.setStores(stores);
+    },
+
+    /**
+     * Activated the "preset filter" button if the layer
+     * has the repspective properties.
+     *
+     * @param {Ext.app.ViewModel } viewModel The ViewModel
+     */
+    activatePresetFilterButton: function (viewModel) {
+        var me = this;
+        // check if layer has preset grid Filters
+        // if yes, we activate the respective button
+        var wmsLayerKey = viewModel.get('wmsLayerKey');
+        var vectorLayerKey = viewModel.get('vectorLayerKey');
+        var layer;
+        if (wmsLayerKey) {
+            layer = me.getLayerByKey(wmsLayerKey);
+        } else if (vectorLayerKey) {
+            layer = me.getLayerByKey(vectorLayerKey);
+        }
+        if (layer && layer.get('gridFilters')) {
+            viewModel.set('usePresetFilters', true);
+        }
     },
 
     /**
@@ -725,6 +757,7 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
         }
 
         // loop through all provided preset filter definitions
+        // TODO: ? extract function ?
         Ext.each(gridFilters, function (filterDef) {
             if (!filterDef || !Ext.isObject(filterDef)) {
                 return;

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -115,6 +115,8 @@ Ext.define('CpsiMapview.factory.Layer', {
             mapLayer.set('opacitySlider', allowOpacitySlider);
             // the xtype of any associated grid
             mapLayer.set('gridXType', layerConf.gridXType);
+            // the preset filters for the grid
+            mapLayer.set('gridFilters', layerConf.gridFilters);
             // if layer should show a feature info window
             mapLayer.set('featureInfoWindow', layerConf.featureInfoWindow);
             // attribute grouping config

--- a/app/model/grid/Grid.js
+++ b/app/model/grid/Grid.js
@@ -20,7 +20,8 @@ Ext.define('CpsiMapview.model.grid.Grid', {
         gridStoreType: null,
         allowFeatureSelection: false,
         // when isSpatialGrid is set to false the 'Select by Shape' button will be hidden
-        isSpatialGrid: true
+        isSpatialGrid: true,
+        usePresetFilters: false
     },
 
     formulas: {

--- a/app/model/grid/Grid.js
+++ b/app/model/grid/Grid.js
@@ -12,8 +12,8 @@ Ext.define('CpsiMapview.model.grid.Grid', {
     ],
 
     /**
-    * The following should all be overridden in child classes
-    */
+     * The following should all be overridden in child classes
+     */
     data: {
         vectorLayerKey: null,
         wmsLayerKey: null,

--- a/app/view/grid/ExampleGrid.js
+++ b/app/view/grid/ExampleGrid.js
@@ -77,7 +77,7 @@ Ext.define('CpsiMapview.view.grid.ExampleGrid', {
                 dataIndex: 'code',
                 flex: 2,
                 filter: {
-                    type: 'string'
+                    type: 'number'
                 }
             },
             {

--- a/app/view/grid/Grid.js
+++ b/app/view/grid/Grid.js
@@ -36,9 +36,9 @@ Ext.define('CpsiMapview.view.grid.Grid', {
     exportTitle: 'Records Export',
 
     /**
-    * The filename of the Excel export
-    * @cfg {String}
-    */
+     * The filename of the Excel export
+     * @cfg {String}
+     */
     exportFileName: 'RecordsExport.xlsx',
 
     bind: {
@@ -79,8 +79,8 @@ Ext.define('CpsiMapview.view.grid.Grid', {
     },
 
     /**
-    * Functions attached to various listeners on the grid
-    */
+     * Functions attached to various listeners on the grid
+     */
     listeners: {
         filterchange: 'updateAssociatedLayers',
         itemcontextmenu: 'onItemContextMenu',
@@ -94,8 +94,8 @@ Ext.define('CpsiMapview.view.grid.Grid', {
     },
 
     /**
-    * Collection of tools and buttons at the top of the grid
-    */
+     * Collection of tools and buttons at the top of the grid
+     */
     dockedItems: [{
         xtype: 'toolbar',
         dock: 'top',
@@ -110,7 +110,14 @@ Ext.define('CpsiMapview.view.grid.Grid', {
             text: 'Clear Sorting',
             glyph: 'f039@FontAwesome',
             handler: 'onClearSort'
-        }, '->',
+        },
+        {
+            xtype: 'button',
+            text: 'Apply Preset Filters',
+            glyph: 'f005@FontAwesome',
+            handler: 'onApplyPresetFilters'
+        },
+        '->',
         {
             xtype: 'cmv_spatial_query_button',
             drawGeometryType: 'Polygon',

--- a/app/view/grid/Grid.js
+++ b/app/view/grid/Grid.js
@@ -115,7 +115,10 @@ Ext.define('CpsiMapview.view.grid.Grid', {
             xtype: 'button',
             text: 'Apply Preset Filters',
             glyph: 'f005@FontAwesome',
-            handler: 'onApplyPresetFilters'
+            handler: 'onApplyPresetFilters',
+            bind: {
+                hidden: '{!usePresetFilters}'
+            }
         },
         '->',
         {

--- a/app/view/grid/Grid.js
+++ b/app/view/grid/Grid.js
@@ -90,7 +90,8 @@ Ext.define('CpsiMapview.view.grid.Grid', {
         // ensure columns are set when the store is bound to the grid
         reconfigure: 'onColumnsReconfigure',
         hide: 'onHide',
-        show: 'onShow'
+        show: 'onShow',
+        boxready: 'onBoxReady'
     },
 
     /**

--- a/app/view/grid/GridFiltersExample.js
+++ b/app/view/grid/GridFiltersExample.js
@@ -75,8 +75,7 @@ Ext.define('CpsiMapview.model.GridFiltersExample', {
 Ext.define('CpsiMapview.store.GridFiltersExample', {
     extend: 'CpsiMapview.store.WfsFeatures',
     alias: 'store.GridFiltersExample',
-    //url: 'https://w08-mapserver.compass.ie/mapserver/?map=/MapServer/apps/mapview-demo/example.map&',
-    url: 'http://localhost/mapserver2/?map=/MapServer/apps/mapview-demo/example.map&',
+    url: 'https://w08-mapserver.compass.ie/mapserver/?map=/MapServer/apps/mapview-demo/example.map&',
     storeId: 'GridFiltersExample',
     requestMethod: 'POST',
     //srsName: 'epsg:2157',

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -346,6 +346,18 @@
     {
       "layerType": "wfs",
       "gridXType": "cmv_examplegrid",
+      "gridFilters": [
+        {
+          "property": "code",
+          "value": "42",
+          "operator": ">"
+        },
+        {
+          "property": "name",
+          "value": "old",
+          "operator": "="
+        }
+      ],
       "layerKey": "RUINS_WFS",
       "geometryProperty": "msGeometry",
       "featureType": "ruins",

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -390,6 +390,23 @@
     {
       "layerType": "wms",
       "gridXType": "cmv_filtersexamplegrid",
+      "gridFilters": [
+        {
+          "property": "Calc_Area",
+          "value": "1.7",
+          "operator": ">"
+        },
+        {
+          "property": "Location",
+          "value": "Ba",
+          "operator": "="
+        },
+        {
+          "property": "AUTHORITY",
+          "value": ["Kerry", "Cavan"],
+          "operator": "in"
+        }
+      ],
       "layerKey": "LA_SITES",
       "serverOptions": {
         "layers": "lasites"

--- a/test/spec/controller/grid/Grid.spec.js
+++ b/test/spec/controller/grid/Grid.spec.js
@@ -1,0 +1,12 @@
+describe('CpsiMapview.controller.grid.Grid', function() {
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(CpsiMapview.controller.grid.Grid).not.to.be(undefined);
+        });
+
+        it('can be created', function() {
+            var ctrl = new CpsiMapview.controller.grid.Grid();
+            expect(ctrl).to.not.be(undefined);
+        });
+    });
+});

--- a/test/spec/view/grid/Grid.spec.js
+++ b/test/spec/view/grid/Grid.spec.js
@@ -1,0 +1,13 @@
+describe('CpsiMapview.view.grid.Grid', function() {
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(CpsiMapview.view.grid.Grid).not.to.be(undefined);
+        });
+
+        it('can be instantiated', function() {
+            var inst = Ext.create('CpsiMapview.view.grid.Grid');
+            expect(inst).to.be.a(CpsiMapview.view.grid.Grid);
+        });
+
+    });
+});


### PR DESCRIPTION
references #401

This PR is already fully functional for `string` and `number` based filters, but is missing the `list` filter preset.

example configuration:
```json
[...]
      "gridFilters": [
        {
          "property": "code",
          "value": "42",
          "operator": ">"
        },
        {
          "property": "name",
          "value": "old",
          "operator": "="
        }
      ],
[...]
```

With the button ":star: Apply Preset Filters", the preset filters can be applied to the grid. See screenshot below.

- This works so far for `number` and `string` filter. 
- basic test classes have been created

**remaining:**
- [x] the `list` filter needs to be implemented
- [ ] `boolean` filter
- [ ] `date` filter

![image](https://user-images.githubusercontent.com/15704517/119163878-21b1f380-ba5c-11eb-8206-10708be4a133.png)



