### PR TITLE
SteetView window null fix

### DIFF
--- a/app/controller/button/StreetViewTool.js
+++ b/app/controller/button/StreetViewTool.js
@@ -231,8 +231,8 @@ Ext.define('CpsiMapview.controller.button.StreetViewTool', {
                         }
                     },
                     destroy: function () {
-                        me.svPanorama = null;
                         me.unregisterGmapsEvents();
+                        me.svPanorama = null;
                         me.streetViewWin = null;
                         me.vectorLayer.getSource().clear();
                     }
@@ -305,6 +305,11 @@ Ext.define('CpsiMapview.controller.button.StreetViewTool', {
      */
     updatePositionFeature: function () {
         var me = this;
+
+        if (!me.svPanorama) {
+            return;
+        }
+
         var newHeading = me.getHeadingRad();
         var newPosCoord = me.getPositionCoord();
         var vectorSource = me.vectorLayer.getSource();


### PR DESCRIPTION
`updatePositionFeature` was sometimes called when `me.svPanorama` was null leading to JS errors. 


1. Open SV window
2. Close SV window
3. Open a grid window. Use Export to Excel from a grid to force a download which resizes the browsers (as in image below):

![image](https://user-images.githubusercontent.com/490840/134016117-0e9a89c9-c7e0-4d6e-8720-44a84a4b37a5.png)

Call stack:

```
Uncaught TypeError: Cannot read properties of null (reading 'getPov')
    at constructor.getHeadingRad (app.js?_dc=1632146254785:98006)
    at constructor.updatePositionFeature (app.js?_dc=1632146254785:97990)
    at constructor.handlePovChanged (app.js?_dc=1632146254785:98000)
    at Wf.pr (js?v=quarterly&key=AIzaSyCmQRf1m6EISENeiijFjza18iIyrIQiArQ&_dc=1632146254785:232)
    at Object._.I.trigger (js?v=quarterly&key=AIzaSyCmQRf1m6EISENeiijFjza18iIyrIQiArQ&_dc=1632146254785:228)
    at cg (js?v=quarterly&key=AIzaSyCmQRf1m6EISENeiijFjza18iIyrIQiArQ&_dc=1632146254785:90)
    at ii._.J.set (js?v=quarterly&key=AIzaSyCmQRf1m6EISENeiijFjza18iIyrIQiArQ&_dc=1632146254785:234)
    at ii.setPov (js?v=quarterly&key=AIzaSyCmQRf1m6EISENeiijFjza18iIyrIQiArQ&_dc=1632146254785:98)
```

Unsure why this event is triggered, so the current fix is to simply check for a null to avoid the error. 