### PR TITLE
Allow POST requests for WMS layers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
     "env": {
-        "browser": true
+        "browser": true,
+        "es6": true // to allow Uint8Array
     },
     "extends": "eslint:recommended",
     "globals": {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -35,7 +35,9 @@ module.exports = function(config) {
         // optionally, configure the reporter
         coverageReporter: {
             dir: 'coverage/',
-            emitWarning: true, // don't fail the tests
+            check: {
+                emitWarning: true, // don't fail the tests
+            },
             reporters: [
                 { type: 'html', subdir: '.' },
                 { type: 'lcovonly', subdir: '.', file: 'lcov.info' }


### PR DESCRIPTION
Adds a new layer config setting `"requestMethod": "POST"` that can be set on WMS layers to use `POST` rather than the default `GET` requests. 

This fixes the issue where the URL querystring is too long to be handled by the server due to large attribute and spatial query filters. 

The `debounce` function is also updated to take this into account. 