### PR TITLE
Ensure button pressed property is set to false prior to firing event

### DIFF
--- a/app/controller/button/DigitizeButtonController.js
+++ b/app/controller/button/DigitizeButtonController.js
@@ -1058,6 +1058,7 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
 
         // fire the button's toggle event so that the defaultClickEnabled property
         // is updated in CpsiMapview.util.ApplicationMixin to re-enable clicks
+        btn.pressed = false;
         btn.fireEvent('toggle');
 
         if (me.drawInteraction) {


### PR DESCRIPTION
Fix to #537 to ensure the button property is set to false before recalculating `defaultClickEnabled`