### PR TITLE
Ensure switchlayer loadstart events have corresponding loadend event

### DIFF
--- a/app/util/SwitchLayer.js
+++ b/app/util/SwitchLayer.js
@@ -76,6 +76,20 @@ Ext.define('CpsiMapview.util.SwitchLayer', {
      */
     changeInternalLayer: function(layerCollection, switchLayer, index) {
         var staticMe = CpsiMapview.util.SwitchLayer;
+
+        // complete any load events for the layer so the BasiGX.view.MapLoadingStatusBar
+        // decrements correctly
+
+        var source = switchLayer.getSource();
+
+        if (source instanceof ol.source.Image) {
+            source.dispatchEvent('imageloadend');
+        } else if (source instanceof ol.source.Tile) {
+            source.dispatchEvent('tileloadend');
+        } else if (source instanceof ol.source.Vector) {
+            source.dispatchEvent('vectorloadend');
+        }
+
         var switchConfiguration = switchLayer.get('switchConfiguration');
         // restore current layer visibility
         switchConfiguration.visibility = switchLayer.getVisible();


### PR DESCRIPTION
There is an issue where the "Loading..." status bar remains stuck. Can be recreated on https://compassinformatics.github.io/cpsi-mapview/ by zooming in to 1:500 scale and then back to 1:250,000. 

This occurs as the map zoom level changes causing the switchlayer to change its source. The original layer has triggered a `loadstart` event but never completes a `loadend` event. This pull request ensures the event is fired and [decrementAndCheck](https://github.com/terrestris/BasiGX/blob/d1f904c178f87fabb52c6ef43c1b5ee59c9d7e9e/src/view/MapLoadingStatusBar.js#L265) is called in `BasiGX.view.MapLoadingStatusBar`. 

I originally considered trying to add `change:visible` event handlers to `BasiGX.view.MapLoadingStatusBar`, but this issue may only be applicable to switch layers. 



