### PR TITLE
Add improved error logging for missing layers and keys

### DIFF
--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -235,7 +235,7 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
      */
     createOlLayerGroups: function (treeNodeChilds, parentGroup) {
         var me = this;
-        // go over all passed in tree childs nodes
+        // go over all passed in tree child nodes
         Ext.each(treeNodeChilds, function (child) {
             // apply defaults for tree nodes from config
             var generalDefaults = me.treeConfDefaults.general || {};
@@ -276,7 +276,24 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
                     parentGroup.getLayers().insertAt(0, mapLyr);
 
                 } else {
-                    Ext.Logger.warn('Layer with layerKey ' + child.id + ' not found in map layers');
+                    //<debug>
+
+                    // get the layers config object
+                    var app = Ext.getApplication ? Ext.getApplication() : Ext.app.Application.instance;
+                    var layerJson = app.layerJson;
+
+
+                    // any switch layers not in the resolution when the app is loaded will be missing
+                    // so we check for layer keys in the config JSON
+
+                    var childLayers = Ext.Array.pluck(layerJson.layers, 'layers').filter(Boolean);
+                    var allLayers = Ext.Array.merge(Ext.Array.flatten(childLayers), layerJson.layers)
+                    var layerKeys = Ext.Array.pluck(allLayers, 'layerKey');
+
+                    if (!Ext.Array.indexOf(layerKeys, child.id) === -1) {
+                        Ext.Logger.warn('Layer with layerKey ' + child.id + ' not found in map layers');
+                    }
+                    //</debug>
                 }
             }
         });

--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -287,7 +287,7 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
                     // so we check for layer keys in the config JSON
 
                     var childLayers = Ext.Array.pluck(layerJson.layers, 'layers').filter(Boolean);
-                    var allLayers = Ext.Array.merge(Ext.Array.flatten(childLayers), layerJson.layers)
+                    var allLayers = Ext.Array.merge(Ext.Array.flatten(childLayers), layerJson.layers);
                     var layerKeys = Ext.Array.pluck(allLayers, 'layerKey');
 
                     if (!Ext.Array.indexOf(layerKeys, child.id) === -1) {

--- a/app/model/FeatureEventsMixin.js
+++ b/app/model/FeatureEventsMixin.js
@@ -50,7 +50,7 @@ Ext.define('CpsiMapview.model.FeatureEventsMixin', {
                 layerUtil.layerRefresh(layer);
             } else {
                 //<debug>
-                Ext.log.error('layerKey "' + k + '" in layerKey invalid for ' + me.$className);
+                Ext.log.error('layerKey "' + k + '" in syncLayerKeys invalid for ' + me.$className);
                 //</debug>
             }
         });

--- a/app/model/FeatureEventsMixin.js
+++ b/app/model/FeatureEventsMixin.js
@@ -48,6 +48,10 @@ Ext.define('CpsiMapview.model.FeatureEventsMixin', {
             if (layers.length > 0) {
                 var layer = layers[0];
                 layerUtil.layerRefresh(layer);
+            } else {
+                //<debug>
+                Ext.log.error('layerKey "' + k + '" in layerKey invalid for ' + me.$className);
+                //</debug>
             }
         });
 
@@ -56,6 +60,15 @@ Ext.define('CpsiMapview.model.FeatureEventsMixin', {
             var store = Ext.data.StoreManager.lookup(k);
             if (store) {
                 store.reload();
+            } else {
+                //<debug>
+                // store may not be found if it has not yet been created
+                // so check if it can be created by the supplied alias
+                if (!Ext.ClassManager.getByAlias('store.' + k)) {
+                    Ext.log.error('Store alias "' + k + '" in syncStoreIds not found for '
+                        + me.$className);
+                }
+                //</debug>
             }
         });
 

--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -241,7 +241,7 @@ Ext.define('CpsiMapview.view.main.Map', {
                 //<debug>
                 // save the layer configuration as property on the application for debugging
                 var app = Ext.getApplication ? Ext.getApplication() : Ext.app.Application.instance;
-                app.layerJson = newConfiguration
+                app.layerJson = newConfiguration;
                 //</debug>
 
                 // fire event to inform subscribers that all layers are loaded

--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -238,6 +238,12 @@ Ext.define('CpsiMapview.view.main.Map', {
                     }
                 });
 
+                //<debug>
+                // save the layer configuration as property on the application for debugging
+                var app = Ext.getApplication ? Ext.getApplication() : Ext.app.Application.instance;
+                app.layerJson = newConfiguration
+                //</debug>
+
                 // fire event to inform subscribers that all layers are loaded
                 me.fireEvent('cmv-init-layersadded', me);
 


### PR DESCRIPTION
When running locally (in debug) add console messages warning if any of the model `syncStoreIds` or `syncLayerKeys` are invalid.

Also check all layer keys in the `tree.json` are available as layers from `default.json` -by getting the full list of `layerKey` properties and checking they exist. 


![image](https://user-images.githubusercontent.com/490840/132564350-a2ca6585-6690-422b-9134-41b1ffb6e816.png)
