### PR TITLE
Use page offset for tooltips to work in IE11

### DIFF
--- a/app/view/layer/ToolTip.js
+++ b/app/view/layer/ToolTip.js
@@ -110,8 +110,8 @@ Ext.define('CpsiMapview.view.layer.ToolTip', {
         me.setHtml(html);
 
         // show tooltip near mouse pointer
-        var screenX = evt.originalEvent.x + me.offsetX;
-        var screenY = evt.originalEvent.y + me.offsetY;
+        var screenX = evt.originalEvent.pageX + me.offsetX;
+        var screenY = evt.originalEvent.pageY + me.offsetY;
         me.showAt([screenX, screenY]);
 
         // extjs has somehow problems with the very first render of the tooltip


### PR DESCRIPTION
Otherwise they are displayed in the wrong location. 

![image](https://user-images.githubusercontent.com/490840/124933127-eff0ee00-e003-11eb-98e1-3419e6ca3fe5.png)
