### PR TITLE
Introduce splitByClick button

### DIFF
--- a/app/controller/button/SplitByClickButtonController.js
+++ b/app/controller/button/SplitByClickButtonController.js
@@ -222,7 +222,8 @@ Ext.define('CpsiMapview.controller.button.SplitByClickButtonController', {
     handleFinalResult: function(features) {
         if (features) {
             var me = this;
-            var resultSource = me.resultLayer.getSource().clear();
+            var resultSource = me.resultLayer.getSource();
+            resultSource.clear();
             resultSource.addFeatures(features);
         }
     },

--- a/app/controller/button/SplitByClickButtonController.js
+++ b/app/controller/button/SplitByClickButtonController.js
@@ -1,0 +1,246 @@
+/**
+ * This class is the controller for the SplitByClick button.
+ */
+Ext.define('CpsiMapview.controller.button.SplitByClickButtonController', {
+    extend: 'Ext.app.ViewController',
+    requires: [
+        'BasiGX.util.Map',
+        'GeoExt.component.FeatureRenderer',
+        'GeoExt.data.store.Features'
+    ],
+
+    alias: 'controller.cmv_split_by_click_button',
+
+    /**
+     * The OpenLayers map. If not given, will be auto-detected
+     */
+    map: null,
+
+    /**
+     * The BasiGX mapComponent. If not given, will be auto-detected
+     */
+    mapComponent: null,
+
+    /**
+     * Temporary vector layer used to display the response split features
+     */
+    resultLayer: null,
+
+    constructor: function() {
+        var me = this;
+        me.splitOnClickedPosition = me.splitOnClickedPosition.bind(me);
+
+        me.callParent(arguments);
+    },
+
+
+    /**
+     * Main handler which activates or deactivates the click listener for the
+     * map.
+     *
+     * @param {Ext.button.Button} btn The button that has been pressed
+     * @param {boolean} pressed The toggle state of the button
+     */
+    onToggle: function(btn, pressed) {
+        var me = this;
+        var view = me.getView();
+
+        // guess the map if not given
+        if (!me.map) {
+            me.map = BasiGX.util.Map.getMapComponent().map;
+        }
+
+        // create a result layer unless one has already been set
+        if (!me.resultLayer) {
+            me.resultLayer = view.resultLayer;
+        }
+
+        if (pressed) {
+            me.map.on('click', me.splitOnClickedPosition);
+        } else {
+            me.map.un('click', me.splitOnClickedPosition);
+        }
+    },
+
+    /**
+     * Asynchronously request and proceed split features depending on clicked
+     * position.
+     *
+     * @param {Event} evt OpenLayers click event
+     * @returns {Ext.Promise<any|undefined>}
+     */
+    splitOnClickedPosition: function(evt) {
+        var me = this;
+        var map = me.map;
+        var proj = map.getView().getProjection().getCode();
+        var coordinates = evt.coordinate;
+        var point = new ol.Feature(new ol.geom.Point(coordinates));
+        var extent = point.getGeometry().getExtent();
+        var associatedWin = this.getView().up('window');
+        var associatedVm = associatedWin.getViewModel();
+        var parentId = associatedVm.get('currentRecord.publicPrivateSplitId');
+        var buffered = ol.extent.buffer(extent, me.getView().getPointExtentBuffer());
+        // transform to ITM since this projection is expected by backend.
+        var bufferedITM = ol.proj.transformExtent(buffered, proj, 'EPSG:2157');
+        var bboxSearchParam = '&bbox=' + encodeURIComponent(bufferedITM.join(','));
+        var idParam = 'publicPrivateSplitId=';
+
+        if (isNaN(parentId)) {
+            // we're going to create a new split
+            idParam += '0';
+        } else {
+            // we're going to edit the existing one
+            idParam += parentId;
+        }
+        var searchParams = idParam + bboxSearchParam;
+
+        return me.doAjaxRequest(searchParams)
+            .then(me.parseSplitResponse.bind(me))
+            .then(me.handleFinalResult.bind(me));
+    },
+
+    /**
+     * Parses the split result to OpenLayers features
+     *
+     * @param {XMLHttpRequest} response
+     * @returns {ol.Feature[]}
+     */
+    parseSplitResponse: function(response) {
+        if (response) {
+            var json;
+
+            if (!Ext.isEmpty(response.responseText)) {
+
+                try {
+                    json = Ext.decode(response.responseText);
+                } catch (e) {
+                    BasiGX.error('Could not parse the response: ' +
+                        response.responseText);
+                    return;
+                }
+
+                if (json.success && json.data) {
+                    var existingPpSplitId = json.data.existingPublicPrivateSplitId;
+                    if (existingPpSplitId !== null) {
+                        this.handleExistingSplit(existingPpSplitId);
+                    } else {
+                        var splitEdgeFeats = json.data.splitEdgeFeatures;
+                        if (splitEdgeFeats.features && splitEdgeFeats.features.length === 2) {
+                            var format = new ol.format.GeoJSON();
+                            return format.readFeaturesFromObject(splitEdgeFeats);
+                        }
+                    }
+                } else {
+                    BasiGX.error('Could not perform the split: ' +
+                        (json.message ? json.message : JSON.stringify(json)));
+                }
+            } else {
+                BasiGX.error('Could not perform the split: ' +
+                    (json.message ? json.message : JSON.stringify(json)));
+            }
+        } else {
+            BasiGX.error('Response was empty');
+        }
+    },
+
+    /**
+     * Issues an Ext.Ajax.request against the configured endpoint with
+     * the given params.
+     *
+     * @param {string} searchParams The serarchParams which will be
+     *   appended to the request url
+     * @returns {Ext.request.Base}
+     */
+    doAjaxRequest: function(searchParams) {
+        var me = this;
+        var mapComponent = me.mapComponent || BasiGX.util.Map.getMapComponent();
+        var view = me.getView();
+        var url = view.getApiUrl();
+
+        if (!url) {
+            return;
+        }
+
+        if (searchParams) {
+            url = Ext.urlAppend(url, searchParams);
+        }
+
+        mapComponent.setLoading(true);
+
+        return new Ext.Promise(function(resolve) {
+            Ext.Ajax.request({
+                url: url,
+                method: 'GET',
+                success: function(response) {
+                    mapComponent.setLoading(false);
+                    resolve(response);
+                },
+                failure: function(response) {
+                    mapComponent.setLoading(false);
+
+                    if (response.aborted !== true) {
+                        var errorMessage = 'Error while requesting the API endpoint';
+
+                        if (response.responseText && response.responseText.message) {
+                            errorMessage += ': ' + response.responseText.message;
+                        }
+
+                        BasiGX.error(errorMessage);
+                    }
+                }
+            });
+        });
+    },
+
+    /**
+     * Show confirm dialog to decide, whether the found existing split should be
+     * opened for edit.
+     * @param {number} splitId
+     */
+    handleExistingSplit: function(splitId) {
+
+        var msg = 'This edge has already been split. Open existing split record?';
+        var me = this;
+
+        BasiGX.confirm(msg, {
+            title: 'Open Existing Split?',
+            fn: function(buttonId) {
+                if (buttonId === 'yes') {
+                    var win = me.getView().up('window');
+                    win.fireEvent('splitedgesupdate', splitId);
+                }
+            }
+        });
+    },
+
+    /**
+     * Handles the final result from endopoint. Refreshes the result layer with
+     * retrieved split features.
+     *
+     * @param {undefined|ol.Feature[]} features The features returned from the API.
+     */
+    handleFinalResult: function(features) {
+        if (features) {
+            var me = this;
+            var resultSource = me.resultLayer.getSource().clear();
+            resultSource.addFeatures(features);
+        }
+    },
+
+    /**
+     * Remove the result layer when this component gets destroyed.
+     */
+    onBeforeDestroy: function() {
+
+        var me = this;
+        var btn = me.getView();
+
+        // detoggle button
+        me.onToggle(btn, false);
+
+        if (me.resultLayer) {
+            me.map.removeLayer(me.resultLayer);
+        }
+
+    }
+});

--- a/app/controller/button/SplitByClickButtonController.js
+++ b/app/controller/button/SplitByClickButtonController.js
@@ -176,6 +176,7 @@ Ext.define('CpsiMapview.controller.button.SplitByClickButtonController', {
         var url = view.getApiUrl();
 
         if (!url) {
+            Ext.log.warn('No API URL passed - split is not possible.');
             return;
         }
 

--- a/app/controller/button/SplitByClickButtonController.js
+++ b/app/controller/button/SplitByClickButtonController.js
@@ -33,6 +33,24 @@ Ext.define('CpsiMapview.controller.button.SplitByClickButtonController', {
         me.callParent(arguments);
     },
 
+    /**
+     * Set the layer used to store features returned by the split service
+     * @param {ol.Layer} layer
+     */
+    setResultLayer: function(layer) {
+        var me = this;
+
+        if (!me.map) {
+            return;
+        }
+
+        if (me.resultLayer) {
+            me.map.removeLayer(me.resultLayer);
+        }
+
+        me.resultLayer = layer;
+    },
+
 
     /**
      * Main handler which activates or deactivates the click listener for the

--- a/app/field/Line.js
+++ b/app/field/Line.js
@@ -97,7 +97,8 @@ Ext.define('CpsiMapview.field.Line', {
     },
 
     /**
-    * Create a new ol style
+    * Create a new ol style. One of the ol.style.Style or OpenLayers style function
+    * will be returned.
     *
     * @return {ol.style.Style} The new style
     */
@@ -105,6 +106,10 @@ Ext.define('CpsiMapview.field.Line', {
 
         var me = this;
         var cfg = me.featureStoreConfig || {};
+
+        if (cfg && cfg.styleFn) {
+            return cfg.styleFn;
+        }
 
         var lineColor = cfg.lineColor || me.styleDefaults.lineColor;
         var pointColor = cfg.pointColor || me.styleDefaults.pointColor;

--- a/app/form/ControllerMixin.js
+++ b/app/form/ControllerMixin.js
@@ -320,6 +320,12 @@ Ext.define('CpsiMapview.form.ControllerMixin', {
             toolCtrl.setResultLayer(resultLayer);
         }
 
+        if (vm.get('hideSplitByClickButton') === false) {
+            tool = vw.down('#splitByClickButton');
+            toolCtrl = tool.getController();
+            toolCtrl.setResultLayer(resultLayer);
+        }
+
         // only destroy this after the new record has been set as getting errors in checkHadValue > getChildValue
         // it seems to be an issue with checkBoxes only
         existingRec.destroy();

--- a/app/form/ViewMixin.js
+++ b/app/form/ViewMixin.js
@@ -6,7 +6,8 @@
 Ext.define('CpsiMapview.form.ViewMixin', {
     extend: 'Ext.Mixin',
     requires: [
-        'CpsiMapview.view.button.DigitizeButton'
+        'CpsiMapview.view.button.DigitizeButton',
+        'CpsiMapview.view.button.SplitByClickButton'
     ],
     mixinConfig: {
         after: {
@@ -60,6 +61,7 @@ Ext.define('CpsiMapview.form.ViewMixin', {
             hideDigitiseLineButton: true,
             hideDigitiseCircleButton: true,
             hideDigitisePointButton: true,
+            hideSplitByClickButton: true,
             hideSaveButton: false,
             hideCancelButton: false,
             hideConfirmButton: true,
@@ -224,6 +226,16 @@ Ext.define('CpsiMapview.form.ViewMixin', {
                             disabled: '{isLocked}',
                             resultLayer: '{resultLayer}',
                             hidden: '{hideDigitisePointButton}'
+                        }
+                    },
+                    {
+                        xtype: 'cmv_split_by_click_button',
+                        itemId: 'splitByClickButton',
+                        apiUrl: '/WebServices/roadschedule/publicprivatesplit/split',
+                        bind: {
+                            disabled: '{isProcessed}',
+                            resultLayer: '{resultLayer}',
+                            hidden: '{hideSplitByClickButton}'
                         }
                     },
                     { xtype: 'tbfill' },

--- a/app/model/button/SplitByClickButtonModel.js
+++ b/app/model/button/SplitByClickButtonModel.js
@@ -1,0 +1,12 @@
+/**
+ * This class is the view model for the SplitByClickButtonModel.
+ */
+Ext.define('CpsiMapview.model.button.SplitByClickButtonModel', {
+    extend: 'Ext.app.ViewModel',
+
+    alias: 'viewmodel.cmv_split_by_click_button',
+
+    data: {
+        tooltip: 'Click on a road to split an edge into two parts - public and private'
+    }
+});

--- a/app/view/button/SplitByClickButton.js
+++ b/app/view/button/SplitByClickButton.js
@@ -1,0 +1,75 @@
+/**
+ * This class is the split by click button of cpsi mapview application
+ * It can be used e.g. for the public/private splits tool
+ */
+/**
+ * SplitByClick Button
+ *
+ * @class CpsiMapview.view.button.SplitByClickButton
+ */
+Ext.define('CpsiMapview.view.button.SplitByClickButton', {
+    extend: 'Ext.button.Button',
+    xtype: 'cmv_split_by_click_button',
+
+    requires: [
+        'CpsiMapview.model.button.SplitByClickButtonModel',
+        'CpsiMapview.controller.button.SplitByClickButtonController'
+    ],
+
+    /**
+     * The viewModel for this class
+     */
+    viewModel: 'cmv_split_by_click_button',
+
+    /**
+     * The controller for this class
+     */
+    controller: 'cmv_split_by_click_button',
+
+    /**
+     * The icon (scissors) used for the button
+     */
+    glyph: 'xf0c4@FontAwesome',
+
+    config: {
+
+        /**
+         * URL needs to be set on instantiation of button
+         */
+        apiUrl: null,
+
+        /**
+         * If set higher than 0 the request URL gets appended with a `bbox`
+         * parameter, which is calculated by the point and
+         * this buffer in units of the maps projection.
+         * Internally, this uses the `buffer` method of ol.extent
+         */
+        pointExtentBuffer: 50,
+
+        /**
+         * Set a layer to store the split results
+         * If not set a layer will be created and added to the map automatically
+         */
+        resultLayer: null
+    },
+
+    /**
+     * The name to be used e.g. in ComponentQueries
+     */
+    name: 'splitByClickButton',
+
+    /**
+     * The name of the toggleGroup
+     * Activates the toggle behaviour of the button
+     */
+    toggleGroup: 'map',
+
+    /**
+     * Register the listeners and redirect them
+     * to their corresponding controller methods
+     */
+    listeners: {
+        toggle: 'onToggle',
+        beforedestroy: 'onBeforeDestroy'
+    }
+});

--- a/test/spec/controller/button/SplitByClickButtonController.spec.js
+++ b/test/spec/controller/button/SplitByClickButtonController.spec.js
@@ -1,0 +1,12 @@
+describe('CpsiMapview.controller.button.SplitByClickButtonController', function() {
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(CpsiMapview.controller.button.SplitByClickButtonController).not.to.be(undefined);
+        });
+
+        it('can be created', function() {
+            var ctrl = new CpsiMapview.controller.button.SplitByClickButtonController();
+            expect(ctrl).to.not.be(undefined);
+        });
+    });
+});

--- a/test/spec/view/button/SplitByClickButton.spec.js
+++ b/test/spec/view/button/SplitByClickButton.spec.js
@@ -1,0 +1,12 @@
+describe('CpsiMapview.view.button.SplitByClickButton', function() {
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(CpsiMapview.view.button.SplitByClickButton).not.to.be(undefined);
+        });
+
+        it('can be instantiated', function() {
+            var inst = Ext.create('CpsiMapview.view.button.SplitByClickButton');
+            expect(inst).to.be.a(CpsiMapview.view.button.SplitByClickButton);
+        });
+    });
+});


### PR DESCRIPTION
* Introduces `splitByClickButton` component which enables to split existing road segments into two parts (public and private) by clicking on the appropriate segment feature on the map
* Concepted to used while operating on `Public/Private Splits` component currently integrated into PMS project
* Additionally enables passing of OpenLayers style function while configuring selectionLayer bound to grid store

Please review @geographika @select-8 