### PR TITLE
IE 11 fixes

### DIFF
--- a/app.json
+++ b/app.json
@@ -208,7 +208,7 @@
      */
   "js": [
     {
-      "path": "./node_modules/@geoext/openlayers-legacy/dist/ol-debug.js"
+      "path": "./node_modules/@geoext/openlayers-legacy/dist/ol.js"
     },
     {
       "path": "./node_modules/geostyler-sld-parser/browser/sldStyleParser.js"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/compassinformatics/cpsi-mapview#readme",
   "dependencies": {
-    "@geoext/openlayers-legacy": "^6.5.3",
+    "@geoext/openlayers-legacy": "^6.5.4",
     "eslint": "^6.2.1",
     "font-gis": "^1.0.2",
     "geostyler-openlayers-parser": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@geoext/openlayers-legacy": "^6.5.4",
     "eslint": "^6.2.1",
     "font-gis": "^1.0.2",
-    "geostyler-openlayers-parser": "^2.3.0",
+    "geostyler-openlayers-parser": "^2.3.1",
     "geostyler-sld-parser": "^2.3.0",
     "jsonlint": "^1.6.3"
   },


### PR DESCRIPTION
While investigating the ie11 bug I found out that the openlayers 6.5.0 version we used was not working in ie11. I created a new version that is packaged in `@geoext/openlayers-legacy@6.5.4`.

**Important**: Only the `ol.js` file will work in IE11. The `ol-debug.js` will not work!