### PR TITLE
Ensure the External Layers group layer is visible in the layer tree

### DIFF
--- a/app/controller/addWms/AddWmsFormController.js
+++ b/app/controller/addWms/AddWmsFormController.js
@@ -7,12 +7,18 @@ Ext.define('CpsiMapview.controller.addWms.AddWmsFormController', {
         var me = this;
         var map = BasiGX.util.Map.getMapComponent().getMap();
 
-        if (this.layerGroup === undefined) {
-            this.layerGroup = new ol.layer.Group({
-                name: this.getView().layerGroupName,
+        if (me.layerGroup === undefined) {
+
+            // create a new layer group to hold the external layers
+            me.layerGroup = new ol.layer.Group({
+                name: me.getView().layerGroupName,
                 collapsed: false
             });
-            map.addLayer(this.layerGroup);
+
+            // add the external group layer to the layerTreeRoot
+            // so it appears in the layer tree
+            var layerTreeRoot = map.get('layerTreeRoot');
+            layerTreeRoot.getLayers().push(me.layerGroup);
 
             setTimeout(function () {
                 var layerTrees = Ext.ComponentQuery.query('cmv_layertree');
@@ -26,7 +32,8 @@ Ext.define('CpsiMapview.controller.addWms.AddWmsFormController', {
         olLayer.set('refreshLayerOption', true);
         olLayer.set('opacitySlider', true);
 
+        // now add the external layer to the external layers group
         map.removeLayer(olLayer);
-        this.layerGroup.getLayers().push(olLayer);
+        me.layerGroup.getLayers().push(olLayer);
     }
 });

--- a/test/spec/view/addWms/AddWmsForm.spec.js
+++ b/test/spec/view/addWms/AddWmsForm.spec.js
@@ -1,0 +1,13 @@
+describe('CpsiMapview.view.addWms.AddWmsForm', function() {
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(CpsiMapview.view.addWms.AddWmsForm).not.to.be(undefined);
+        });
+
+        it('can be instantiated', function() {
+            var inst = Ext.create('CpsiMapview.view.addWms.AddWmsForm', {});
+            expect(inst).to.be.a(CpsiMapview.view.addWms.AddWmsForm);
+        });
+
+    });
+});


### PR DESCRIPTION
Following #403 the External Layers folder was no longer visible in the layer tree. This pull request adds it back to the new `map.get('layerTreeRoot')`. 