### PR TITLE
Avoid JS errors when right-clicking on a layer in the tree

### DIFF
--- a/app/view/menuitem/LayerLabels.js
+++ b/app/view/menuitem/LayerLabels.js
@@ -62,17 +62,17 @@ Ext.define('CpsiMapview.view.menuitem.LayerLabels', {
      */
     initComponent: function () {
         var me = this;
-
-        me.clientSideStyle = (me.layer && (
-            me.layer.getSource() instanceof ol.source.VectorTile
-            || me.layer.getSource() instanceof ol.source.Vector
-        ));
-        // try to detect the 'labelClassName' property of a WMS layer
-        if (me.layer && (me.layer.getSource() instanceof ol.source.TileWMS ||
-            me.layer.getSource() instanceof ol.source.ImageWMS)) {
-            me.labelClassName = me.layer.get('labelClassName');
+        if (me.layer && !(me.layer instanceof ol.layer.Group)) {
+            me.clientSideStyle = (
+                me.layer.getSource() instanceof ol.source.VectorTile
+                || me.layer.getSource() instanceof ol.source.Vector
+            );
+            // try to detect the 'labelClassName' property of a WMS layer
+            if (me.layer.getSource() instanceof ol.source.TileWMS ||
+                me.layer.getSource() instanceof ol.source.ImageWMS) {
+                me.labelClassName = me.layer.get('labelClassName');
+            }
         }
-
         me.callParent();
 
         if (me.clientSideStyle) {


### PR DESCRIPTION
This is due to `CpsiMapview.view.menuitem.LayerLabels` expecting a layer with a source, which `ol.layer.Group` does not have. 