### PR TITLE
Fire toggle event when the DigitizeButtons are destroyed

### DIFF
--- a/app/controller/button/DigitizeButtonController.js
+++ b/app/controller/button/DigitizeButtonController.js
@@ -1056,6 +1056,10 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
         // detoggle button
         me.onToggle(btn, false);
 
+        // fire the button's toggle event so that the defaultClickEnabled property
+        // is updated in CpsiMapview.util.ApplicationMixin to re-enable clicks
+        btn.fireEvent('toggle');
+
         if (me.drawInteraction) {
             me.map.removeInteraction(me.drawInteraction);
         }


### PR DESCRIPTION
Otherwise the the `defaultClickEnabled` property remains set to false even though the digitising tools are no longer active. 