### PR TITLE
Fire a custom localdrawend event

### DIFF
--- a/app/controller/button/DigitizeButtonController.js
+++ b/app/controller/button/DigitizeButtonController.js
@@ -250,6 +250,15 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
 
             me.pointerInteraction = new ol.interaction.Pointer({
                 handleEvent: function (evt) {
+
+                    // fire an event to handle drag event ends for local drawing
+                    if (evt.type === 'pointerup') {
+                        if (!view.getApiUrl()) {
+                            var drawSource = me.drawLayer.getSource();
+                            drawSource.dispatchEvent({ type: 'localdrawend' });
+                        }
+                    }
+
                     if (deleteCondition(evt)) {
                         return me.handlePointDelete(evt);
                     }
@@ -535,6 +544,8 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
         var drawSource = me.drawLayer.getSource();
         // clear all previous features so only the last drawn feature remains
         drawSource.clear();
+        // fire an event when the drawing is complete
+        drawSource.dispatchEvent({ type: 'localdrawend' });
     },
 
     /**


### PR DESCRIPTION
When drawing features "locally" (without triggering server-side services) fire a new `localdrawend` event. This captures both draw end and when a drag and drop of a feature occurs (by checking the `pointerup` event. 

See http://jsfiddle.net/48ykaLhq/ for modifying the pointer interaction events. 

Note when using `handleEvent` it appears the other events (https://openlayers.org/en/latest/apidoc/module-ol_interaction_Pointer.html) e.g. `handleUpEvent` are no longer fired. 
See also https://github.com/openlayers/openlayers/issues/4509
