### PR TITLE
Add Help mixin

### DIFF
--- a/app/controller/button/HelpButtonController.js
+++ b/app/controller/button/HelpButtonController.js
@@ -1,0 +1,10 @@
+/**
+ * This class is the controller for the {@link CpsiMapview.view.button.HelpButton} button.
+ */
+Ext.define('CpsiMapview.controller.button.HelpButtonController', {
+    extend: 'Ext.app.ViewController',
+
+    alias: 'controller.cmv_help_button',
+
+    mixins: ['CpsiMapview.form.HelpMixin']
+});

--- a/app/controller/button/LoginButtonController.js
+++ b/app/controller/button/LoginButtonController.js
@@ -22,7 +22,7 @@ Ext.define('CpsiMapview.controller.button.LoginButtonController', {
      * */
     onClick: function () {
 
-        var app = Ext.getApplication();
+        var app = Ext.getApplication ? Ext.getApplication() : Ext.app.Application.instance;
         var loginWin;
 
         if (app && app.loginWindow) {

--- a/app/controller/window/MinimizableWindow.js
+++ b/app/controller/window/MinimizableWindow.js
@@ -6,6 +6,8 @@ Ext.define('CpsiMapview.controller.window.MinimizableWindow', {
 
     alias: 'controller.cmv_minimizable_window',
 
+    mixins: ['CpsiMapview.form.HelpMixin'],
+
     /**
      * When closing the window in code make
      * sure that the window is restored first so
@@ -66,37 +68,6 @@ Ext.define('CpsiMapview.controller.window.MinimizableWindow', {
             if (minimizeTo) {
                 minimizeTo.fireEvent('restoreFromWindow', me.getView());
             }
-        }
-    },
-
-    /**
-     * Opens any associated helpUrl in a new browser tab
-     * If the URL does not start with 'http' then an application
-     * rootHelpUrl is appended to the URL if present
-     * */
-    onHelp: function () {
-
-        var me = this;
-        var url = me.getViewModel().get('helpUrl');
-
-        if (!url) {
-            return;
-        }
-
-        // TODO unsure why Ext.getApplication is sometimes undefined
-        var app = Ext.getApplication ? Ext.getApplication() : Ext.app.Application.instance;
-        var rootUrl = app.rootHelpUrl;
-
-        if (rootUrl && (Ext.String.startsWith(url, 'http') === false)){
-            url = rootUrl + url;
-        }
-
-        var win = window.open(url, 'mapview-help'); // use '_blank' if we want a new window each time
-
-        if (!win) {
-            Ext.Msg.alert('Pop-up Blocked', 'The help page was blocked from opening. Please allow pop-ups for this site.');
-        } else {
-            win.focus();
         }
     }
 });

--- a/app/form/HelpMixin.js
+++ b/app/form/HelpMixin.js
@@ -16,16 +16,19 @@ Ext.define('CpsiMapview.form.HelpMixin', {
     onHelp: function () {
 
         var me = this;
-        var helpUrl = me.getViewModel().get('helpUrl');
 
-        if (!helpUrl) {
-            // no link provided
-            return;
-        }
+        // get the helpUrl from the viewmodel (if set)
+        var vm = me.getViewModel();
+        var helpUrl = vm ? vm.get('helpUrl') : '';
 
         // unsure why Ext.getApplication is sometimes undefined
         var app = Ext.getApplication ? Ext.getApplication() : Ext.app.Application.instance;
         var rootUrl = app.rootHelpUrl;
+
+        if (!helpUrl && !rootUrl) {
+            // no link provided
+            return;
+        }
 
         var fullUrl = me.buildHelpUrl(helpUrl, rootUrl);
         var win = window.open(fullUrl, 'mapview-help'); // use '_blank' if we want a new window each time

--- a/app/form/HelpMixin.js
+++ b/app/form/HelpMixin.js
@@ -1,0 +1,75 @@
+﻿/**
+ * A mixin that can be added to a controller
+ * to handle opening system help links
+ *
+ * @class CpsiMapview.form.HelpMixin
+ */
+Ext.define('CpsiMapview.form.HelpMixin', {
+    extend: 'Ext.Mixin',
+
+    /**
+     * Opens any associated helpUrl in a new browser tab
+     * If the URL does not start with 'http' then an application
+     * rootHelpUrl is appended to the URL if present
+     * @return {String} Full URL to the help page*
+     */
+    onHelp: function () {
+
+        var me = this;
+        var helpUrl = me.getViewModel().get('helpUrl');
+
+        if (!helpUrl) {
+            // no link provided
+            return;
+        }
+
+        // unsure why Ext.getApplication is sometimes undefined
+        var app = Ext.getApplication ? Ext.getApplication() : Ext.app.Application.instance;
+        var rootUrl = app.rootHelpUrl;
+
+        var fullUrl = me.buildHelpUrl(helpUrl, rootUrl);
+        var win = window.open(fullUrl, 'mapview-help'); // use '_blank' if we want a new window each time
+
+        if (!win) {
+            Ext.Msg.alert('Pop-up Blocked', 'The help page was blocked from opening. Please allow pop-ups for this site.');
+        } else {
+            win.focus();
+        }
+
+        return fullUrl;
+    },
+
+    /**
+    * Build a URL based on root and page fragments
+    *
+    * @param {String} helpUrl A full URL or a relative link within the documentation
+    * @param {String} rootUrl A root/base URL for the documentation
+    * @return {String} Full URL to the help page
+    * @private
+    */
+    buildHelpUrl: function (helpUrl, rootUrl) {
+
+        var fullUrl;
+
+        if (rootUrl && (Ext.String.startsWith(helpUrl, 'http') === false)) {
+
+            // trim any slashes from the URLs to avoid double slashes
+            if (Ext.String.endsWith(rootUrl, '/')) {
+                rootUrl = rootUrl.slice(0, -1);
+            }
+
+            if (Ext.String.startsWith(helpUrl, '/')) {
+                helpUrl = helpUrl.slice(1);
+            }
+
+            // now format the URLs with a single slash
+            fullUrl = Ext.String.format('{0}/{1}', rootUrl, helpUrl);
+
+        } else {
+            // no rootUrl is set or the link URL is a direct http link
+            fullUrl = helpUrl;
+        }
+
+        return fullUrl;
+    }
+});

--- a/app/form/ViewMixin.js
+++ b/app/form/ViewMixin.js
@@ -27,7 +27,8 @@ Ext.define('CpsiMapview.form.ViewMixin', {
 
         // depending on the global application flag enableIsLocked
         // hide or show the padlock icon in the window header
-        var addPadlock = Ext.getApplication().enableIsLocked;
+        var app = Ext.getApplication ? Ext.getApplication() : Ext.app.Application.instance;
+        var addPadlock = app.enableIsLocked;
 
         if (addPadlock !== false) {
             var toolConfig = {

--- a/app/view/button/HelpButton.js
+++ b/app/view/button/HelpButton.js
@@ -1,0 +1,38 @@
+/**
+ * This class is a button to open the system help
+ *
+ * @class CpsiMapview.view.button.HelpButton
+ */
+Ext.define('CpsiMapview.view.button.HelpButton', {
+    extend: 'Ext.button.Button',
+    xtype: 'cmv_help_button',
+
+    requires: [
+        'CpsiMapview.controller.button.HelpButtonController'
+    ],
+
+    tooltip: 'Open the Help System',
+
+    /**
+     * The icon the button should use
+     */
+    glyph: 'f059@FontAwesome',
+
+    /**
+     * The controller for this class
+     */
+    controller: 'cmv_help_button',
+
+    /**
+     * The name to be used e.g. in ComponentQueries
+     */
+    name: 'helpButton',
+
+    /**
+     * Register the listeners and redirect them
+     * to their corresponding controller methods
+     */
+    listeners: {
+        click: 'onHelp'
+    }
+});

--- a/test/load-tests.js
+++ b/test/load-tests.js
@@ -9,11 +9,9 @@
         }
     });
 
-    // Get "Ext.getApplication is not a function" when running tests so mock this here
-    Ext.getApplication = function () {
-        return {
-            enableIsLocked: true // enable the padlock icon
-        };
-    }
+    // create a simple object to mock the application for testing
+    Ext.app.Application.instance = {
+        enableIsLocked: true // enable the padlock icon
+    };
 
 }(document, this));

--- a/test/spec/controller/button/HelpButtonController.spec.js
+++ b/test/spec/controller/button/HelpButtonController.spec.js
@@ -1,0 +1,12 @@
+describe('CpsiMapview.controller.button.HelpButtonController', function() {
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(CpsiMapview.controller.button.HelpButtonController).not.to.be(undefined);
+        });
+
+        it('can be created', function() {
+            var ctrl = new CpsiMapview.controller.button.HelpButtonController();
+            expect(ctrl).to.not.be(undefined);
+        });
+    });
+});

--- a/test/spec/form/HelpMixin.spec.js
+++ b/test/spec/form/HelpMixin.spec.js
@@ -1,0 +1,85 @@
+Ext.define('CpsiMapview.form.TestHelpController', {
+    extend: 'Ext.app.ViewController',
+    alias: 'controller.TestHelpController',
+    mixins: ['CpsiMapview.form.HelpMixin']
+});
+
+describe('CpsiMapview.form.HelpMixin', function () {
+
+    it('is defined', function () {
+        expect(CpsiMapview.form.HelpMixin).not.to.be(undefined);
+    });
+
+    it('can be instantiated', function () {
+        var inst = Ext.create('CpsiMapview.form.HelpMixin');
+        expect(inst).to.be.a(CpsiMapview.form.HelpMixin);
+    });
+
+    describe('Functions', function () {
+
+        var editForm;
+
+        beforeEach(function () {
+
+            // create a new view with the controller and mixin
+            editForm = Ext.create('Ext.window.Window', {
+                viewModel: {
+                    helpUrl: ''
+                },
+                controller: {
+                    type: 'TestHelpController'
+                }
+            });
+
+        });
+
+        afterEach(function () {
+            // reset the application value
+            Ext.app.Application.instance.rootHelpUrl = '';
+        });
+
+        it('check a URL is built with a root URL', function () {
+
+            Ext.app.Application.instance.rootHelpUrl = 'http://localhost/';
+            editForm.getViewModel().set('helpUrl', 'path/page.html');
+
+            var ctrl = editForm.getController();
+            var fullUrl = ctrl.onHelp();
+
+            expect(fullUrl).to.be('http://localhost/path/page.html');
+        });
+
+        it('check a URL can override a root URL', function () {
+
+            Ext.app.Application.instance.rootHelpUrl = 'http://localhost/';
+            editForm.getViewModel().set('helpUrl', 'http://localhost2/path/page.html');
+
+            var ctrl = editForm.getController();
+            var fullUrl = ctrl.onHelp();
+
+            expect(fullUrl).to.be('http://localhost2/path/page.html');
+        });
+
+        it('check a URL without a root URL', function () {
+
+            Ext.app.Application.instance.rootHelpUrl = '';
+            editForm.getViewModel().set('helpUrl', './path/page.html');
+
+            var ctrl = editForm.getController();
+            var fullUrl = ctrl.onHelp();
+
+            expect(fullUrl).to.be('./path/page.html');
+        });
+
+        it('check double slashes are removedL', function () {
+
+            Ext.app.Application.instance.rootHelpUrl = 'http://localhost/';
+            editForm.getViewModel().set('helpUrl', '/path/page.html');
+
+            var ctrl = editForm.getController();
+            var fullUrl = ctrl.onHelp();
+
+            expect(fullUrl).to.be('http://localhost/path/page.html');
+        });
+    });
+});

--- a/test/spec/view/button/HelpButton.spec.js
+++ b/test/spec/view/button/HelpButton.spec.js
@@ -1,0 +1,12 @@
+describe('CpsiMapview.view.button.HelpButton', function() {
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(CpsiMapview.view.button.HelpButton).not.to.be(undefined);
+        });
+
+        it('can be instantiated', function() {
+            var inst = Ext.create('CpsiMapview.view.button.HelpButton');
+            expect(inst).to.be.a(CpsiMapview.view.button.HelpButton);
+        });
+    });
+});


### PR DESCRIPTION
This moves the logic to open a help link out of the `MinimizableWindow` controller into its own mixin.
This then allows the same logic to be used on a new standalone help button. 

On addition this update uses the following logic in the codebase to allow tests to run successfully, as `Ext.getApplication` is always null:

`Ext.getApplication ? Ext.getApplication() : Ext.app.Application.instance;`

`Ext.app.Application.instance` is set to a simple object in `test/load-tests.js`