### PR TITLE
Add custom tileGrid support for xyz layers

### DIFF
--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -623,7 +623,7 @@ Ext.define('CpsiMapview.factory.Layer', {
         olSourceConf = Ext.apply(olSourceConf, olSourceProps);
 
         if (olSourceConf.tileGrid) {
-            olSourceConf.tileGrid = new ol.tilegrid.TileGrid(olSourceConf.tileGrid)
+            olSourceConf.tileGrid = new ol.tilegrid.TileGrid(olSourceConf.tileGrid);
         }
 
         var olLayerConf = {

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -619,7 +619,12 @@ Ext.define('CpsiMapview.factory.Layer', {
         var olSourceConf = {
             url: layerConf.url
         };
+
         olSourceConf = Ext.apply(olSourceConf, olSourceProps);
+
+        if (olSourceConf.tileGrid) {
+            olSourceConf.tileGrid = new ol.tilegrid.TileGrid(olSourceConf.tileGrid)
+        }
 
         var olLayerConf = {
             name: layerConf.text,
@@ -888,6 +893,7 @@ Ext.define('CpsiMapview.factory.Layer', {
             projection: ol2Conf.projection,
             transition: ol2Conf.transitionEffect === null ? 0 : undefined,
             gutter: ol2Conf.gutter,
+            tileGrid: ol2Conf.tileGrid,
             tileSize: ol2Conf.tileSize
         };
 


### PR DESCRIPTION
Allows the config file to set custom tile grids (for example in other projections) in the layers config file.

E.g.

```json
    {
      "layerType": "xyz",
      "layerKey": "CUSTOM_TILES",
      "openLayers": {
        "opacity": 0.7,
        "visibility": false,
        "projection": "EPSG:2157",
        "tileGrid": {
          "origin": [ -5022200.0, 4821100.0 ],
          "resolutions": [
            1058.3354500042335,
            661.4596562526459,
            330.72982812632296,
            158.75031750063502,
            105.83354500042334,
            52.91677250021167,
            26.458386250105836,
            13.229193125052918,
            6.614596562526459,
            2.6458386250105836,
            1.3229193125052918,
            0.6614596562526459,
            0.26458386250105836
          ]
        }
      },
      "url": "http://example.com/arcgis/{z}/{y}/{x}"
    }
```
Resoultions and origin taken from an [ArcGIS Server Metadata page](https://webcache.googleusercontent.com/search?q=cache:jzPnfcqUP8gJ:https://gsi.geodata.gov.ie/server/rest/services/Quaternary/Quaternary_Sediments_50K_IE26_ITM/MapServer)
