### PR TITLE
Demo updates

### DIFF
--- a/app/store/WfsFeatures.js
+++ b/app/store/WfsFeatures.js
@@ -2,7 +2,7 @@ Ext.define('CpsiMapview.store.WfsFeatures', {
     extend: 'GeoExt.data.store.WfsFeatures',
     cacheFeatureCount: false,
     remoteSort: true,
-    passThroughFilter: false,
+    passThroughFilter: true,
     remoteFilter: true,
     url: '/mapserver/?',
     version: '2.0.0',

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -361,11 +361,12 @@
       "layerKey": "RUINS_WFS",
       "geometryProperty": "msGeometry",
       "featureType": "ruins",
+      "noCluster": true,
       "hasMetadata": true,
       "sldUrl": "https://w08-mapserver.compass.ie/mapserver/?map=/MapServer/apps/mapview-demo/example.map&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&LAYERS=ruins",
       "idProperty": "osm_id",
       "openLayers": {
-        "visibility": true,
+        "visibility": true
         "maxScale": 400000
       },
       "tooltipsConfig": [

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -366,7 +366,7 @@
       "sldUrl": "https://w08-mapserver.compass.ie/mapserver/?map=/MapServer/apps/mapview-demo/example.map&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&LAYERS=ruins",
       "idProperty": "osm_id",
       "openLayers": {
-        "visibility": true
+        "visibility": true,
         "maxScale": 400000
       },
       "tooltipsConfig": [

--- a/resources/data/layers/tree.json
+++ b/resources/data/layers/tree.json
@@ -27,37 +27,25 @@
             "leaf": true
           },
           {
-            "title": "Boreholes (Switch Layer)",
-            "expanded": false,
-            "children": [
-              {
-                "id": "BOREHOLE_WMS",
-                "leaf": true,
-                "text": "Borehole WMS"
-              },
-              {
-                "id": "BOREHOLE_WFS",
-                "leaf": true,
-                "text": "Borehole WFS (Time)",
-                "qtip": "Filter records with the timeslider control"
-              }
-            ]
+            "id": "BOREHOLE_WMS",
+            "leaf": true,
+            "text": "Borehole WMS"
           },
           {
-            "title": "Waterbody (Switch Layer)",
-            "expanded": false,
-            "children": [
-              {
-                "id": "WATERBODY_SWITCH_LAYER_FAR",
-                "leaf": true,
-                "text": "Waterbody Switch Layer (far)"
-              },
-              {
-                "id": "WATERBODY_SWITCH_LAYER_CLOSE",
-                "leaf": true,
-                "text": "Waterbody Switch Layer (close)"
-              }
-            ]
+            "id": "BOREHOLE_WFS",
+            "leaf": true,
+            "text": "Borehole WFS (Time)",
+            "qtip": "Filter records with the timeslider control"
+          },
+          {
+            "id": "WATERBODY_SWITCH_LAYER_FAR",
+            "leaf": true,
+            "text": "Waterbody Switch Layer (far)"
+          },
+          {
+            "id": "WATERBODY_SWITCH_LAYER_CLOSE",
+            "leaf": true,
+            "text": "Waterbody Switch Layer (close)"
           },
           {
             "id": "TIME_WFS_PROXY",


### PR DESCRIPTION
- Simplifies tree structure
- Changes ruin layer to `noCluster` to allow grid synch (see #428 notes)
- Set `passThroughFilter` to `true` by default for stores