### PR TITLE
Fixes to DigitizeButtonController

### DIFF
--- a/app/controller/button/DigitizeButtonController.js
+++ b/app/controller/button/DigitizeButtonController.js
@@ -989,10 +989,14 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
             var allFeatures = me.resultLayer.getSource().getFeatures().slice(0);
             Ext.each(allFeatures, function (f) {
                 if (f.get('group') === me.activeGroupIdx || !f.get('group')) {
+                    if (!f.get('group')) {
+                        // the property must be updated before removing the feature, or it is readded to the store
+                        f.set('group', me.activeGroupIdx);
+                    }
                     resultSource.removeFeature(f);
                 }
-                f.set('group', me.activeGroupIdx);
             });
+
             // add the new features for the current active group
             resultSource.addFeatures(features);
 

--- a/app/model/FeatureStoreMixin.js
+++ b/app/model/FeatureStoreMixin.js
@@ -110,6 +110,8 @@ Ext.define('CpsiMapview.model.FeatureStoreMixin', {
                     me.set(field.name, null, { convert: false });
                 },
                 remove: function (store) {
+                    // if there are issues here with features being added and then removed
+                    // then make sure the model ids are unique!
                     me.updateAssociatedField(store, field);
                 }
             }


### PR DESCRIPTION
After some lengthy debug sessions, 2 changes:

1. Add a comment about unique Ids for models (for example if there is a record in store with and id set to `index: 0`, and a new record is fetched from the server with `index: 0` then the original model is added and removed rather than being replaced with the new one.
2. Relating to #505 - when a feature is removed and then a property updated then it is re-added to the `olCollection` resulting in a phantom model remaining in an ExtJS grid. Code updated to update this property prior to removal, and only in the case it is null. I'm sure I fully understand the logic for this update - @annarieger if you get a chance to review in a future sprint please let me know if this change will cause an issue. 