### PR TITLE
Allow custom map view properties to be set

### DIFF
--- a/app/util/ApplicationMixin.js
+++ b/app/util/ApplicationMixin.js
@@ -209,14 +209,6 @@ Ext.define('CpsiMapview.util.ApplicationMixin', {
                 toggle: me.onMapToolsToggle
             }
         });
-
-        // setup all the projections required for the application
-        proj4.defs('EPSG:4326', '+proj=longlat +datum=WGS84 +no_defs');
-        proj4.defs('EPSG:3857', '+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs');
-        proj4.defs('EPSG:2157', '+proj=tmerc +lat_0=53.5 +lon_0=-8 +k=0.99982 +x_0=600000 +y_0=750000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
-        proj4.defs('EPSG:29902', '+proj=tmerc +lat_0=53.5 +lon_0=-8 +k=1.000035 +x_0=200000 +y_0=250000 +ellps=mod_airy +towgs84=482.5,-130.6,564.6,-1.042,-0.214,-0.631,8.15 +units=m +no_defs');
-
-        ol.proj.proj4.register(proj4);
     },
 
     /**

--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -227,7 +227,7 @@ Ext.define('CpsiMapview.view.main.Map', {
         }
 
         // now apply any defaults if not set by the app
-        Ext.applyIf(viewConfig, me.mapViewConfig)
+        Ext.applyIf(viewConfig, me.mapViewConfig);
 
         var view = new ol.View(viewConfig);
 


### PR DESCRIPTION
This update allows a map to set custom properties, such as a projection, on the map view, using a new `mapViewConfig` object.
For example to have a custom projection:

```js

Ext.define('Example.view.main.Map', {
    extend: 'CpsiMapview.view.main.Map',
    xtype: 'example_map',
..
    mapViewConfig: {
        projection: 'EPSG:2157',
        zoom: 11,
        center: [616038, 629971]
    },
```
