### PR TITLE
Warn instead of failing tests due to coverage changes

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -35,6 +35,7 @@ module.exports = function(config) {
         // optionally, configure the reporter
         coverageReporter: {
             dir: 'coverage/',
+            emitWarning: true, // don't fail the tests
             reporters: [
                 { type: 'html', subdir: '.' },
                 { type: 'lcovonly', subdir: '.', file: 'lcov.info' }


### PR DESCRIPTION
See issue at https://github.com/karma-runner/karma-coverage/issues/432
This doesn't resolve #486 but at least will distinguish between failing tests and reduced coverage. 