### PR TITLE
Ensure all tool layers use new stores when a model is reloaded

### DIFF
--- a/app/controller/button/DigitizeButtonController.js
+++ b/app/controller/button/DigitizeButtonController.js
@@ -1151,6 +1151,7 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
      */
     clearActiveGroup: function (activeGroupIdx) {
         var me = this;
+        var view = me.getView();
 
         if (!me.resultLayer) {
             // no results have been returned so nothing to clear
@@ -1162,10 +1163,7 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
 
         var resultSource = me.resultLayer.getSource();
 
-        if (Ext.isEmpty(activeGroupIdx)) {
-            // remove all features
-            resultSource.clear();
-        } else {
+        if (view.getGroups() === true) {
             resultSource.getFeatures()
                 .slice(0)
                 .filter(function (feature) {
@@ -1174,6 +1172,9 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
                 .forEach(function (feature) {
                     resultSource.removeFeature(feature);
                 });
+        } else {
+            // remove all features
+            resultSource.clear();
         }
 
         var modifications = {

--- a/app/form/ViewModelMixin.js
+++ b/app/form/ViewModelMixin.js
@@ -63,18 +63,6 @@ Ext.define('CpsiMapview.form.ViewModelMixin', {
                     var storeName = me.get('featureStoreName');
                     var currentRecord = me.get('currentRecord');
                     var fs = me.getFeatureStore(currentRecord, storeName);
-
-                    // when a model is reloaded then the featureStore and layer
-                    // is recreated, and the tool is pointing to the old layer
-                    // TODO fix this for all tool types
-                    // see bindings in CpsiMapview.util.EditFormWindowMixin
-                    var pointTool = me.getView().down('#pointDigitiserButton');
-                    if (pointTool) {
-                        var toolCtrl = pointTool.getController();
-                        toolCtrl.setResultLayer(fs.layer);
-                        toolCtrl.setDrawLayer(fs.layer);
-                    }
-
                     if (fs) {
                         return fs.layer;
                     }


### PR DESCRIPTION
Ensure that if a model is reloaded in a form then all the tools on the form point to the layers associated with the new model. 