### PR TITLE
Add "Reset Filter" menu item on layer tree

### DIFF
--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -544,10 +544,29 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
         var grid = me.getView();
         var store = grid.getStore();
 
-        if (store.isEmptyStore !== true) {
-            var layer = store.getLayer();
+        var layer = me.getOlLayer();
+        if (store.isEmptyStore !== true && layer) {
             layer.setVisible(show);
         }
+    },
+
+    /**
+     * Returns the layer of the grid.
+     *
+     * @returns {ol.layer.Base} The grid's layer
+     */
+    getOlLayer: function() {
+        var me = this;
+        var viewModel = me.getViewModel();
+        var wmsLayerKey = viewModel.get('wmsLayerKey');
+        var vectorLayerKey = viewModel.get('vectorLayerKey');
+        var layer;
+        if (wmsLayerKey) {
+            layer = me.getLayerByKey(wmsLayerKey);
+        } else if (vectorLayerKey) {
+            layer = me.getLayerByKey(vectorLayerKey);
+        }
+        return layer;
     },
 
     /**
@@ -564,14 +583,6 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
      */
     onShow: function () {
         this.toggleLayerVisibility(true);
-    },
-
-    /**
-     * Apply preset filters once grid is created
-     */
-    onBoxReady: function () {
-        var me = this;
-        me.onApplyPresetFilters();
     },
 
     /**
@@ -707,22 +718,16 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
 
     /**
      * Activated the "preset filter" button if the layer
-     * has the repspective properties.
+     * has the respective properties.
      *
      * @param {Ext.app.ViewModel } viewModel The ViewModel
      */
     activatePresetFilterButton: function (viewModel) {
         var me = this;
+
         // check if layer has preset grid Filters
         // if yes, we activate the respective button
-        var wmsLayerKey = viewModel.get('wmsLayerKey');
-        var vectorLayerKey = viewModel.get('vectorLayerKey');
-        var layer;
-        if (wmsLayerKey) {
-            layer = me.getLayerByKey(wmsLayerKey);
-        } else if (vectorLayerKey) {
-            layer = me.getLayerByKey(vectorLayerKey);
-        }
+        var layer = me.getOlLayer();
         if (layer && layer.get('gridFilters')) {
             viewModel.set('usePresetFilters', true);
         }
@@ -732,23 +737,10 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
      * Applies preset filters from the configuration
      * to the grid.
      */
-    onApplyPresetFilters: function () {
+    applyPresetFilters: function () {
         var me = this;
 
-        var viewModel = me.getViewModel();
-
-        var wmsLayerKey = viewModel.get('wmsLayerKey');
-        var vectorLayerKey = viewModel.get('vectorLayerKey');
-
-        var layer;
-        if (wmsLayerKey) {
-            layer = me.getLayerByKey(wmsLayerKey);
-        } else if (vectorLayerKey) {
-            layer = me.getLayerByKey(vectorLayerKey);
-        } else {
-            // no layer found
-            return;
-        }
+        var layer = me.getOlLayer();
         var gridFilters = layer.get('gridFilters');
 
         if (!gridFilters || !Ext.isArray(gridFilters)) {
@@ -759,6 +751,7 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
         if (!grid) {
             return;
         }
+
         var columnManager = grid.getColumnManager();
         if (!columnManager) {
             return;
@@ -827,7 +820,9 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
                 default:
                     break;
             }
-        });
+        }
+
+        );
     },
 
     /**

--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -573,14 +573,6 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
      * Template method for Ext.Component that
      * can be overridden
      */
-    onHide: function () {
-        this.toggleLayerVisibility(false);
-    },
-
-    /**
-     * Template method for Ext.Component that
-     * can be overridden
-     */
     onShow: function () {
         this.toggleLayerVisibility(true);
     },

--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -812,9 +812,7 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
                 default:
                     break;
             }
