### PR TITLE
Add common Overrides

### DIFF
--- a/app.json
+++ b/app.json
@@ -46,7 +46,8 @@
      * in the "override" property is also included.
      */
     "overrides": [
-        "overrides"
+      "app/overrides",
+      "app/overrides/Ext.Base.js" // not picked up automatically (as not a standard component?)
     ],
 
     /**

--- a/app/overrides/Ext.Base.js
+++ b/app/overrides/Ext.Base.js
@@ -1,0 +1,38 @@
+﻿/**
+ * When using the expander plugin the maximised window has sometimes been destroyed when this function is called
+ * See https://forum.sencha.com/forum/showthread.php?469880-Cannot-read-property-viewModel-of-null for issue and override
+ * Bug ID EXTJS-27586
+ * See also https://stackoverflow.com/questions/64571571/extjs-27586-cannot-read-property-viewmodel-of-null - not fixed in 7.3
+ */
+Ext.override(Ext.Base, {
+    getConfig: function (name, peek, ifInitialized) {
+        var me = this,
+            ret, cfg, propName;
+        if (name) {
+            cfg = me.self.$config.configs[name];
+            if (cfg) {
+                propName = me.$configPrefixed ? cfg.names.internal : name;
+                // They only want the fully initialized value, not the initial config,
+                // but only if it's already present on this instance.
+                // They don't want to trigger the initGetter.
+                // This form is used by Bindable#updatePublishes to initially publish
+                // the properties it's being asked make publishable.
+                if (ifInitialized) {
+                    ret = Object.prototype.hasOwnProperty.call(propName) ? me[propName] : null;
+                } else if (peek) {
+                    // Attempt to return the instantiated property on this instance first.
+                    // Only return the config object if it has not yet been pulled through
+                    // the applier into the instance.
+                    ret = Object.prototype.hasOwnProperty.call(propName) ? me[propName] : (me.config == null ? null : me.config[name]);
+                } else {
+                    ret = me[cfg.names.get]();
+                }
+            } else {
+                ret = me[name];
+            }
+        } else {
+            ret = me.getCurrentConfig();
+        }
+        return ret;
+    }
+});

