### PR TITLE
Fire event when Digitizing layer is cleared

### DIFF
--- a/app/controller/button/DigitizeButtonController.js
+++ b/app/controller/button/DigitizeButtonController.js
@@ -1215,7 +1215,11 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
         };
 
         resultSource.dispatchEvent({ type: 'featuresupdated', modifications: modifications });
-        this.updateDrawSource();
+        me.updateDrawSource();
+
+        // also fire a view event
+        me.getView().fireEvent('responseFeatures', []);
+
     },
 
     init: function () {

--- a/app/util/ApplicationMixin.js
+++ b/app/util/ApplicationMixin.js
@@ -168,7 +168,9 @@ Ext.define('CpsiMapview.util.ApplicationMixin', {
                                     Ext.Msg.alert('Error', result.message);
                                     break;
                                 default:
+                                    //<debug>
                                     Ext.log.error(requestUrl, msg);
+                                    //</debug>
                                     break;
                             }
                         }


### PR DESCRIPTION
Allows listening to this event via the button view in a controler class e.g. 

```js
    listen: {
        component: {
            'cmv_digitize_button': {
                responseFeatures: 'recalculateEdgesData'
            }
         }
    }
```