### PR TITLE
Use app settings when creating map if available and add handler

### DIFF
--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -206,7 +206,7 @@ Ext.define('CpsiMapview.view.main.Map', {
         // use app settings when available
         if (app) {
             zoom = app.zoom ? app.zoom : zoom;
-            center = app.center ? app.center : center
+            center = app.center ? app.center : center;
         }
 
         // create a default map if one has not already been created in a derived class


### PR DESCRIPTION
- Ensures the `onMapClick` in the controller is called
- Uses app defaults for zoom and centre of map when available (moves this out of project code)