### PR TITLE
date filter overrides should check if request is remote

### DIFF
--- a/app/overrides/Ext.grid.filters.filter.Date.js
+++ b/app/overrides/Ext.grid.filters.filter.Date.js
@@ -14,7 +14,10 @@
         var key = Object.keys(filter)[0];
         var val = filter[key];
         if (val) {
-            val = Ext.Date.format(val, me.dateFormat);
+            if (me.getGridStore().remoteFilter === true ) {
+                // we only want to convert to string when sending to mapserver
+                val = Ext.Date.format(val, me.dateFormat);
+            }
         }
 
         filter[key] = val;


### PR DESCRIPTION
If the date filter is remote (mapserver) we need to convert to a string, if local we lave as a js date object