### PR TITLE
Introduce LengthField

### DIFF
--- a/app/form/field/LengthField.js
+++ b/app/form/field/LengthField.js
@@ -1,0 +1,9 @@
+
+Ext.define('CpsiMapview.form.field.LengthField',
+    {
+        extend: 'CpsiMapview.form.field.NumericField',
+        xtype: 'cmv_lengthfield',
+        symbol: 'm',
+        decimalPrecision: 2
+    }
+);


### PR DESCRIPTION
Introduce `lengthField` component which enables simple and quick formatting of measurement fields.

By default, input value `100` becomes `100.00 m` after format is applied.

Please review @geographika 