### PR TITLE
Allow digitizing tool to click on existing points

### DIFF
--- a/app/controller/button/DigitizeButtonController.js
+++ b/app/controller/button/DigitizeButtonController.js
@@ -673,7 +673,17 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
         var points = me.getSolverPoints();
 
         if (features.length > 0 && features[0] !== points[points.length - 1]) {
+
+            // for pointerdown and pointerup events we simply want to return
+            // we only want to create a new point on a user click
+            if (evt.type !== 'singleclick') {
+                return true;
+            }
+
             me.blockEventHandling();
+
+            // to allow loops to be created we need to allow users to click on the
+            // start point to add a duplicate end point
 
             me.getNetByPoints(points.concat([features[0]]))
                 .then(me.handleFinalResult.bind(me))
@@ -681,6 +691,8 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
 
             return false;
         } else {
+            // allow edges to be selected by clicking on them
+            // by temporarily setting a blockedEventHandling flag
             var hasEdge = me.map.hasFeatureAtPixel(evt.pixel, {
                 layerFilter: function (layer) {
                     return layer === me.resultLayer;
@@ -894,13 +906,15 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
                 failure: function (response) {
                     mapComponent.setLoading(false);
 
-                    var errorMessage = 'Error while requesting the API endpoint';
+                    if (response.aborted !== true) {
+                        var errorMessage = 'Error while requesting the API endpoint';
 
-                    if (response.responseText && response.responseText.message) {
-                        errorMessage += ': ' + response.responseText.message;
+                        if (response.responseText && response.responseText.message) {
+                            errorMessage += ': ' + response.responseText.message;
+                        }
+
+                        BasiGX.error(errorMessage);
                     }
-
-                    BasiGX.error(errorMessage);
                 }
             });
         });

--- a/app/form/LayersMixin.js
+++ b/app/form/LayersMixin.js
@@ -53,25 +53,5 @@ Ext.define('CpsiMapview.form.LayersMixin', {
         if (this.syncLayerWindowVisibility) {
             this.toggleLayerVisibility(true);
         }
-    },
-
-    onEdgeSelectionChange: function (grid, selected) {
-
-        var vm = this.getView().getViewModel();
-
-        // reset all selections
-        // setting the style to null defaults to using the layer style
-        grid.store.each(function (rec) {
-            rec.getFeature().setStyle(null);
-        });
-
-        var selectStyle = vm.get('selectStyle');
-
-        if (selectStyle) {
-            // highlight grid selection in map
-            Ext.each(selected, function (rec) {
-                rec.getFeature().setStyle(selectStyle);
-            });
-        }
     }
 });

--- a/app/model/FeatureStoreMixin.js
+++ b/app/model/FeatureStoreMixin.js
@@ -58,7 +58,7 @@ Ext.define('CpsiMapview.model.FeatureStoreMixin', {
     },
 
     /**
-     * Create a new feature store
+     * Create a new feature store for a model field
      *
      * @param {Ext.data.Model} model A model to use when loading features
      * @return {GeoExt.data.store.Features} The new feature store

--- a/app/view/layer/ToolTip.js
+++ b/app/view/layer/ToolTip.js
@@ -89,7 +89,7 @@ Ext.define('CpsiMapview.view.layer.ToolTip', {
         // care about clustered features
         if (featureCluster) {
             // in this case take the first feature in the cluster to define the
-            // tooltop text
+            // tooltip text
             if (featureCluster.length > 0) {
                 feature = featureCluster[0];
             } else {


### PR DESCRIPTION
Ignores interaction `pointerdown` and `pointerup` events otherwise new points would be added to the solver from multiple events rather than just the `singleclick`. 

Pull request also includes:

- some minor comment changes
- remove redundant function