### PR TITLE
Minor fixes to get all tests running

### DIFF
--- a/app/controller/toolbar/CircleSelectionToolbar.js
+++ b/app/controller/toolbar/CircleSelectionToolbar.js
@@ -82,9 +82,15 @@ Ext.define('CpsiMapview.controller.toolbar.CircleSelectionToolbar', {
      */
     setCurrentUnit: function () {
         var me = this;
-        var map = BasiGX.util.Map.getMapComponent().map;
-        var unit = map.getView().getProjection().getUnits();
-        me.getViewModel().set('unit', unit);
+        var cmp = BasiGX.util.Map.getMapComponent();
+
+        if (cmp) {
+            var map = cmp.map;
+            var unit = map.getView().getProjection().getUnits();
+            me.getViewModel().set('unit', unit);
+        } else {
+            Ext.log.warn('No map component found for the CircleSelectionToolbar');
+        }
     },
 
     /**

--- a/app/form/ViewModelMixin.js
+++ b/app/form/ViewModelMixin.js
@@ -54,7 +54,13 @@ Ext.define('CpsiMapview.form.ViewModelMixin', {
         formulas: {
 
             map: function () {
-                return BasiGX.util.Map.getMapComponent().getMap();
+                var cmp = BasiGX.util.Map.getMapComponent();
+                if (cmp) {
+                    return cmp.getMap();
+                }
+                else {
+                    return null;
+                }
             },
 
             resultLayer: {
@@ -106,7 +112,9 @@ Ext.define('CpsiMapview.form.ViewModelMixin', {
                 get: function (data) {
                     var ret = data.isValid;
                     ret = ret && (data.isLocked !== true);
-                    ret = ret && this.getFormulas().belongsToRoleReadWrite.call(this, this.getFormulaFn);
+                    if (this.getFormulas().belongsToRoleReadWrite) {
+                        ret = ret && this.getFormulas().belongsToRoleReadWrite.call(this, this.getFormulaFn);
+                    }
                     return ret;
                 }
             },
@@ -118,7 +126,9 @@ Ext.define('CpsiMapview.form.ViewModelMixin', {
                 },
                 get: function (data) {
                     var ret = (data.isLocked !== true) && !data.phantom;
-                    ret = ret && this.getFormulas().belongsToRoleReadWrite.call(this, this.getFormulaFn);
+                    if (this.getFormulas().belongsToRoleReadWrite) {
+                        ret = ret && this.getFormulas().belongsToRoleReadWrite.call(this, this.getFormulaFn);
+                    }
                     return ret;
                 }
             },
@@ -129,6 +139,9 @@ Ext.define('CpsiMapview.form.ViewModelMixin', {
                     phantom: '{currentRecord.phantom}'
                 },
                 get: function (data) {
+                    if (!data.currentRecord || !data.currentRecord.isPhantom) {
+                        return false;
+                    }
                     return !data.currentRecord.isPhantom();
                 }
             }

--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -110,7 +110,7 @@ Ext.define('CpsiMapview.view.main.Map', {
 
     inheritableStatics: {
         /**
-         * Tries to detect the first occurance of this map panel.
+         * Tries to detect the first occurrence of this map panel.
          * @return {CpsiMapview.view.main.Map} The map panel, which is at least
          *     a GeoExt.component.Map and possibly an instance of this class.
          */
@@ -129,12 +129,12 @@ Ext.define('CpsiMapview.view.main.Map', {
         var newLayerConf = {};
 
         // general default
-        var generalDefaults = defaults['general'];
+        var generalDefaults = defaults ? defaults['general'] : {};
         Ext.Object.merge(newLayerConf, generalDefaults);
 
         // layer type default
-        var typeDefaults = defaults[layerConf.layerType];
-        Ext.Object.merge(newLayerConf,typeDefaults);
+        var typeDefaults = defaults ? defaults[layerConf.layerType] : {};
+        Ext.Object.merge(newLayerConf, typeDefaults);
 
         // actual config
         Ext.Object.merge(newLayerConf, layerConf);

--- a/karma-conf.common.js
+++ b/karma-conf.common.js
@@ -10,6 +10,16 @@ module.exports = function(config) {
         'node_modules/@geoext/openlayers-legacy/dist/ol.js',
         'https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all-debug.js',
         'https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/packages/ux/classic/ux.js',
+        // GeoExt source files
+        {
+            pattern: 'lib/geoext3/src/**/*.js',
+            included: true
+        },
+        // GeoExt classic toolkit source files
+        {
+            pattern: 'lib/geoext3/classic/**/*.js',
+            included: true
+        },
         'https://cdnjs.cloudflare.com/ajax/libs/opentype.js/0.6.9/opentype.min.js',
         'https://cdn.jsdelivr.net/npm/jsonix@3.0.0/jsonix.min.js',
         'https://cdn.jsdelivr.net/gh/bjornharrtell/jsts@gh-pages/1.4.0/jsts.min.js',
@@ -24,13 +34,14 @@ module.exports = function(config) {
         'https://cdn.jsdelivr.net/gh/highsource/ogc-schemas@2.6.1/scripts/lib/WPS_1_0_0.js',
         'https://cdn.jsdelivr.net/gh/highsource/w3c-schemas@1.4.0/scripts/lib/XLink_1_0.js',
         'https://cdn.jsdelivr.net/npm/proj4@2.5.0/dist/proj4-src.min.js',
-        'https://maps.googleapis.com/maps/api/js?v=3.36',
-        'lib/geoext3/src/**/*.js',
-        'lib/geoext3/classic/**/*.js',
+        'https://maps.googleapis.com/maps/api/js?v=3.42&key=AIzaSyAj6xrC0L3G0YquO1q6Qsma1ZEfYgGQotU',
+        {
+            pattern: 'app/**/*.js',
+            included: true
+        },
         'lib/BasiGX/src/**/*.js',
-        'app/**/*js',
         'test/test-helper-functions.js',
-        'test/**/*js',
+        'test/**/*.js',
         {pattern: 'test/resources/**/*', watched: false, included: false, served: true}
     ];
 
@@ -58,7 +69,7 @@ module.exports = function(config) {
         ],
 
         preprocessors: {
-            'src/**/*.js': ['coverage']
+            'app/**/*.js': ['coverage']
         },
 
         // test results reporter to use

--- a/test/spec/form/ViewMixin.spec.js
+++ b/test/spec/form/ViewMixin.spec.js
@@ -27,7 +27,7 @@ describe('CpsiMapview.form.ViewMixin', function () {
 
             // create a new view with the mixin
             editWindow = Ext.create('CpsiMapview.form.TestWindow');
-            editWindow.show();
+            editWindow.show(); // we need to show the window to create the tools
             buttonBar = editWindow.down('buttonBar');
         });
 

--- a/test/spec/form/ViewModelMixin.spec.js
+++ b/test/spec/form/ViewModelMixin.spec.js
@@ -1,10 +1,10 @@
 Ext.define('CpsiMapview.form.TestViewModelModel', {
-    extend: 'Ext.data.Model',
-    fields: ['id']
+    extend: 'Ext.data.Model'
 });
 
 Ext.define('CpsiMapview.form.TestViewModel', {
     extend: 'Ext.app.ViewModel',
+    alias: 'viewmodel.cmv_testviewmodel',
     mixins: ['CpsiMapview.form.ViewModelMixin']
 });
 
@@ -21,12 +21,17 @@ describe('CpsiMapview.form.ViewModelMixin', function () {
 
     describe('Functions', function () {
 
-        var vm, currentRecord;
+        var editForm, vm, currentRecord;
 
         beforeEach(function () {
-            // create a new view with the mixin
-            vm = Ext.create('CpsiMapview.form.TestViewModel');
+            // create a new view with the viewmodel and mixin
+            editForm = Ext.create('Ext.window.Window', {
+                viewModel: {
+                    type: 'cmv_testviewmodel'
+                }
+            });
 
+            vm = editForm.getViewModel();
             currentRecord = Ext.create('CpsiMapview.form.TestViewModelModel');
             vm.set('currentRecord', currentRecord);
 
@@ -50,6 +55,6 @@ describe('CpsiMapview.form.ViewModelMixin', function () {
             vm.destroy();
             expect(currentRecord).not.to.be(undefined);
         });
-
     });
+
 });

--- a/test/spec/view/LayerTree.spec.js
+++ b/test/spec/view/LayerTree.spec.js
@@ -1,7 +1,7 @@
 describe('CpsiMapview.view.LayerTree', function() {
     describe('Basics', function() {
         it('is defined', function() {
-            expect(CpsiMapview.view.main.Map).not.to.be(undefined);
+            expect(CpsiMapview.view.LayerTree).not.to.be(undefined);
         });
 
         it('can be instantiated', function() {


### PR DESCRIPTION
The previous pull request reduced the test coverage, even though more tests were added. 
On each run of the tests (using `karma start karma.conf.js --single-run`) different numbers of tests were run - (worringly) missing tests didn't appear at all in the summary.
On inspection in the browser debugger (`karma start --browsers Chrome --single-run=False --debug --auto-watch`) there were several JS errors relating to viewmodel formulas that required a map etc. 
Once these were fixed the full test suite started running again. 