### PR TITLE
Only trigger FeatureInfo clicks when no other tools are active

### DIFF
--- a/app/Application.js
+++ b/app/Application.js
@@ -6,6 +6,12 @@
 Ext.define('CpsiMapview.Application', {
     extend: 'Ext.app.Application',
 
+    mixins: {
+        appmixin: 'CpsiMapview.util.ApplicationMixin'
+    },
+
+    requireLogin: false,
+
     name: 'CpsiMapview',
 
     quickTips: false,

--- a/app/util/ApplicationMixin.js
+++ b/app/util/ApplicationMixin.js
@@ -9,7 +9,15 @@ Ext.define('CpsiMapview.util.ApplicationMixin', {
     // see https://docs.sencha.com/extjs/6.7.0/classic/Ext.app.Application.html#cfg-quickTips
     quickTips: false,
 
+    /**
+     * Property to store a reference to the login window
+     */
     loginWindow: null,
+
+    /**
+     * Does the application require a login window for access
+     */
+    requireLogin: true,
 
     // when the platform is matched any properties are placed on the class
     platformConfig: {
@@ -24,15 +32,24 @@ Ext.define('CpsiMapview.util.ApplicationMixin', {
         }
     },
 
-    // URLs to monitor for service errors
+    /**
+     * URLs to monitor for service errors
+     */
     serviceUrls: [],
 
-    // URLs to ignore for errors
+    /**
+     * URLs to ignore for errors
+     */
     excludedUrls: [],
 
-    // URL to use as the root for any window helpUrl
+    /**
+     * URL to use as the root for any window helpUrl
+     */
     rootHelpUrl: '',
 
+    /**
+     * The token name within a cookie that stores a login token
+     */
     tokenName: 'cookietoken',
 
     errorCode: {
@@ -68,7 +85,7 @@ Ext.define('CpsiMapview.util.ApplicationMixin', {
             if (Ext.Array.some(me.excludedUrls, urlTest) === false) {
 
                 // FORMS submission (i.e. attachments upoad) return bogus responses with no content-type
-                var responseType = response.responseType ? response.responseType: response.getResponseHeader ? response.getResponseHeader('content-type') : null;
+                var responseType = response.responseType ? response.responseType : response.getResponseHeader ? response.getResponseHeader('content-type') : null;
 
                 // check for geojson (coming from MapServer)
                 if (responseType && responseType.includes('subtype=geojson')) {
@@ -123,7 +140,9 @@ Ext.define('CpsiMapview.util.ApplicationMixin', {
 
         var me = this;
         me.setupRequestHooks();
-        me.doLogin();
+        if (me.requireLogin) {
+            me.doLogin();
+        }
         // add a listener for whenever any button in the map toggleGroup is toggled
         me.control({
             'button[toggleGroup=map]': {

--- a/app/view/toolbar/MapTools.js
+++ b/app/view/toolbar/MapTools.js
@@ -39,15 +39,15 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
                     extent: [-1210762, 6688545, -600489, 7490828]
                 }, {
                     xtype: 'basigx-button-zoomin',
-                    toggleGroup: 'zoom'
+                    toggleGroup: 'map'
                 }, {
                     xtype: 'basigx-button-zoomout',
-                    toggleGroup: 'zoom',
+                    toggleGroup: 'map',
                     enableZoomOutWithBox: true
                 }, {
                     xtype: 'basigx-button-measure',
+                    toggleGroup: 'map',
                     measureType: 'line',
-                    toggleGroup: 'measure-tools',
                     viewModel: 'cmv_btn_measure',
                     controller: 'cmv_btn_measure',
                     glyph: 'ea13@font-gis',
@@ -56,8 +56,8 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
                     }
                 }, {
                     xtype: 'basigx-button-measure',
+                    toggleGroup: 'map',
                     measureType: 'polygon',
-                    toggleGroup: 'measure-tools',
                     glyph: 'ea14@font-gis',
                     viewModel: 'cmv_btn_measure',
                     controller: 'cmv_btn_measure',
@@ -79,6 +79,7 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
             title: 'Advanced Tools',
             items: [{
                 xtype: 'cmv_digitize_button',
+                toggleGroup: 'map',
                 tooltip: 'Point',
                 glyph: 'ea52@font-gis',
                 apiUrl: 'https://pmstipperarydev.compass.ie/pmspy/netsolver',
@@ -89,13 +90,17 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
                         this.getController().onResponseFeatures();
                     }
                 }
-            }, {
+            },
+            {
                 xtype: 'cmv_digitize_button',
+                toggleGroup: 'map',
                 type: 'LineString',
                 glyph: 'ea02@font-gis',
                 tooltip: 'Line'
-            }, {
+            },
+            {
                 xtype: 'cmv_digitize_button',
+                toggleGroup: 'map',
                 type: 'Polygon',
                 tooltip: 'Polygon',
                 glyph: 'ea03@font-gis',
@@ -105,8 +110,10 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
                         this.getController().onResponseFeatures();
                     }
                 }
-            }, {
+            },
+            {
                 xtype: 'cmv_digitize_button',
+                toggleGroup: 'map',
                 type: 'Circle',
                 tooltip: 'Circle',
                 apiUrl: 'https://pmstipperarydev.compass.ie/WebServices/roadschedule/cutWithPolygon',
@@ -116,7 +123,8 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
                     }
                 }
             }, {
-                xtype: 'cmv_streetview_tool'
+                xtype: 'cmv_streetview_tool',
+                toggleGroup: 'map',
             }, {
                 xtype: 'cmv_line_slice_grid_button',
                 text: '',


### PR DESCRIPTION
Ensure FeatureInfo clicks are only active when no other tools in the `map` `toggleGroup` are active. 
See also #385. 

Also switches ApplicationMixin.js to LF instead of CRLF end-of-lines (hence the large diff). 