### PR TITLE
Simplify adding the StreetView to the map

### DIFF
--- a/app/controller/button/StreetViewTool.js
+++ b/app/controller/button/StreetViewTool.js
@@ -131,27 +131,12 @@ Ext.define('CpsiMapview.controller.button.StreetViewTool', {
      */
     onToggle: function (btn, pressed) {
         var me = this;
-        var view = me.getView();
-        var lyrGroupName = view.layerGroupName;
-
-        // detect the layer group to add position layer
-        var overlayGroup = BasiGX.util.Layer.getLayerByName(lyrGroupName);
-        var overlayLayers;
-        if (overlayGroup) {
-            overlayLayers = overlayGroup.getLayers();
-        } else{
-            overlayLayers = me.map.getLayers();
-        }
 
         if (pressed) {
-            if (overlayLayers) {
-                // add layer and raise layer to top of stack
-                overlayLayers.insertAt(overlayLayers.getLength(), me.vectorLayer);
-            }
+            // add layer and raise layer to top of stack
+            me.map.addLayer(me.vectorLayer);
         } else {
-            if (overlayLayers) {
-                overlayLayers.remove(me.vectorLayer);
-            }
+            me.map.removeLayer(me.vectorLayer);
             // cleanup
             me.vectorLayer.getSource().clear();
             if (me.streetViewWin) {

--- a/app/controller/button/StreetViewTool.js
+++ b/app/controller/button/StreetViewTool.js
@@ -316,7 +316,6 @@ Ext.define('CpsiMapview.controller.button.StreetViewTool', {
 
             // rotate position feature to current heading
             me.vectorLayer.getStyle().getImage().setRotation(newHeading);
-            vectorSource.refresh();
         }
     },
 

--- a/app/view/button/StreetViewTool.js
+++ b/app/view/button/StreetViewTool.js
@@ -62,13 +62,6 @@ Ext.define('CpsiMapview.view.button.StreetViewTool', {
     vectorLayerStyle: null,
 
     /**
-     * Name of the layer group to which the position layer will be added.
-     *
-     * @cfg {String}
-     */
-    layerGroupName: 'Layers',
-
-    /**
      * The position icon image to be shown on the map.
      *
      * @cfg {String}


### PR DESCRIPTION
With the switch to putting the tree in a group layer in #403, the code to add the StreetView layer can be simplified. It can be hidden from the layer tree like other tool layers (measure, gazetteers etc.). 

However as per #427 the icon is no longer appearing when clicking on the map. This was also the case prior to any changes in this pull request. 

I'm out of ideas why this is no longer appearing. It seems to be added to the (correct) map, and visible. 
