### PR TITLE
Rename functions and classes for clarity and add docstrings

### DIFF
--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -1,3 +1,8 @@
+/**
+ * The controller for the {@link CpsiMapview.view.LayerTree}
+ *
+ * @class CpsiMapview.controller.LayerTreeController
+ */
 Ext.define('CpsiMapview.controller.LayerTreeController', {
     extend: 'Ext.app.ViewController',
 

--- a/app/controller/form/Login.js
+++ b/app/controller/form/Login.js
@@ -1,3 +1,8 @@
+/**
+ * The controller for the {@link CpsiMapview.view.form.Login}
+ *
+ * @class CpsiMapview.controller.form.Login
+ */
 Ext.define('CpsiMapview.controller.form.Login', {
     extend: 'Ext.app.ViewController',
     requires: [

--- a/app/controller/panel/NumericAttributeSlider.js
+++ b/app/controller/panel/NumericAttributeSlider.js
@@ -1,6 +1,6 @@
 /**
  * This is the controller for the {@link CpsiMapview.view.panel.NumericAttributeSlider} component
- * 
+ *
  * @class CpsiMapview.controller.panel.NumericAttributeSlider
  */
 Ext.define('CpsiMapview.controller.panel.NumericAttributeSlider', {

--- a/app/controller/panel/NumericAttributeSlider.js
+++ b/app/controller/panel/NumericAttributeSlider.js
@@ -1,3 +1,8 @@
+/**
+ * This is the controller for the {@link CpsiMapview.view.panel.NumericAttributeSlider} component
+ * 
+ * @class CpsiMapview.controller.panel.NumericAttributeSlider
+ */
 Ext.define('CpsiMapview.controller.panel.NumericAttributeSlider', {
     extend: 'Ext.app.ViewController',
 

--- a/app/form/ControllerMixin.js
+++ b/app/form/ControllerMixin.js
@@ -8,7 +8,7 @@ Ext.define('CpsiMapview.form.ControllerMixin', {
     extend: 'Ext.Mixin',
     mixins: {
         zoomer: 'CpsiMapview.util.ZoomerMixin',
-        validation: 'CpsiMapview.form.ValidationMessages'
+        validation: 'CpsiMapview.form.ValidationMessagesMixin'
     },
 
     /** The possible return codes from the services */
@@ -60,6 +60,10 @@ Ext.define('CpsiMapview.form.ControllerMixin', {
                     iconCls: Ext.MessageBox.ERROR
                 });
         }
+
+        // fire an event that saving the model failed
+        var view = me.getView();
+        view.fireEvent('savefailed');
     },
 
     /**

--- a/app/form/LayersMixin.js
+++ b/app/form/LayersMixin.js
@@ -51,7 +51,7 @@ Ext.define('CpsiMapview.form.LayersMixin', {
     /**
      * Hides the layers associated with the form when the
      * form is hidden
-     * */
+     */
     onHide: function () {
         if (this.syncLayerWindowVisibility) {
             this.toggleLayerVisibility(false);
@@ -61,7 +61,7 @@ Ext.define('CpsiMapview.form.LayersMixin', {
     /**
      * Shows the layers associated with the form when the
      * form is hidden
-     * */
+     */
     onWindowShow: function () {
         if (this.syncLayerWindowVisibility) {
             this.toggleLayerVisibility(true);

--- a/app/form/LayersMixin.js
+++ b/app/form/LayersMixin.js
@@ -24,6 +24,11 @@ Ext.define('CpsiMapview.form.LayersMixin', {
         }
     },
 
+    /**
+     * Changes the visibility of any of the layers associated
+     * with the form (layers are defined in the viewmodel)
+     * @param {boolean} show
+     */
     toggleLayerVisibility: function (show) {
 
         var vm = this.getView().getViewModel();
@@ -43,12 +48,20 @@ Ext.define('CpsiMapview.form.LayersMixin', {
         }
     },
 
+    /**
+     * Hides the layers associated with the form when the
+     * form is hidden
+     * */
     onHide: function () {
         if (this.syncLayerWindowVisibility) {
             this.toggleLayerVisibility(false);
         }
     },
 
+    /**
+     * Shows the layers associated with the form when the
+     * form is hidden
+     * */
     onWindowShow: function () {
         if (this.syncLayerWindowVisibility) {
             this.toggleLayerVisibility(true);

--- a/app/form/RightInfoField.js
+++ b/app/form/RightInfoField.js
@@ -1,5 +1,9 @@
 /**
- * A mixin to handle hiding and showing layers associated with an edit model
+ * A field container that wraps a field component and adds an "i"
+ * button with a tooltip that gives a description of the field.
+ * 
+ * This allows the tooltip to always be available, unlike the
+ * built-in field tooltip which is used to show field validation messages.
  *
  * @class CpsiMapview.form.RightInfoField
  */

--- a/app/form/RightInfoField.js
+++ b/app/form/RightInfoField.js
@@ -1,7 +1,7 @@
 /**
  * A field container that wraps a field component and adds an "i"
  * button with a tooltip that gives a description of the field.
- * 
+ *
  * This allows the tooltip to always be available, unlike the
  * built-in field tooltip which is used to show field validation messages.
  *

--- a/app/form/ValidationMessagesMixin.js
+++ b/app/form/ValidationMessagesMixin.js
@@ -2,9 +2,9 @@
  * A mixin to handle form validation and displaying
  * the reason why the Save button is disabled
  *
- * @class CpsiMapview.form.ValidationMessages
+ * @class CpsiMapview.form.ValidationMessagesMixin
  */
-Ext.define('CpsiMapview.form.ValidationMessages', {
+Ext.define('CpsiMapview.form.ValidationMessagesMixin', {
     extend: 'Ext.Mixin',
 
     checkValid: function (rec) {

--- a/app/form/ViewMixin.js
+++ b/app/form/ViewMixin.js
@@ -215,7 +215,7 @@ Ext.define('CpsiMapview.form.ViewMixin', {
                         itemId: 'saveButton',
                         text: 'Save',
                         handler: 'onSaveClick',
-                        // Save button tooltips are updated using CpsiMapview.form.ValidationMessages
+                        // Save button tooltips are updated using CpsiMapview.form.ValidationMessagesMixin
                         tooltip: 'Save the record',
                         bind: {
                             disabled: '{!canSave}',

--- a/app/form/ViewModelMixin.js
+++ b/app/form/ViewModelMixin.js
@@ -13,7 +13,7 @@ Ext.define('CpsiMapview.form.ViewModelMixin', {
 
     mixinConfig: {
         before: {
-            destroy: 'destroyUtil'
+            destroy: 'destroyCurrentRecord'
         },
         after: {
             initConfig: 'onInitConfig'
@@ -23,7 +23,7 @@ Ext.define('CpsiMapview.form.ViewModelMixin', {
     /**
      * Destroy the currently associated record
      * */
-    destroyUtil: function () {
+    destroyCurrentRecord: function () {
         var me = this;
         var rec = me.get('currentRecord');
         rec.destroy();

--- a/app/plugin/ExpandPanel.js
+++ b/app/plugin/ExpandPanel.js
@@ -1,3 +1,9 @@
+/**
+ * A plugin that allows a panel nested in a form
+ * to be expanded to a full-size window
+ *
+ * @class CpsiMapview.plugin.ExpandPanel
+ */
 Ext.define('CpsiMapview.plugin.ExpandPanel', {
     extend: 'Ext.plugin.Abstract',
     alias: 'plugin.cmv_expand_panel',

--- a/app/plugin/FeatureAttributeGrouping.js
+++ b/app/plugin/FeatureAttributeGrouping.js
@@ -1,3 +1,9 @@
+/**
+ * A plugin that highlights features in a {ol.layer.Vector} which share
+ * a property
+ *
+ * @class CpsiMapview.plugin.FeatureAttributeGrouping
+ */
 Ext.define('CpsiMapview.plugin.FeatureAttributeGrouping', {
     extend: 'Ext.plugin.Abstract',
     alias: 'plugin.cmv_feature_attribute_grouping',

--- a/app/store/Readme.md
+++ b/app/store/Readme.md
@@ -1,2 +1,0 @@
-This folder contains store instances (identified by storeId) and store types
-(with "store.foo" aliases).

--- a/app/store/WfsFeatures.js
+++ b/app/store/WfsFeatures.js
@@ -1,3 +1,9 @@
+/**
+ * A customized version of {@link GeoExt.data.store.WfsFeatures} with
+ * preset store properties
+ *
+ * @class CpsiMapview.store.WfsFeatures
+ */
 Ext.define('CpsiMapview.store.WfsFeatures', {
     extend: 'GeoExt.data.store.WfsFeatures',
     cacheFeatureCount: false,

--- a/app/view/button/DigitizeButton.js
+++ b/app/view/button/DigitizeButton.js
@@ -1,9 +1,5 @@
 /**
- * This class is the digitize button of cpsi mapview application
- * It can be used e.g. for the zone tool
- */
-/**
- * Digitize Button
+ * A digitize button used for drawing and modifying features
  *
  * @class CpsiMapview.view.button.DigitizeButton
  */

--- a/app/view/grid/ItemDeleter.js
+++ b/app/view/grid/ItemDeleter.js
@@ -1,3 +1,9 @@
+/**
+ * A column action that displays a button that can be used to delete a record
+ * in a grid
+ *
+ * @class CpsiMapview.view.grid.ItemDeleter
+ */
 Ext.define('CpsiMapview.view.grid.ItemDeleter',
     {
         extend: 'Ext.grid.column.Action',


### PR DESCRIPTION
This pull request addresses some of the issues highlighted by @chrismayer in a code review.
The following are addressed:

https://github.com/compassinformatics/cpsi-mapview/blob/master/app/form/ControllerMixin.js#L40
Maybe fire also an event like 'savefailed', like it is done for success case.

https://github.com/compassinformatics/cpsi-mapview/blob/master/app/form/RightInfoField.js#L2
API-Docs are maybe wrong here? I think this is no Mixin, is it?

https://github.com/compassinformatics/cpsi-mapview/blob/master/app/form/ValidationMessages.js#L7
I'd suggest to rename it with a 'Mixin' suffix in the class name to be consistent.

https://github.com/compassinformatics/cpsi-mapview/blob/master/app/form/ViewModelMixin.js#L26
The 'destroyUtil' naming seems non intuitive here

https://github.com/compassinformatics/cpsi-mapview/blob/master/app/form/ViewModelMixin.js#L43
Missing API-docs should be added. Also applies for other Mixin classes.

There are still plenty of doc updates to add in and also the types issue below to address, so this pull request is hopefully the first of several (time permitting). 

https://github.com/compassinformatics/cpsi-mapview/blob/master/app/form/ViewModelMixin.js#L34
The API-Docs type {any} should be precised. Also applies for other Mixin classes.