--- a/app/overrides/Ext.data.validator.Bound.js
+++ b/app/overrides/Ext.data.validator.Bound.js
@@ -1,5 +1,4 @@
-﻿
-Ext.override(Ext.data.validator.Bound, {
+﻿Ext.override(Ext.data.validator.Bound, {
     /**
     * When using a range or bound validator allow null values to return true
     * See https://forum.sencha.com/forum/showthread.php?298213-Range-validator-validates-nullable-fields

--- a/app/overrides/Ext.data.validator.Bound.js
+++ b/app/overrides/Ext.data.validator.Bound.js
@@ -1,0 +1,16 @@
+﻿
+Ext.override(Ext.data.validator.Bound, {
+    /**
+    * When using a range or bound validator allow null values to return true
+    * See https://forum.sencha.com/forum/showthread.php?298213-Range-validator-validates-nullable-fields
+    * And Compass ticket https://support.sencha.com/#ticket-53539
+    * @param {any} value
+    */
+    validate: function (value) {
+        var me = this;
+        if (value === null) {
+            return true;
+        }
+        return me.callParent([value]);
+    }
+});

--- a/app/overrides/Ext.form.field.Base.js
+++ b/app/overrides/Ext.form.field.Base.js
@@ -1,6 +1,4 @@
-﻿
-Ext.override(Ext.form.field.Base, {
-/*
+﻿/*
  * Based on:  https://forum.sencha.com/forum/showthread.php?304374-Binding-doesn-t-work-with-validation
  *
  * by design the bound model isn't updated if the form field is invalid, therefore validation-related bindings aren't triggered
@@ -13,6 +11,7 @@ Ext.override(Ext.form.field.Base, {
  *  "valid"/<not set>: (default) the model is updated only if the field value is valid (default behaviour)
  */
 
+Ext.override(Ext.form.field.Base, {
     bindOn: 'both',
     publishValue: function () {
         var me = this;

--- a/app/overrides/Ext.form.field.Base.js
+++ b/app/overrides/Ext.form.field.Base.js
@@ -1,0 +1,38 @@
+﻿
+Ext.override(Ext.form.field.Base, {
+/*
+ * Based on:  https://forum.sencha.com/forum/showthread.php?304374-Binding-doesn-t-work-with-validation
+ *
+ * by design the bound model isn't updated if the form field is invalid, therefore validation-related bindings aren't triggered
+ * (like the "canSave" formula in the EditFormViewModelMixin" class)
+ * This override lets the model to be updated even if the value in the field is invalid, allowing for further logic to be processed
+ *
+ * It relies on a "bindOn" configuration to be set on the fields to one of the following values:
+ *  "both": updates the model when the field value is either valid or invalid
+ *  "invalid": updates the model only when the value is invalid
+ *  "valid"/<not set>: (default) the model is updated only if the field value is valid (default behaviour)
+ */
+
+    bindOn: 'both',
+    publishValue: function () {
+        var me = this;
+
+        if (me.rendered) {
+            switch (me.bindOn) {
+                case 'both':
+                    me.publishState('value', me.getValue());
+                    break;
+                case 'invalid':
+                    if (me.getErrors().length) {
+                        me.publishState('value', me.getValue());
+                    }
+                    break;
+                case 'valid':
+                default:
+                    if (!me.getErrors().length) {
+                        me.publishState('value', me.getValue());
+                    }
+            }
+        }
+    }
+});

--- a/app/overrides/Ext.grid.RowEditor.js
+++ b/app/overrides/Ext.grid.RowEditor.js
@@ -1,0 +1,44 @@
+﻿/**
+ * Bug ID EXTJS-27043
+ * See https://forum.sencha.com/forum/showthread.php?471594-ExtJS-6-x-Cancel-new-record-in-grid-raise-exception
+ * Still not fixed in https://docs.sencha.com/extjs/7.3.1/classic/src/RowEditor.js.html
+ */
+Ext.override(Ext.grid.RowEditor, {
+
+    cancelEdit: function () {
+        var me = this,
+            form = me.getForm(),
+            fields = form.getFields(),
+            items = fields.items,
+            length = items.length,
+            i,
+            context = me.context;
+
+        if (me._cachedNode) {
+            me.clearCache();
+        }
+
+        me.hide();
+
+        // If we are editing a new record, and we cancel still in invalid state, then remove it.
+        if (context) { // additional guard added to fix bug
+            var record = context.record;
+            if (record && record.phantom && !record.modified && me.removeUnmodified) {
+                me.editingPlugin.grid.store.remove(record);
+            }
+        }
+        form.clearInvalid();
+
+        // temporarily suspend events on form fields before resetting the form to prevent
+        // the fields' change events from firing
+        for (i = 0; i < length; i++) {
+            items[i].suspendEvents();
+        }
+
+        form.reset();
+
+        for (i = 0; i < length; i++) {
+            items[i].resumeEvents();
+        }
+    }
+});

--- a/app/overrides/Ext.grid.column.Column.js
+++ b/app/overrides/Ext.grid.column.Column.js
@@ -1,0 +1,17 @@
+﻿/**
+ * If a tooltip has not been set for a column header
+ * then always default to the column name
+ **/
+Ext.override(Ext.grid.column.Column, {
+    initRenderData: function () {
+
+        var me = this;
+
+        if (Ext.isEmpty(me.tooltip)) {
+            // remove any HTML tags and whitespace so icons don't break the tooltips
+            me.tooltip = Ext.String.trim(Ext.util.Format.stripTags(me.text));
+        }
+
+        return me.callParent(arguments);
+    }
+});

--- a/app/overrides/Ext.grid.filters.filter.Date.js
+++ b/app/overrides/Ext.grid.filters.filter.Date.js
@@ -1,5 +1,4 @@
 ﻿Ext.override(Ext.grid.filters.filter.Date, {
-
     /**
      * The grid Date filter currently ignores the dateFormat and passes raw dates back to
      * the server. This function converts them prior to sending them back using the dateFormat
@@ -19,8 +18,6 @@
         }
 
         filter[key] = val;
-
         me.callParent([filter]);
-
     }
 });

--- a/app/overrides/Ext.grid.filters.filter.Date.js
+++ b/app/overrides/Ext.grid.filters.filter.Date.js
@@ -1,0 +1,26 @@
+﻿Ext.override(Ext.grid.filters.filter.Date, {
+
+    /**
+     * The grid Date filter currently ignores the dateFormat and passes raw dates back to
+     * the server. This function converts them prior to sending them back using the dateFormat
+     * property of the filter.
+     * Date filters are subclasses of Ext.grid.filters.filter.TriFilter so its properties appear
+     * to be ignored.
+     * @param {any} filter
+     */
+    setValue: function (filter) {
+        var me = this;
+
+        // values are in the format {lt: Wed Oct 07 2020 00:00:00 GMT+0200 (Central European Summer Time)}
+        var key = Object.keys(filter)[0];
+        var val = filter[key];
+        if (val) {
+            val = Ext.Date.format(val, me.dateFormat);
+        }
+
+        filter[key] = val;
+
+        me.callParent([filter]);
+
+    }
+});

--- a/app/overrides/Ext.picker.Date.js
+++ b/app/overrides/Ext.picker.Date.js
@@ -1,0 +1,13 @@
+﻿Ext.override(Ext.picker.Date, {
+
+    setValue: function (value) {
+        if (Ext.isString(value)) {
+            // as the date needs to be formatted as a string to send to the server
+            // we need to convert it back again or the DatePicker fails when sending
+            // a string to Ext.Date.clearTime
+            value = Ext.Date.parse(value, this.format);
+        }
+        this.value = Ext.Date.clearTime(value || this.defaultValue, true);
+        return this.update(this.value);
+    }
+});

--- a/app/overrides/Ext.tip.ToolTip.js
+++ b/app/overrides/Ext.tip.ToolTip.js
@@ -1,0 +1,8 @@
+﻿/**
+ * Show tooltips for as long as a user hovers over the relevant item
+ * See https://stackoverflow.com/questions/5817074/ext-js-tooltip-to-stay-when-hover-over
+ * Overriding here fixes tooltips throughout the application - including grid column titles
+ */
+Ext.override(Ext.tip.ToolTip, {
+    dismissDelay: 0
+});


### PR DESCRIPTION
This is a collection of ExtJS overrides that are used in all child applications. 
They are added to the `app.json` file as follows:

```json
  "overrides": [
    "./lib/cpsi-mapview/app/overrides",
    "./lib/cpsi-mapview/app/overrides/Ext.Base.js" // not picked up automatically (as not a standard component?)
  ],
```