### PR TITLE
Use getFeaturesCollection for interactions

### DIFF
--- a/app/controller/button/DigitizeButtonController.js
+++ b/app/controller/button/DigitizeButtonController.js
@@ -212,7 +212,7 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
         // create the modify interaction
         if (type !== 'Circle') {
             var modifyInteractionConfig = {
-                source: layer.getSource(),
+                features: layer.getSource().getFeaturesCollection(),
                 condition: drawCondition,
                 deleteCondition: deleteCondition
             };
@@ -292,7 +292,7 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
             });
             me.map.addInteraction(me.snapVertexInteraction);
             me.snapEdgeInteraction = new ol.interaction.Snap({
-                source: me.resultLayer.getSource(),
+                features: me.resultLayer.getSource().getFeaturesCollection(),
                 vertex: false
             });
             me.map.addInteraction(me.snapEdgeInteraction);
@@ -326,8 +326,9 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
                 me.drawLayer = view.drawLayer;
             } else {
                 me.drawLayer = new ol.layer.Vector({
-                    source: new ol.source.Vector(),
-                    style: view.getDrawLayerStyle()
+                    source: new ol.source.Vector({
+                        features: new ol.Collection()
+                    })
                 });
 
                 // apply any draw style set from the view


### PR DESCRIPTION
When using an `ol.collection` for the `drawLayer` with a ` ol.interaction.Modify` duplicated features are added. 
This can be seen when using the polyon tool. The first time a polygon is drawn there are two identical features (with the same `ol_uid`) in the layer source:

https://github.com/compassinformatics/cpsi-mapview/blob/e831849db1e0246e163477786cfab952448e95c1/app/controller/button/DigitizeButtonController.js#L924

When the "Clear All" option is used it tries to remove both features, however when removing the second (duplicate) the following error is thrown:

`Get the following error `TypeError: Cannot read property 'ol_uid' of undefined`

The solution (from trial and error) was to set the interaction to use the `features` rather than `source` setting for the [ol.interaction.Modify](https://openlayers.org/en/latest/apidoc/module-ol_interaction_Modify-Modify.html):

  `features: me.resultLayer.getSource().getFeaturesCollection(),`

This pull request also uses the same approach for the snap interaction, altough no errors were notcied when using this. 

@simonseyock - this might be worth adding to the application update notes at https://github.com/terrestris/BasiGX/wiki/Update-application-to-ol-6.5.0,-geoext-4.0.0,-BasiGX-3.0.0 ?
However there is a possibility there is a bug in OpenLayers?

To recreate switch the interaction back to using the `source` and try right-clicking and "Clear All" to throw the error (or check the feature count when adding a new polygon). 