### PR TITLE
Allow bypassing of vector layer caching

### DIFF
--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -201,7 +201,7 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
             if (force === true || originalFilterString !== wmsFilterString) {
                 wmsSource.updateParams({
                     FILTER: wmsFilterString,
-                    cacheBuster: Math.random()
+                    TIMESTAMP: Ext.Date.now()
                 });
             }
             // keep a reference to the raw filters so they can be applied to the vector layer
@@ -217,6 +217,10 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
 
             if (vectorSource instanceof ol.source.Cluster) {
                 vectorSource = vectorSource.getSource(); // we use the raw source
+            }
+
+            if (force === true) {
+                vectorSource.set('timestamp', Ext.Date.now())
             }
 
             vectorSource.set('additionalFilters', filters);

--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -220,7 +220,7 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
             }
 
             if (force === true) {
-                vectorSource.set('timestamp', Ext.Date.now())
+                vectorSource.set('timestamp', Ext.Date.now());
             }
 
             vectorSource.set('additionalFilters', filters);

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -443,6 +443,15 @@ Ext.define('CpsiMapview.factory.Layer', {
                 url, 'FILTER=' + encodeURIComponent(filter)
             );
 
+            // add a timestamp parameter to the URL is set on the source
+            // so that we can bypass the browser cache if required
+            var ts = vectorSource.get('timestamp');
+            if (ts) {
+                reqUrl = Ext.String.urlAppend(
+                    reqUrl, 'TIMESTAMP=' + ts
+                );
+            }
+
             var xhr = new XMLHttpRequest();
             xhr.open('GET', reqUrl);
             var onError = function() {

--- a/app/util/Layer.js
+++ b/app/util/Layer.js
@@ -22,7 +22,7 @@ Ext.define('CpsiMapview.util.Layer', {
         // mostly WMS layers
         if (source.updateParams) {
             var params = source.getParams();
-            params.noCache = new Date().getMilliseconds();
+            params.TIMESTAMP = Ext.Date.now();
             source.updateParams(params);
             source.refresh();
         } else if (layer.get('isWfs') === true) {
@@ -31,6 +31,7 @@ Ext.define('CpsiMapview.util.Layer', {
                 source = source.getSource();
             }
             // for WFS trigger reload of source
+            source.set('timestamp', Ext.Date.now())
             source.refresh();
         } else {
             // only refresh for other layers and sources (to not loose data)

--- a/app/util/Layer.js
+++ b/app/util/Layer.js
@@ -31,7 +31,7 @@ Ext.define('CpsiMapview.util.Layer', {
                 source = source.getSource();
             }
             // for WFS trigger reload of source
-            source.set('timestamp', Ext.Date.now())
+            source.set('timestamp', Ext.Date.now());
             source.refresh();
         } else {
             // only refresh for other layers and sources (to not loose data)

--- a/app/util/SwitchLayer.js
+++ b/app/util/SwitchLayer.js
@@ -139,7 +139,7 @@ Ext.define('CpsiMapview.util.SwitchLayer', {
             var newParams = {
                 STYLES: activeStyle,
                 FILTER: wmsFilterString,
-                cacheBuster: Math.random()
+                TIMESTAMP: Ext.Date.now()
             };
             newLayerSource.updateParams(newParams);
         } else if (newLayer.get('isWfs') || newLayer.get('isVt')) {
@@ -151,7 +151,7 @@ Ext.define('CpsiMapview.util.SwitchLayer', {
 
             // load and parse SLD and apply it to layer
             LayerFactory.loadSld(newLayer, sldUrl);
-            newLayerSource.clear();
+            newLayerSource.set('timestamp', Ext.Date.now())
             newLayerSource.refresh();
         } else {
             Ext.Logger.info('Layer type not supported in StyleSwitcherRadioGroup');

--- a/app/util/SwitchLayer.js
+++ b/app/util/SwitchLayer.js
@@ -151,7 +151,7 @@ Ext.define('CpsiMapview.util.SwitchLayer', {
 
             // load and parse SLD and apply it to layer
             LayerFactory.loadSld(newLayer, sldUrl);
-            newLayerSource.set('timestamp', Ext.Date.now())
+            newLayerSource.set('timestamp', Ext.Date.now());
             newLayerSource.refresh();
         } else {
             Ext.Logger.info('Layer type not supported in StyleSwitcherRadioGroup');


### PR DESCRIPTION
Adds a `timestamp` property on the vector source that can then be used as a URL parameter to ensure features are requested from the server rather than browser cache. 

This pull request also harmonises the cache-bustin parameter to `TIMESTAMP` for both WFS and WMS. 