### PR TITLE
Ensure onApplicationUpdated is triggered

### DIFF
--- a/app/util/ApplicationMixin.js
+++ b/app/util/ApplicationMixin.js
@@ -28,7 +28,8 @@ Ext.define('CpsiMapview.util.ApplicationMixin', {
 
     mixinConfig: {
         after: {
-            constructor: 'onApplicationCreated'
+            constructor: 'onApplicationCreated',
+            onAppUpdate: 'onApplicationUpdated'
         }
     },
 
@@ -271,7 +272,7 @@ Ext.define('CpsiMapview.util.ApplicationMixin', {
     /**
      * Ask the use if they wish to refresh the browser following an application update
      * */
-    onAppUpdate: function () {
+    onApplicationUpdated: function () {
         Ext.Msg.confirm('Application Update', 'This application has an update, reload?',
             function (choice) {
                 if (choice === 'yes') {


### PR DESCRIPTION
Prior to this update the `onAppUpdate` was never called (due to having the same name as a function in [Ext.app.Application](https://docs.sencha.com/extjs/6.7.0/classic/Ext.app.Application.html#method-onAppUpdate).

This adds a hook (and renames the function to distinguish it from its owning class). 