-        }
-
-        );
+        });
     },
 
     /**

--- a/app/util/Grid.js
+++ b/app/util/Grid.js
@@ -1,0 +1,110 @@
+/**
+ * Static util class for Grid related operations.
+ */
+Ext.define('CpsiMapview.util.Grid', {
+
+    statics: {
+        /**
+         * Gets the grid panel component for this layer if it exists.
+         * Otherwise it will be created.
+         *
+         * @param {ol.layer.Base} layer The layer for which the grid shall be retrieved
+         * @returns {CpsiMapview.view.grid.Grid} The grid panel component
+         */
+        getGridWindow: function (layer) {
+            var staticMe = CpsiMapview.util.Grid;
+            var gridWindow;
+            var gridXType = layer.get('gridXType');
+            if (!gridXType) {
+                return;
+            }
+
+            // we can't keep a reference to the window in this class
+            // as a new Ext.menu.Item is created each time the menu is
+            // opened - use Ext.ComponentQuery instead
+            var existingGrids = Ext.ComponentQuery.query(gridXType);
+
+            var gridWindowExists =
+                existingGrids.length > 0 &&
+                existingGrids[0] &&
+                existingGrids[0].up('window');
+
+            if (gridWindowExists) {
+                // get the parent window of the grid
+                gridWindow = existingGrids[0].up('window');
+            } else {
+                gridWindow = staticMe.createGridWindow(layer);
+            }
+            return gridWindow;
+        },
+
+
+        /**
+         * Creates a grid window for the layer.
+         *
+         * @param {ol.layer.Base} layer The layer for which the grid shall be created
+         * @returns {CpsiMapview.view.grid.Grid} The grid panel component
+         */
+        createGridWindow: function (layer) {
+            var gridXType = layer.get('gridXType');
+
+            // the Ext.window.Window configuration object
+            var windowConfig = {
+                minHeight: 600,
+                constrain: true,
+                layout: 'fit',
+                maximizable: true,
+                closeAction: 'hide' // don't destroy the window when closed
+            };
+
+            Ext.apply(windowConfig, {
+                title: layer.get('name'),
+                layout: 'fit',
+                items: [{
+                    xtype: gridXType,
+                    // we need to create this store, otherwise Ext will
+                    // create a default store that causes interference
+                    // between layers with grid
+                    // manually setting another store avoids problems like
+                    // that setting filters to one layers are applied to
+                    // another layer
+                    store: Ext.create('Ext.data.Store')
+                }],
+                listeners: {
+                    minimize: Ext.emptyFn,
+                    close: function () {
+                        // hide the spatial tool only when closed rather than when
+                        // minimising the window
+                        var me = this;
+                        var queryButton = me.down('cmv_spatial_query_button');
+                        if (queryButton !== null) {
+                            queryButton.fireEvent('hideAssociatedPermanentLayer');
+                            queryButton.toggle(false);
+                        }
+                        // hide the layer with the grid (to hide selections)
+                        var grid = me.down('grid');
+                        grid.fireEvent('hide');
+                    },
+                    show: function () {
+                        var me = this;
+                        var queryButton = me.down('cmv_spatial_query_button');
+                        if (queryButton !== null) {
+                            queryButton.fireEvent('showAssociatedPermanentLayer');
+                        }
+
+                        var grid = me.down('grid');
+                        grid.fireEvent('show');
+                    }
+                }
+            });
+            var gridWindow = Ext.create('CpsiMapview.view.window.MinimizableWindow', windowConfig);
+
+            // copy any ViewModel properties from the grid on to its containing window
+            // this allows helpUrl to be set at the grid level
+            var gridViewModelData = gridWindow.down(gridXType).getViewModel().getData();
+            // use apply rather than applyIf otherwise the default empty helpUrl is not overwritten
+            Ext.apply(gridWindow.getViewModel().getData(), gridViewModelData);
+            return gridWindow;
+        }
+    }
+});

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -14,6 +14,7 @@ Ext.define('CpsiMapview.view.LayerTree', {
         'CpsiMapview.view.menuitem.LayerGrid',
         'CpsiMapview.view.menuitem.LayerStyleSwitcher',
         'CpsiMapview.view.menuitem.LayerMetadata',
+        'CpsiMapview.view.menuitem.LayerFilterReset',
         'CpsiMapview.plugin.TreeColumnStyleSwitcher',
         'CpsiMapview.controller.LayerTreeController',
         'CpsiMapview.view.window.MinimizableWindow',
@@ -85,7 +86,8 @@ Ext.define('CpsiMapview.view.LayerTree', {
                         'cmv_menuitem_layerlabels',
                         'cmv_menuitem_layeropacity',
                         'cmv_menuitem_layergrid',
-                        'cmv_menuitem_layermetadata'
+                        'cmv_menuitem_layermetadata',
+                        'cmv_menuitem_layerfilterreset'
                     ]
                 }, {
                     ptype: 'cmv_tree_inresolutionrange'

--- a/app/view/grid/Grid.js
+++ b/app/view/grid/Grid.js
@@ -91,7 +91,8 @@ Ext.define('CpsiMapview.view.grid.Grid', {
         reconfigure: 'onColumnsReconfigure',
         hide: 'onHide',
         show: 'onShow',
-        boxready: 'onBoxReady'
+        clearfilters: 'clearFilters',
+        applypresetfilters: 'applyPresetFilters'
     },
 
     /**
@@ -116,7 +117,7 @@ Ext.define('CpsiMapview.view.grid.Grid', {
             xtype: 'button',
             text: 'Apply Preset Filters',
             glyph: 'f005@FontAwesome',
-            handler: 'onApplyPresetFilters',
+            handler: 'applyPresetFilters',
             bind: {
                 hidden: '{!usePresetFilters}'
             }

--- a/app/view/grid/Grid.js
+++ b/app/view/grid/Grid.js
@@ -89,7 +89,6 @@ Ext.define('CpsiMapview.view.grid.Grid', {
         rowdblclick: 'onRowDblClick',
         // ensure columns are set when the store is bound to the grid
         reconfigure: 'onColumnsReconfigure',
-        hide: 'onHide',
         show: 'onShow',
         clearfilters: 'clearFilters',
         applypresetfilters: 'applyPresetFilters'

--- a/app/view/menuitem/LayerFilterReset.js
+++ b/app/view/menuitem/LayerFilterReset.js
@@ -1,0 +1,109 @@
+/**
+ * Resets the all applied filters.
+ * Aftwards applies predefined filters in case they exist.
+ *
+ * @class CpsiMapview.view.menuitem.LayerFilterReset
+ */
+Ext.define('CpsiMapview.view.menuitem.LayerFilterReset', {
+    extend: 'Ext.menu.Item',
+    xtype: 'cmv_menuitem_layerfilterreset',
+
+    requires: [
+        'CpsiMapview.util.Grid'
+    ],
+
+    /**
+     * The connected layer for this item
+     *
+     * @cfg {ol.layer.Base}
+     */
+    layer: null,
+
+    /**
+     * Text shown in this MenuItem
+     * @cfg {String}
+     */
+    text: 'Reset Filters',
+
+    /**
+     * @private
+     */
+    initComponent: function () {
+        var me = this;
+
+        me.handler = me.handlerFunc;
+
+        me.callParent();
+
+        me.setHidden(!me.shallMenuItemBeShown());
+    },
+
+    /**
+     * Executed when this menu item is clicked.
+     */
+    handlerFunc: function () {
+        var me = this;
+        var gridWindow = CpsiMapview.util.Grid.getGridWindow(me.layer);
+
+        var grid = gridWindow.down('grid');
+        grid.fireEvent('clearfilters');
+        grid.fireEvent('applypresetfilters');
+    },
+
+    /**
+     * Checks if menu item should be shown.
+     *
+     * @returns {Boolean} If menu item should be shown
+     */
+    shallMenuItemBeShown: function(){
+        var me = this;
+
+        // the menu can only be shown for layers that have a grid
+        if (!me.layer.get('gridXType')) {
+            return false;
+        }
+
+        // check preset filters
+        var hasPresetFilters = false;
+        if (me.layer.get('gridFilters')) {
+            hasPresetFilters = true;
+        }
+
+        // if the layer has preset filters, we always show the menu item
+        // otherwise we only show it there are currently any preset filters
+        return hasPresetFilters || me.isLayerCurrentlyFiltered();
+    },
+
+    /**
+     * Checks if the grid is currently filtered.
+     *
+     * @returns {Boolean} If grid is currently filtered
+     */
+    isLayerCurrentlyFiltered: function() {
+        var me = this;
+
+        // retrieve store to check if it is filtered
+        var gridWindow = CpsiMapview.util.Grid.getGridWindow(me.layer);
+        var grid = gridWindow.down('grid');
+        var store = grid.getStore();
+        if (!store) {
+            return false;
+        }
+
+        // check if common Ext filters (string, number, list, ...) are set
+        var filters = store.getFilters();
+        var hasGridFilters = false;
+        if (filters) {
+            hasGridFilters = (filters.length > 0);
+        }
+
+        // spatial filters can only be detected by a property in the controller
+        var spatialFilter = grid.getController().spatialFilter;
+        var hasSpatialFilter = false;
+        if (spatialFilter) {
+            hasSpatialFilter = true;
+        }
+
+        return hasGridFilters || hasSpatialFilter;
+    }
+});

--- a/app/view/menuitem/LayerGrid.js
+++ b/app/view/menuitem/LayerGrid.js
@@ -6,8 +6,10 @@
 Ext.define('CpsiMapview.view.menuitem.LayerGrid', {
     extend: 'Ext.menu.Item',
     xtype: 'cmv_menuitem_layergrid',
-    requires: 'CpsiMapview.view.window.MinimizableWindow',
-
+    requires: [
+        'CpsiMapview.view.window.MinimizableWindow',
+        'CpsiMapview.util.Grid'
+    ],
     /**
      * The connected layer for this item.
      *
@@ -22,32 +24,20 @@ Ext.define('CpsiMapview.view.menuitem.LayerGrid', {
     text: 'Open Data Grid',
 
     /**
-     * A Ext.window.Window configuration object
-     * @cfg {Object}
-     */
-    windowConfig: {
-        minHeight: 600,
-        constrain: true,
-        layout: 'fit',
-        maximizable: true,
-        closeAction: 'hide' // don't destroy the window when closed
-    },
-
-    /**
      * @private
      */
     initComponent: function () {
         var me = this;
-        var hasGrid = false;
-
-        if (me.layer) {
-            hasGrid = me.layer.get('gridXType');
-        }
 
         me.handler = me.handlerFunc;
 
         me.callParent();
 
+        // check if layer has a grid
+        var hasGrid = false;
+        if (me.layer.get('gridXType')) {
+            hasGrid = true;
+        }
         me.setHidden(!hasGrid);
     },
 
@@ -57,67 +47,16 @@ Ext.define('CpsiMapview.view.menuitem.LayerGrid', {
      * If there is already an instance of the grid then
      * find its parent window and show this, otherwise
      * create a new grid and associated window.
+     *
+     * Applies the preset filters to the grid.
      */
     handlerFunc: function () {
         var me = this;
+        var gridWindow = CpsiMapview.util.Grid.getGridWindow(me.layer);
 
-        var gridXType = me.layer.get('gridXType');
-        var title = me.layer.get('name');
+        var grid = gridWindow.down('grid');
+        grid.fireEvent('applypresetfilters');
 
-        // we can't keep a reference to the window in this class
-        // as a new Ext.menu.Item is created each time the menu is
-        // opened - use Ext.ComponentQuery instead
-
-        var existingGrids = Ext.ComponentQuery.query(gridXType);
-        var gridWindow;
-        var windowConfig = me.windowConfig;
-
-        if (existingGrids.length > 0) {
-            // get the parent window of the grid
-            gridWindow = existingGrids[0].up('window');
-        } else {
-
-            Ext.apply(windowConfig, {
-                title: title,
-                layout: 'fit',
-                items: [{
-                    xtype: gridXType
-                }],
-                listeners: {
-                    minimize: Ext.emptyFn,
-                    close: function () {
-                        // hide the spatial tool only when closed rather than when
-                        // minimising the window
-                        var me = this;
-                        var queryButton = me.down('cmv_spatial_query_button');
-                        if (queryButton !== null) {
-                            queryButton.fireEvent('hideAssociatedPermanentLayer');
-                            queryButton.toggle(false);
-                        }
-                        // hide the layer with the grid (to hide selections)
-                        var grid = me.down('grid');
-                        grid.fireEvent('hide');
-                    },
-                    show: function () {
-                        var me = this;
-                        var queryButton = me.down('cmv_spatial_query_button');
-                        if (queryButton !== null) {
-                            queryButton.fireEvent('showAssociatedPermanentLayer');
-                        }
-
-                        var grid = me.down('grid');
-                        grid.fireEvent('show');
-                    }
-                }
-            });
-            gridWindow = Ext.create('CpsiMapview.view.window.MinimizableWindow', windowConfig);
-
-            // copy any ViewModel properties from the grid on to its containing window
-            // this allows helpUrl to be set at the grid level
-            var gridViewModelData = gridWindow.down(gridXType).getViewModel().getData();
-            // use apply rather than applyIf otherwise the default empty helpUrl is not overwritten
-            Ext.apply(gridWindow.getViewModel().getData(), gridViewModelData);
-        }
         gridWindow.show();
     }
 });

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -404,7 +404,7 @@
         },
         {
           "property": "AUTHORITY",
-          "value": ["Kerry", "Cavan"],
+          "value": ["Kerry", "Cavan", "Laois", "Galway City", "Carlow", "Kilkenny CC", "Kildare", "Louth", "Offaly", "Roscommon CC", "Tipperary", "Waterford"],
           "operator": "in"
         }
       ],

--- a/test/spec/util/Grid.spec.js
+++ b/test/spec/util/Grid.spec.js
@@ -1,0 +1,22 @@
+describe('CpsiMapview.util.Grid', function() {
+    var cmp = CpsiMapview.util.Grid;
+
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(cmp).not.to.be(undefined);
+        });
+    });
+
+    describe('Functions', function() {
+
+        it('#getGridWindow', function() {
+            var fn = cmp.getGridWindow;
+            expect(fn).not.to.be(undefined);
+        });
+
+        it('#createGridWindow', function() {
+            var fn = cmp.createGridWindow;
+            expect(fn).not.to.be(undefined);
+        });
+    });
+});


### PR DESCRIPTION
references #417 

This PR adds the menu item "Reset Filter".

![image](https://user-images.githubusercontent.com/15704517/121360514-c7a69e80-c934-11eb-8e6e-bfff1025a473.png)


It removes all filters by calling the [`clearFilters`](https://github.com/compassinformatics/cpsi-mapview/blob/master/app/controller/grid/Grid.js#L594-L612) method of the layer's grid. Additionally, if the layer has preset filters, they will be applied with the [`applyPresetFilters`](https://github.com/compassinformatics/cpsi-mapview/blob/master/app/controller/grid/Grid.js#L731-L735) method afterwards.

The menu item is only shown for layers that have a grid. And additionally if one of these conditions are fulfilled:
- the layer-config contains "preset filters"
OR
- the layer is currently filtered

For checking if the layer is currently filtered it is necessary to create the grid earlier. That's why the creation of the grid in the class [`LayerGrid`](https://github.com/compassinformatics/cpsi-mapview/blob/master/app/view/menuitem/LayerGrid.js) is done as soon the context menu of a layer is opened. I could not feeld any performance limitation with this approach.

~~The functionality does not work for the `ruins` layer. Probably because its synchronization between grid and layer is currently broken.~~ 