### PR TITLE
disable draw while on edge

### DIFF
--- a/app/controller/button/DigitizeButtonController.js
+++ b/app/controller/button/DigitizeButtonController.js
@@ -1160,6 +1160,7 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
             resultSource.clear();
         } else {
             resultSource.getFeatures()
+                .slice(0)
                 .filter(function (feature) {
                     return feature.get('group') === activeGroupIdx;
                 })


### PR DESCRIPTION
This PR disables draw when clicking on an edge for the digitize tool. This is needed if selection of digitized features in the map should be possible.

It also adds a selection model that allows map selection to the digitize button example.

https://github.com/geoext/geoext/pull/690 should be added for a better selection and a bugfix.

Fixes #421 