### PR TITLE
Allow insertion of custom buttons in toolbar

### DIFF
--- a/app/form/ViewMixin.js
+++ b/app/form/ViewMixin.js
@@ -45,6 +45,221 @@ Ext.define('CpsiMapview.form.ViewMixin', {
         }
     },
 
+    defaultEditButtons: [{
+        xtype: 'button',
+        itemId: 'deleteButton',
+        text: 'Delete',
+        handler: 'onDeleteClick',
+        tooltip: 'Permanently delete the record',
+        bind: {
+            hidden: '{hideDeleteButton}',
+            disabled: '{!canDelete}',
+            text: '{deleteButtonText}' // TODO this never appears to be set. Remove?
+        }
+    },
+    {
+        xtype: 'button',
+        itemId: 'rejectButton',
+        text: 'Reject',
+        handler: 'onRejectClick',
+        bind: {
+            hidden: '{hideRejectButton}',
+            disabled: '{!canReject}'
+        }
+    },
+    {
+        xtype: 'button',
+        itemId: 'exportButton',
+        text: 'Export',
+        handler: 'onExportClick',
+        tooltip: 'Export the record to Excel',
+        bind: {
+            hidden: '{hideExportButton}'
+        }
+    },
+    {
+        xtype: 'button',
+        itemId: 'zoomButton',
+        text: 'Zoom',
+        handler: 'onZoomClick',
+        tooltip: 'Zoom the map to the location of the record',
+        bind: {
+            hidden: '{hideZoomButton}'
+        }
+    },
+    {
+        xtype: 'button',
+        itemId: 'refreshButton',
+        text: 'Refresh',
+        handler: 'onRefreshClick',
+        tooltip: 'Reload the record with the latest data from the server (only for existing records)',
+        style: {
+            pointerEvents: 'all' // display tooltip even when the button is disabled
+        },
+        bind: {
+            hidden: '{hideRefreshButton}',
+            disabled: '{!canRefresh}'
+        }
+    },
+    {
+        xtype: 'cmv_digitize_button',
+        itemId: 'segmentDigitiserButton',
+        type: 'Point',
+        tooltip: 'Create features by clicking points on the road schedule',
+        toggleGroup: 'map',
+        useContextMenu: false,
+        groups: false,
+        resetOnToggle: false,
+        pointExtentBuffer: 50,
+        iconCls: 'icon-line3',
+        glyph: null,  // set this or we get the default glyph and the icon
+        drawLayerStyle: new ol.style.Style({
+            image: new ol.style.Circle({
+                radius: 5,
+                fill: new ol.style.Fill({
+                    color: 'rgba(135,206,250,1)' // circle fill lightskyblue with opacity as last value
+                }),
+                stroke: new ol.style.Stroke({
+                    color: 'rgba(70, 130, 180)' // steelblue outline of circle
+                })
+            })
+        }),
+        listeners: {
+            toggle: 'onDigitizingToolToggle'
+        },
+        bind: {
+            apiUrl: '{networkSolverUrl}',
+            disabled: '{isLocked}',
+            resultLayer: '{resultLayer}',
+            hidden: '{hideDigitiseSegmentButton}'
+        }
+    },
+    {
+        xtype: 'cmv_digitize_button',
+        itemId: 'areaDigitiserButton',
+        type: 'Polygon',
+        tooltip: 'Create features by drawing polygons to select parts of the road schedule',
+        toggleGroup: 'map',
+        apiUrl: '/WebServices/roadschedule/cutWithPolygon',
+        resetOnToggle: false,
+        iconCls: 'icon-polygon2',
+        glyph: null,
+        listeners: {
+            toggle: 'onDigitizingToolToggle'
+        },
+        bind: {
+            drawLayer: '{polygonLayer}',
+            disabled: '{isLocked}',
+            resultLayer: '{resultLayer}',
+            hidden: '{hideDigitiseAreaButton}'
+        }
+    },
+    {
+        xtype: 'cmv_digitize_button',
+        itemId: 'lineDigitiserButton',
+        type: 'LineString',
+        tooltip: 'Create features by drawing lines',
+        toggleGroup: 'map',
+        resetOnToggle: false,
+        iconCls: 'icon-line3',
+        glyph: null,
+        bind: {
+            drawLayer: '{resultLayer}',
+            disabled: '{isLocked}',
+            resultLayer: '{resultLayer}',
+            hidden: '{hideDigitiseLineButton}'
+        }
+    },
+    {
+        xtype: 'cmv_digitize_button',
+        itemId: 'circleDigitiserButton',
+        type: 'Circle',
+        tooltip: 'Create features by drawing circles to select parts of the road schedule',
+        toggleGroup: 'map',
+        apiUrl: '/WebServices/roadschedule/cutWithPolygon',
+        resetOnToggle: false,
+        glyph: 'xf1db@FontAwesome',
+        listeners: {
+            toggle: 'onDigitizingToolToggle'
+        },
+        bind: {
+            drawLayer: '{polygonLayer}',
+            disabled: '{isLocked}',
+            resultLayer: '{resultLayer}',
+            hidden: '{hideDigitiseCircleButton}'
+        }
+    },
+    {
+        xtype: 'cmv_digitize_button',
+        itemId: 'pointDigitiserButton',
+        type: 'Point',
+        tooltip: 'Create points by clicking on the map',
+        toggleGroup: 'map',
+        resetOnToggle: false,
+        glyph: 'xf1db@FontAwesome',
+        bind: {
+            drawLayer: '{resultLayer}',
+            disabled: '{isLocked}',
+            resultLayer: '{resultLayer}',
+            hidden: '{hideDigitisePointButton}'
+        }
+    },
+    {
+        xtype: 'cmv_split_by_click_button',
+        itemId: 'splitByClickButton',
+        apiUrl: '/WebServices/roadschedule/publicprivatesplit/split',
+        tooltip: 'Split a line by clicking on it',
+        bind: {
+            disabled: '{isProcessed}',
+            resultLayer: '{resultLayer}',
+            hidden: '{hideSplitByClickButton}'
+        }
+    },
+    { xtype: 'tbfill' },
+    {
+        xtype: 'button',
+        itemId: 'saveButton',
+        text: 'Save',
+        handler: 'onSaveClick',
+        // Save button tooltips are updated using CpsiMapview.form.ValidationMessagesMixin
+        tooltip: 'Save the record',
+        bind: {
+            disabled: '{!canSave}',
+            hidden: '{hideSaveButton}',
+            text: '{saveButtonText}'
+        }
+    },
+    {
+        xtype: 'button',
+        itemId: 'approveButton',
+        text: 'Approve',
+        handler: 'onApproveClick',
+        bind: {
+            disabled: '{!canApprove}',
+            hidden: '{hideApproveButton}'
+        }
+    },
+    {
+        xtype: 'button',
+        itemId: 'cancelButton',
+        text: 'Cancel',
+        handler: 'onCancelClick',
+        tooltip: 'Discard any changes without saving and close the window',
+        bind: {
+            hidden: '{hideCancelButton}'
+        }
+    },
+    {
+        xtype: 'button',
+        itemId: 'closeButton',
+        text: 'Close',
+        handler: 'onCloseClick',
+        tooltip: 'Close the window',
+        bind: {
+            hidden: '{hideCloseButton}'
+        }
+    }],
+
     initViewModel: function () {
 
         var me = this;
@@ -74,228 +289,23 @@ Ext.define('CpsiMapview.form.ViewMixin', {
             helpUrl: ''
         });
 
-        me.addDocked(
-            {
-                xtype: 'toolbar',
-                dock: 'bottom',
-                itemId: 'buttonBar',
-                items: [
-                    {
-                        xtype: 'button',
-                        itemId: 'deleteButton',
-                        text: 'Delete',
-                        handler: 'onDeleteClick',
-                        tooltip: 'Permanently delete the record',
-                        bind: {
-                            hidden: '{hideDeleteButton}',
-                            disabled: '{!canDelete}',
-                            text: '{deleteButtonText}' // TODO this never appears to be set. Remove?
-                        }
-                    },
-                    {
-                        xtype: 'button',
-                        itemId: 'rejectButton',
-                        text: 'Reject',
-                        handler: 'onRejectClick',
-                        bind: {
-                            hidden: '{hideRejectButton}',
-                            disabled: '{!canReject}'
-                        }
-                    },
-                    {
-                        xtype: 'button',
-                        itemId: 'exportButton',
-                        text: 'Export',
-                        handler: 'onExportClick',
-                        tooltip: 'Export the record to Excel',
-                        bind: {
-                            hidden: '{hideExportButton}'
-                        }
-                    },
-                    {
-                        xtype: 'button',
-                        itemId: 'zoomButton',
-                        text: 'Zoom',
-                        handler: 'onZoomClick',
-                        tooltip: 'Zoom the map to the location of the record',
-                        bind: {
-                            hidden: '{hideZoomButton}'
-                        }
-                    },
-                    {
-                        xtype: 'button',
-                        itemId: 'refreshButton',
-                        text: 'Refresh',
-                        handler: 'onRefreshClick',
-                        tooltip: 'Reload the record with the latest data from the server (only for existing records)',
-                        style: {
-                            pointerEvents: 'all' // display tooltip even when the button is disabled
-                        },
-                        bind: {
-                            hidden: '{hideRefreshButton}',
-                            disabled: '{!canRefresh}'
-                        }
-                    },
-                    {
-                        xtype: 'cmv_digitize_button',
-                        itemId: 'segmentDigitiserButton',
-                        type: 'Point',
-                        tooltip: 'Create features by clicking points on the road schedule',
-                        toggleGroup: 'map',
-                        useContextMenu: false,
-                        groups: false,
-                        resetOnToggle: false,
-                        pointExtentBuffer: 50,
-                        iconCls: 'icon-line3',
-                        glyph: null,  // set this or we get the default glyph and the icon
-                        drawLayerStyle: new ol.style.Style({
-                            image: new ol.style.Circle({
-                                radius: 5,
-                                fill: new ol.style.Fill({
-                                    color: 'rgba(135,206,250,1)' // circle fill lightskyblue with opacity as last value
-                                }),
-                                stroke: new ol.style.Stroke({
-                                    color: 'rgba(70, 130, 180)' // steelblue outline of circle
-                                })
-                            })
-                        }),
-                        listeners: {
-                            toggle: 'onDigitizingToolToggle'
-                        },
-                        bind: {
-                            apiUrl: '{networkSolverUrl}',
-                            disabled: '{isLocked}',
-                            resultLayer: '{resultLayer}',
-                            hidden: '{hideDigitiseSegmentButton}'
-                        }
-                    },
-                    {
-                        xtype: 'cmv_digitize_button',
-                        itemId: 'areaDigitiserButton',
-                        type: 'Polygon',
-                        tooltip: 'Create features by drawing polygons to select parts of the road schedule',
-                        toggleGroup: 'map',
-                        apiUrl: '/WebServices/roadschedule/cutWithPolygon',
-                        resetOnToggle: false,
-                        iconCls: 'icon-polygon2',
-                        glyph: null,
-                        listeners: {
-                            toggle: 'onDigitizingToolToggle'
-                        },
-                        bind: {
-                            drawLayer: '{polygonLayer}',
-                            disabled: '{isLocked}',
-                            resultLayer: '{resultLayer}',
-                            hidden: '{hideDigitiseAreaButton}'
-                        }
-                    },
-                    {
-                        xtype: 'cmv_digitize_button',
-                        itemId: 'lineDigitiserButton',
-                        type: 'LineString',
-                        tooltip: 'Create features by drawing lines',
-                        toggleGroup: 'map',
-                        resetOnToggle: false,
-                        iconCls: 'icon-line3',
-                        glyph: null,
-                        bind: {
-                            drawLayer: '{resultLayer}',
-                            disabled: '{isLocked}',
-                            resultLayer: '{resultLayer}',
-                            hidden: '{hideDigitiseLineButton}'
-                        }
-                    },
-                    {
-                        xtype: 'cmv_digitize_button',
-                        itemId: 'circleDigitiserButton',
-                        type: 'Circle',
-                        tooltip: 'Create features by drawing circles to select parts of the road schedule',
-                        toggleGroup: 'map',
-                        apiUrl: '/WebServices/roadschedule/cutWithPolygon',
-                        resetOnToggle: false,
-                        glyph: 'xf1db@FontAwesome',
-                        listeners: {
-                            toggle: 'onDigitizingToolToggle'
-                        },
-                        bind: {
-                            drawLayer: '{polygonLayer}',
-                            disabled: '{isLocked}',
-                            resultLayer: '{resultLayer}',
-                            hidden: '{hideDigitiseCircleButton}'
-                        }
-                    },
-                    {
-                        xtype: 'cmv_digitize_button',
-                        itemId: 'pointDigitiserButton',
-                        type: 'Point',
-                        tooltip: 'Create points by clicking on the map',
-                        toggleGroup: 'map',
-                        resetOnToggle: false,
-                        glyph: 'xf1db@FontAwesome',
-                        bind: {
-                            drawLayer: '{resultLayer}',
-                            disabled: '{isLocked}',
-                            resultLayer: '{resultLayer}',
-                            hidden: '{hideDigitisePointButton}'
-                        }
-                    },
-                    {
-                        xtype: 'cmv_split_by_click_button',
-                        itemId: 'splitByClickButton',
-                        apiUrl: '/WebServices/roadschedule/publicprivatesplit/split',
-                        tooltip: 'Split a line by clicking on it',
-                        bind: {
-                            disabled: '{isProcessed}',
-                            resultLayer: '{resultLayer}',
-                            hidden: '{hideSplitByClickButton}'
-                        }
-                    },
-                    { xtype: 'tbfill' },
-                    {
-                        xtype: 'button',
-                        itemId: 'saveButton',
-                        text: 'Save',
-                        handler: 'onSaveClick',
-                        // Save button tooltips are updated using CpsiMapview.form.ValidationMessagesMixin
-                        tooltip: 'Save the record',
-                        bind: {
-                            disabled: '{!canSave}',
-                            hidden: '{hideSaveButton}',
-                            text: '{saveButtonText}'
-                        }
-                    },
-                    {
-                        xtype: 'button',
-                        itemId: 'approveButton',
-                        text: 'Approve',
-                        handler: 'onApproveClick',
-                        bind: {
-                            disabled: '{!canApprove}',
-                            hidden: '{hideApproveButton}'
-                        }
-                    },
-                    {
-                        xtype: 'button',
-                        itemId: 'cancelButton',
-                        text: 'Cancel',
-                        handler: 'onCancelClick',
-                        tooltip: 'Discard any changes without saving and close the window',
-                        bind: {
-                            hidden: '{hideCancelButton}'
-                        }
-                    },
-                    {
-                        xtype: 'button',
-                        itemId: 'closeButton',
-                        text: 'Close',
-                        handler: 'onCloseClick',
-                        tooltip: 'Close the window',
-                        bind: {
-                            hidden: '{hideCloseButton}'
-                        }
-                    }
-                ]
-            }
-        );
+        var buttons = me.defaultEditButtons;
+
+        // add in any custom buttons from the view
+        // this should be an array of objects in the form
+        // [{index: 3, button: {xtype: ''...}}]
+        if (me.customButtons) {
+            buttons = Ext.Array.clone(buttons);
+            Ext.each(me.customButtons, function (cfg) {
+                Ext.Array.insert(buttons, cfg.index, [cfg.button]);
+            });
+        }
+
+        me.addDocked({
+            xtype: 'toolbar',
+            dock: 'bottom',
+            itemId: 'buttonBar',
+            items: buttons
+        });
     }
 });

