### PR TITLE
Ensure cluster layers sync with grid filters

### DIFF
--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -211,8 +211,12 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
 
         if (vectorLayer) {
             var vectorSource = vectorLayer.getSource();
+
+            if (vectorSource instanceof ol.source.Cluster) {
+                vectorSource = vectorSource.getSource(); // we use the raw source
+            }
+
             vectorSource.set('additionalFilters', filters);
-            vectorSource.clear();
             vectorSource.refresh();
             me.updateLayerNodeUI(vectorLayer, filters);
         }

--- a/app/util/Layer.js
+++ b/app/util/Layer.js
@@ -26,12 +26,12 @@ Ext.define('CpsiMapview.util.Layer', {
             source.updateParams(params);
             source.refresh();
         } else if (layer.get('isWfs') === true) {
-            // for WFS trigger reload of source
-            if (source.getSource) {
+            if (source instanceof ol.source.Cluster) {
                 // for clustered layers we need to get the original source - see #203
                 source = source.getSource();
             }
-            source.clear();
+            // for WFS trigger reload of source
+            source.refresh();
         } else {
             // only refresh for other layers and sources (to not loose data)
             source.refresh();

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -361,7 +361,7 @@
       "layerKey": "RUINS_WFS",
       "geometryProperty": "msGeometry",
       "featureType": "ruins",
-      "noCluster": true,
+      "noCluster": false,
       "hasMetadata": true,
       "sldUrl": "https://w08-mapserver.compass.ie/mapserver/?map=/MapServer/apps/mapview-demo/example.map&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&LAYERS=ruins",
       "idProperty": "osm_id",


### PR DESCRIPTION
Fixes #430 by ensuring the raw cluster source is used. 
Also removes redundant `vectorSource.clear()` calls as this is called within `vectorSource.refresh()`. 

@simonseyock - there is a comment at https://stackoverflow.com/a/57509897:

> I will just add, that in OL6 this has to be indeed replaced with clusterSource.getSource().refresh()

If this is the case it could be useful to add to the release notes on updating to GeoExt4?