### PR TITLE
Remove polygon when switching to point digitizing tool

### DIFF
--- a/app/controller/button/DigitizeButtonController.js
+++ b/app/controller/button/DigitizeButtonController.js
@@ -998,11 +998,17 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
                 newLength += f.get('length') ? f.get('length') : 0;
             });
 
+            var newEdgeCount = features.filter(function (feature) {
+                return feature.getGeometry() instanceof ol.geom.LineString;
+            }).length;
+
             var modifications = {
                 originalLength: originalLength,
                 newLength: newLength,
+                newEdgeCount: newEdgeCount,
                 originalSolverPoints: originalSolverPoints,
-                newSolverPoints: newSolverPoints
+                newSolverPoints: newSolverPoints,
+                toolType: me.getView().type
             };
 
             // fire a custom event from the source so a listener can be added once

--- a/app/form/ViewMixin.js
+++ b/app/form/ViewMixin.js
@@ -158,6 +158,9 @@ Ext.define('CpsiMapview.form.ViewMixin', {
                                 })
                             })
                         }),
+                        listeners: {
+                            toggle: 'onDigitizingToolToggle'
+                        },
                         bind: {
                             apiUrl: '{networkSolverUrl}',
                             disabled: '{isLocked}',
@@ -175,6 +178,9 @@ Ext.define('CpsiMapview.form.ViewMixin', {
                         resetOnToggle: false,
                         iconCls: 'icon-polygon2',
                         glyph: null,
+                        listeners: {
+                            toggle: 'onDigitizingToolToggle'
+                        },
                         bind: {
                             drawLayer: '{polygonLayer}',
                             disabled: '{isLocked}',
@@ -207,6 +213,9 @@ Ext.define('CpsiMapview.form.ViewMixin', {
                         apiUrl: '/WebServices/roadschedule/cutWithPolygon',
                         resetOnToggle: false,
                         glyph: 'xf1db@FontAwesome',
+                        listeners: {
+                            toggle: 'onDigitizingToolToggle'
+                        },
                         bind: {
                             drawLayer: '{polygonLayer}',
                             disabled: '{isLocked}',

--- a/karma-conf.common.js
+++ b/karma-conf.common.js
@@ -10,16 +10,7 @@ module.exports = function(config) {
         'node_modules/@geoext/openlayers-legacy/dist/ol.js',
         'https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/ext-all-debug.js',
         'https://cdnjs.cloudflare.com/ajax/libs/extjs/6.2.0/packages/ux/classic/ux.js',
-        // GeoExt source files
-        {
-            pattern: 'lib/geoext3/src/**/*.js',
-            included: true
-        },
-        // GeoExt classic toolkit source files
-        {
-            pattern: 'lib/geoext3/classic/**/*.js',
-            included: true
-        },
+        'https://geoext.github.io/geoext3/master/GeoExt.js',
         'https://cdnjs.cloudflare.com/ajax/libs/opentype.js/0.6.9/opentype.min.js',
         'https://cdn.jsdelivr.net/npm/jsonix@3.0.0/jsonix.min.js',
         'https://cdn.jsdelivr.net/gh/bjornharrtell/jsts@gh-pages/1.4.0/jsts.min.js',
@@ -35,11 +26,11 @@ module.exports = function(config) {
         'https://cdn.jsdelivr.net/gh/highsource/w3c-schemas@1.4.0/scripts/lib/XLink_1_0.js',
         'https://cdn.jsdelivr.net/npm/proj4@2.5.0/dist/proj4-src.min.js',
         'https://maps.googleapis.com/maps/api/js?v=3.42&key=AIzaSyAj6xrC0L3G0YquO1q6Qsma1ZEfYgGQotU',
+        'lib/BasiGX/src/**/*.js',
         {
             pattern: 'app/**/*.js',
             included: true
         },
-        'lib/BasiGX/src/**/*.js',
         'test/test-helper-functions.js',
         'test/**/*.js',
         {pattern: 'test/resources/**/*', watched: false, included: false, served: true}
@@ -51,10 +42,8 @@ module.exports = function(config) {
         proxies: {
             '/resources': '/base/test/resources',
             '/spec': '/base/test/spec',
-            '/GeoExt': '/base/lib/geoext3/src',
             '/BasiGX': '/base/lib/BasiGX/src',
-            '/CpsiMapview': '/base/app',
-            '/app': '/base/app'
+            '/CpsiMapview': '/base/app'
         },
 
         // frameworks to use

--- a/test/load-tests.js
+++ b/test/load-tests.js
@@ -3,9 +3,8 @@
     Ext.Loader.setConfig({
         enabled: true,
         paths: {
-            'GeoExt': '../lib/geoext3',
-            'BasiGX': '../lib/BasiGX',
-            'CpsiMapview': '../app'
+            'BasiGX': '/BasiGX',
+            'CpsiMapview': '/CpsiMapview'
         }
     });
 

--- a/test/spec/controller/button/DigitizeButtonController.spec.js
+++ b/test/spec/controller/button/DigitizeButtonController.spec.js
@@ -1,0 +1,57 @@
+describe('CpsiMapview.controller.button.DigitizeButtonController', function () {
+    describe('Basics', function () {
+        it('is defined', function () {
+            expect(CpsiMapview.controller.button.DigitizeButtonController).not.to.be(undefined);
+        });
+
+        it('can be created', function () {
+            var ctrl = new CpsiMapview.controller.button.DigitizeButtonController();
+            expect(ctrl).to.not.be(undefined);
+        });
+
+        describe('Can handle service results', function () {
+
+            var resultLayer, ctrl;
+
+            beforeEach(function () {
+
+                var btn = new CpsiMapview.view.button.DigitizeButton({ type: 'Point'});
+
+                ctrl = btn.getController();
+                ctrl.resultLayer = new ol.layer.Vector({
+                    source: new ol.source.Vector({
+                        features: new ol.Collection()
+                    })
+                });
+            });
+
+
+            it('#handleFinalResult fires events', function (done) {
+
+                var features = [
+                    new ol.Feature({
+                        geometry: new ol.geom.LineString([[0, 0], [1, 1]]),
+                        length: 10
+                    }),
+                    new ol.Feature({
+                        geometry: new ol.geom.Point([0, 0]),
+                        group: 0 // this is the default active group
+                    })
+                ];
+
+                ctrl.resultLayer.getSource().on('featuresupdated', function (evt) {
+                    var mods = evt.modifications;
+                    expect(mods.originalLength).to.be(0);
+                    expect(mods.newLength).to.be(10);
+                    expect(mods.newEdgeCount).to.be(1);
+                    expect(mods.originalSolverPoints.length).to.be(0);
+                    expect(mods.newSolverPoints.length).to.be(1);
+                    expect(mods.toolType).to.be('Point');
+                    done();
+                });
+
+                ctrl.handleFinalResult(features);
+            });
+        });
+    });
+});

--- a/test/spec/form/ControllerMixin.spec.js
+++ b/test/spec/form/ControllerMixin.spec.js
@@ -45,5 +45,98 @@ describe('CpsiMapview.form.ControllerMixin', function () {
             var fn = ctrl.onFieldChanged;
             expect(fn).not.to.be(undefined);
         });
+
+        it('#onDigitizingToolToggle flag and listeners are set', function () {
+            var ctrl = editForm.getController();
+
+            var source = new ol.source.Vector();
+            var resultLayer = new ol.layer.Vector({ source: source });
+
+            editForm.getViewModel().set('resultLayer', resultLayer)
+            expect(ctrl.toolListenerAdded).to.be(false);
+            expect(source.getListeners('featuresupdated')).to.be(undefined);
+            ctrl.onDigitizingToolToggle();
+            expect(ctrl.toolListenerAdded).to.be(true);
+            expect(source.getListeners('featuresupdated').length).to.be(1);
+            ctrl.onDigitizingToolToggle();
+            // listener count should remain the same
+            expect(source.getListeners('featuresupdated').length).to.be(1);
+        });
+
+        describe('Digitizing', function () {
+
+            var polygonLayer;
+
+            beforeEach(function () {
+                var feature = new ol.Feature({ id: 'foo' });
+                polygonLayer = new ol.layer.Vector({
+                    source: new ol.source.Vector({
+                        features: new ol.Collection([feature])
+                    })
+                });
+
+                editForm.getViewModel().set('polygonLayer', polygonLayer)
+            });
+
+            it('#onEdgesModified polygons are removed when Point tool is used', function () {
+
+                var ctrl = editForm.getController();
+
+                var evt = {
+                    modifications: {
+                        newEdgeCount: 3,
+                        toolType: 'Point'
+                    }
+                }
+
+                ctrl.onEdgesModified(evt);
+                expect(polygonLayer.getSource().getFeatures().length).to.be(0);
+            });
+
+            it('#onEdgesModified polygons are not removed when no new edges have been added', function () {
+
+                var ctrl = editForm.getController();
+
+                var evt = {
+                    modifications: {
+                        newEdgeCount: 0,
+                        toolType: 'Point'
+                    }
+                }
+
+                ctrl.onEdgesModified(evt);
+                expect(polygonLayer.getSource().getFeatures().length).to.be(1);
+            });
+
+            it('#onEdgesModified polygons are not removed when Polygon tool is used', function () {
+
+                var ctrl = editForm.getController();
+
+                var evt = {
+                    modifications: {
+                        newEdgeCount: 3,
+                        toolType: 'Polygon'
+                    }
+                }
+
+                ctrl.onEdgesModified(evt);
+                expect(polygonLayer.getSource().getFeatures().length).to.be(1);
+            });
+
+            it('#onEdgesModified polygons are not removed when Circle tool is used', function () {
+
+                var ctrl = editForm.getController();
+
+                var evt = {
+                    modifications: {
+                        newEdgeCount: 3,
+                        toolType: 'Circle'
+                    }
+                }
+
+                ctrl.onEdgesModified(evt);
+                expect(polygonLayer.getSource().getFeatures().length).to.be(1);
+            });
+        });
     });
 });


### PR DESCRIPTION
This pull request removes a polygon feature when a user has switched to the point network selection tool after having used the polygon tool. Previously it was left in place and then incorrectly sent to the server. The polygon is only removed when a selection of edges is created. New behaviour shown below:

![Pavement Management System (3)](https://user-images.githubusercontent.com/490840/132766012-86ca4c6a-6d85-459f-b513-51ed0e1a81a6.gif)

Tests were added for all new functionlity, and a full build of GeoExt (rather than adding individual files and using `Ext.Loader`) is used by the test suite which seems to have resolved the `Duplicate class name` errors (at least when running from the console). 
