### PR TITLE
Ensure validation is in sync

### DIFF
--- a/app/form/ControllerMixin.js
+++ b/app/form/ControllerMixin.js
@@ -113,6 +113,8 @@ Ext.define('CpsiMapview.form.ControllerMixin', {
             throw 'Editing windows must have a top level "xtype: \'form\'" container';
         }
 
+        // ensure validity is refreshed prior to checking it
+        f.getForm().checkValidity();
         var goAhead = f.isValid() && (!this.beforeSave || this.beforeSave());
 
         if (goAhead) {


### PR DESCRIPTION
Encountered situations where the model was valid but clicking the save button did nothing. 
`f.isValid()` returned false, but when validity was refreshed it returned true. 