--- a/test/spec/form/ViewMixin.spec.js
+++ b/test/spec/form/ViewMixin.spec.js
@@ -2,6 +2,16 @@ Ext.define('CpsiMapview.form.TestWindow', {
     extend: 'Ext.window.Window',
     mixins: ['CpsiMapview.form.ViewMixin'],
     viewModel: {},
+    customButtons: [
+        {
+            index: 1,
+            button: {
+                xtype: 'button',
+                itemId: 'test',
+                text: 'Test'
+            }
+        }
+    ],
     tools: [{
         type: 'help'
     }]


### PR DESCRIPTION
An initial atempt to resolve #485 without requiring any dependent code to be changed. 

A view can now have a new `customButtons` property which the `CpsiMapview.form.ViewMixin` will use to insert additional buttons into the toolbar:

```
        customButtons: [
            {
                index: 2,
                button: {
                    xtype: 'button',
                    itemId: 'customExporter',
                    text: 'Custom Button',
                    handler: 'onCustomExport',
                    bind: {
                        disabled: '{!canCustomExport}'
                    }
                }
            }
        ],
```

The array has objects containing the `index` where the button should be inserted, and a `button` config with the button `xtype`. 
Default buttons are cloned to avoid modifying the `defaultButtons` proptotype and applying to all forms that use the mixin. 