### PR TITLE
Use pageX and pageY for all context menus

### DIFF
--- a/app/controller/button/DigitizeButtonController.js
+++ b/app/controller/button/DigitizeButtonController.js
@@ -495,7 +495,7 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
             renderTo: Ext.getBody(),
             items: menuItems
         });
-        menu.showAt(evt.x, evt.y);
+        menu.showAt(evt.pageX, evt.pageY);
     },
 
     /**

--- a/app/controller/button/SpatialQueryButton.js
+++ b/app/controller/button/SpatialQueryButton.js
@@ -195,7 +195,7 @@ Ext.define('CpsiMapview.controller.button.SpatialQueryButtonController', {
                 scope: me
             }]
         });
-        menu.showAt(evt.x, evt.y);
+        menu.showAt(evt.pageX, evt.pageY);
     },
     /**
      * Connects the change:visible event of the query layer

--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -74,7 +74,7 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
      * Open a row-level context-menu with a Zoom to Feature option
      * @private
      */
-    onItemContextMenu: function (grid, record, item, index, e) {
+    onItemContextMenu: function (grid, record, item, index, evt) {
         var me = this;
         var vm = me.getViewModel();
         var map = vm.get('map');
@@ -107,8 +107,8 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
             }
         });
 
-        e.stopEvent();
-        contextMenu.showAt(e.getXY());
+        evt.stopEvent();
+        contextMenu.showAt(evt.pageX, evt.pageY);
     },
 
     /**

--- a/app/plugin/FeatureAttributeGrouping.js
+++ b/app/plugin/FeatureAttributeGrouping.js
@@ -95,11 +95,11 @@ Ext.define('CpsiMapview.plugin.FeatureAttributeGrouping', {
         });
     },
 
-    showContext: function (e) {
+    showContext: function (evt) {
         var me = this;
 
         if (this.groupingActive) {
-            e.preventDefault();
+            evt.preventDefault();
 
             var menu = Ext.create('Ext.menu.Menu', {
                 width: 160,
@@ -112,7 +112,7 @@ Ext.define('CpsiMapview.plugin.FeatureAttributeGrouping', {
                     }
                 }]
             });
-            menu.showAt(e.x, e.y);
+            menu.showAt(evt.pageX, evt.pageY);
         }
     }
 });


### PR DESCRIPTION
This change ensures context menus are shown in the correct location in IE11, and has no changes for other browsers. 