### PR TITLE
Allow exporting of the grid to a shapefile

### DIFF
--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -493,6 +493,35 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
     },
 
     /**
+     * Export the current records in the grid to a zipped shapefile
+     *
+     * @private
+     */
+    exportToShapefile: function () {
+
+        var me = this;
+        var grid = me.getView();
+
+        var store = grid.getStore();
+        var url = store.url;
+
+        var params = store.createParameters();
+        params.outputFormat = 'shapezip';
+
+        // files can't be downloaded using Ext.Ajax.request (due to browser security)
+        // so a hidden form is used with standardSubmit set to true
+        // this approach does not allow callbacks to be run on success / failure
+
+        Ext.create('Ext.form.Panel', {
+            standardSubmit: true
+        }).submit({
+            params: params,
+            url: url
+        });
+
+    },
+
+    /**
      * Whenever columns are shown or hidden update
      * the WFS propertyName so only data to
      * be displayed is returned. The idProperty will

--- a/app/model/grid/Grid.js
+++ b/app/model/grid/Grid.js
@@ -21,7 +21,9 @@ Ext.define('CpsiMapview.model.grid.Grid', {
         allowFeatureSelection: false,
         // when isSpatialGrid is set to false the 'Select by Shape' button will be hidden
         isSpatialGrid: true,
-        usePresetFilters: false
+        usePresetFilters: false,
+        exportExcelVisible: true,
+        exportShapefileVisible: true
     },
 
     formulas: {

--- a/app/view/grid/Grid.js
+++ b/app/view/grid/Grid.js
@@ -121,7 +121,7 @@ Ext.define('CpsiMapview.view.grid.Grid', {
                 hidden: '{!usePresetFilters}'
             }
         },
-        '->',
+            '->',
         {
             xtype: 'cmv_spatial_query_button',
             drawGeometryType: 'Polygon',
@@ -184,7 +184,19 @@ Ext.define('CpsiMapview.view.grid.Grid', {
             xtype: 'button',
             text: 'Export to Excel',
             glyph: 'xf1c3@FontAwesome',
-            handler: 'exportToExcel'
+            handler: 'exportToExcel',
+            bind: {
+                hidden: '{!exportExcelVisible}'
+            }
+        },
+        {
+            xtype: 'button',
+            text: 'Export to Shapefile',
+            glyph: 'eaa2@font-gis',
+            handler: 'exportToShapefile',
+            bind: {
+                hidden: '{!exportShapefileVisible}'
+            }
         }]
     },
     {

--- a/app/view/grid/Grid.js
+++ b/app/view/grid/Grid.js
@@ -121,7 +121,7 @@ Ext.define('CpsiMapview.view.grid.Grid', {
                 hidden: '{!usePresetFilters}'
             }
         },
-            '->',
+        '->',
         {
             xtype: 'cmv_spatial_query_button',
             drawGeometryType: 'Polygon',


### PR DESCRIPTION
Allows the contents of the grid to be exported as a zipped shapefile. 
Relies on https://github.com/geoext/geoext/pull/700

![image](https://user-images.githubusercontent.com/490840/128697810-988a4ba9-1bf0-4c93-b529-5b35b3f48ecc.png)


This also adds 2 new viewmodel properties that can be used to hide/show the export buttons:

```
        exportExcelVisible: true,
        exportShapefileVisible: true
```