### PR TITLE
Allow vector tile layers to be synched with grids

### DIFF
--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -155,7 +155,7 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
                 if (wmsLayer.get('isVt') === true) {
                     CpsiMapview.util.Layer.updateVectorTileParameters(wmsLayer, newParams);
                 } else {
-                    wmsSource.updateParams();
+                    wmsSource.updateParams(newParams);
                 }
             }
             // keep a reference to the raw filters so they can be applied to the vector layer

--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -110,6 +110,13 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
         var filters = Ext.clone(store.getFilters().items); // otherwise the actual grid filters are modified
         var wmsLayer = me.getLayerByKey(viewModel.get('wmsLayerKey'));
 
+        // also check for MVT layer keys
+        if (!wmsLayer) {
+            wmsLayer = me.getLayerByKey(viewModel.get('vtwmsLayerKey'));
+        }
+
+        var isVt = wmsLayer.get('isVt');
+
         if (me.spatialFilter) {
             filters.push(me.spatialFilter);
         }
@@ -120,8 +127,16 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
 
         if (wmsLayer) {
 
+            var wmsFilterUtil = CpsiMapview.util.WmsFilter;
             var wmsSource = wmsLayer.getSource();
-            var wmsParams = wmsSource.getParams();
+            var wmsParams = wmsFilterUtil.getWmsParams(wmsLayer)
+
+            if (wmsLayer.get('isVt') === true) {
+                var urlParts = wmsSource.getUrls()[0].split('?');
+                wmsParams = Ext.Object.fromQueryString(urlParts[1]);
+            } else {
+                wmsSource.getParams();
+            }
 
             // save the current filter string to see if the filter has changed
             var originalFilterString = wmsParams.FILTER || '';
@@ -135,16 +150,22 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
             }
 
             // ensure there is a filter for every layer listed in the WMS request (required by MapServer)
-            var wmsFilterUtil = CpsiMapview.util.WmsFilter;
             var wmsFilterString = wmsFilterUtil.getWmsFilterString(wmsLayer);
 
             // if the filters have not changed then we do not need to refresh
             // unless the underlying data has changed and force is used
             if (force === true || originalFilterString !== wmsFilterString) {
-                wmsSource.updateParams({
+
+                var newParams = {
                     FILTER: wmsFilterString,
                     TIMESTAMP: Ext.Date.now()
-                });
+                };
+
+                if (wmsLayer.get('isVt') === true) {
+                    CpsiMapview.util.Layer.updateVectorTileParameters(newParams)
+                } else {
+                    wmsSource.updateParams();
+                }
             }
             // keep a reference to the raw filters so they can be applied to the vector layer
             // when switching

--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -548,7 +548,8 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
     getOlLayer: function () {
         var me = this;
         var viewModel = me.getViewModel();
-        var wmsLayerKey = viewModel.get('wmsLayerKey');
+        // look for both wms and vector tile layers (vtwms)
+        var wmsLayerKey = viewModel.get('wmsLayerKey') ? viewModel.get('wmsLayerKey') : viewModel.get('vtwmsLayerKey');
         var vectorLayerKey = viewModel.get('vectorLayerKey');
         var layer;
 

--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -115,8 +115,6 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
             wmsLayer = me.getLayerByKey(viewModel.get('vtwmsLayerKey'));
         }
 
-        var isVt = wmsLayer.get('isVt');
-
         if (me.spatialFilter) {
             filters.push(me.spatialFilter);
         }
@@ -129,14 +127,7 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
 
             var wmsFilterUtil = CpsiMapview.util.WmsFilter;
             var wmsSource = wmsLayer.getSource();
-            var wmsParams = wmsFilterUtil.getWmsParams(wmsLayer)
-
-            if (wmsLayer.get('isVt') === true) {
-                var urlParts = wmsSource.getUrls()[0].split('?');
-                wmsParams = Ext.Object.fromQueryString(urlParts[1]);
-            } else {
-                wmsSource.getParams();
-            }
+            var wmsParams = wmsFilterUtil.getWmsParams(wmsLayer);
 
             // save the current filter string to see if the filter has changed
             var originalFilterString = wmsParams.FILTER || '';
@@ -150,7 +141,7 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
             }
 
             // ensure there is a filter for every layer listed in the WMS request (required by MapServer)
-            var wmsFilterString = wmsFilterUtil.getWmsFilterString(wmsLayer);
+            var wmsFilterString = wmsFilterUtil.getWmsFilterString(wmsParams);
 
             // if the filters have not changed then we do not need to refresh
             // unless the underlying data has changed and force is used
@@ -162,7 +153,7 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
                 };
 
                 if (wmsLayer.get('isVt') === true) {
-                    CpsiMapview.util.Layer.updateVectorTileParameters(newParams)
+                    CpsiMapview.util.Layer.updateVectorTileParameters(wmsLayer, newParams);
                 } else {
                     wmsSource.updateParams();
                 }

--- a/app/util/SwitchLayer.js
+++ b/app/util/SwitchLayer.js
@@ -136,7 +136,7 @@ Ext.define('CpsiMapview.util.SwitchLayer', {
 
             // ensure there is a filter for every layer listed in the WMS request (required by MapServer)
             var wmsFilterUtil = CpsiMapview.util.WmsFilter;
-            var wmsFilterString = wmsFilterUtil.getWmsFilterString(newLayer);
+            var wmsFilterString = wmsFilterUtil.getWmsFilterString(newLayerSource.getParams());
 
             // apply new style parameter and reload layer
             var newParams = {

--- a/app/util/WmsFilter.js
+++ b/app/util/WmsFilter.js
@@ -13,13 +13,33 @@ Ext.define('CpsiMapview.util.WmsFilter', {
     singleton: true,
 
     /**
+     * Get the parameters to be sent to the server as a JS object
+     * Supports getting parameters from WMS layers or vector tile
+     * layers which store WMS parameters in a URL template
+     * @param {any} layer
+     */
+    getWmsParams: function (layer) {
+
+        var wmsParams;
+        var wmsSource = layer.getSource();
+
+        if (layer.get('isVt') === true) {
+            var urlParts = wmsSource.getUrls()[0].split('?');
+            wmsParams = Ext.Object.fromQueryString(urlParts[1]);
+        } else {
+            wmsParams = wmsSource.getParams();
+        }
+
+        return wmsParams;
+    },
+
+    /**
     * Executed when this menu item is clicked.
     * Forces redraw of the connected layer.
     */
     getWmsFilterString: function (layer) {
 
-        var wmsSource = layer.getSource();
-        var wmsParams = wmsSource.getParams();
+        var wmsParams = CpsiMapview.util.WmsFilter.getWmsParams(layer);
 
         var layers = wmsParams.LAYERS || [];
         var originalFilters = wmsParams.FILTER || [];

--- a/app/util/WmsFilter.js
+++ b/app/util/WmsFilter.js
@@ -37,9 +37,7 @@ Ext.define('CpsiMapview.util.WmsFilter', {
     * Executed when this menu item is clicked.
     * Forces redraw of the connected layer.
     */
-    getWmsFilterString: function (layer) {
-
-        var wmsParams = CpsiMapview.util.WmsFilter.getWmsParams(layer);
+    getWmsFilterString: function (wmsParams) {
 
         var layers = wmsParams.LAYERS || [];
         var originalFilters = wmsParams.FILTER || [];

--- a/app/view/menuitem/LayerLabels.js
+++ b/app/view/menuitem/LayerLabels.js
@@ -255,7 +255,7 @@ Ext.define('CpsiMapview.view.menuitem.LayerLabels', {
         // once the LAYERS parameter has been updated
         // ensure there is a filter for every layer listed in the WMS request (required by MapServer)
         var wmsFilterUtil = CpsiMapview.util.WmsFilter;
-        var wmsFilterString = wmsFilterUtil.getWmsFilterString(layer);
+        var wmsFilterString = wmsFilterUtil.getWmsFilterString(wmsSource.getParams());
 
         var newParams = {
             FILTER: wmsFilterString,

--- a/test/spec/util/Layer.spec.js
+++ b/test/spec/util/Layer.spec.js
@@ -12,9 +12,8 @@ describe('CpsiMapview.util.Layer', function () {
         it('#layerRefresh WMS', function () {
 
             var lyr = new ol.layer.Image({
-                source: new ol.source.ImageWMS({
-                    isWms: true
-                })
+                isWms: true,
+                source: new ol.source.ImageWMS()
             });
 
             var params = lyr.getSource().getParams();
@@ -42,7 +41,7 @@ describe('CpsiMapview.util.Layer', function () {
 
             var lyr = new ol.layer.VectorTile({
                 isVt: true,
-                source: new ol.source.Vector({
+                source: new ol.source.VectorTile({
                     url: '/mapserver/?FORMAT=mvt'
                 })
             });

--- a/test/spec/util/Layer.spec.js
+++ b/test/spec/util/Layer.spec.js
@@ -13,7 +13,7 @@ describe('CpsiMapview.util.Layer', function () {
 
             var lyr = new ol.layer.Image({
                 source: new ol.source.ImageWMS({
-                    isWfs: true
+                    isWms: true
                 })
             });
 
@@ -36,6 +36,25 @@ describe('CpsiMapview.util.Layer', function () {
             expect(src.get('timestamp')).to.be(undefined);
             layerUtil.layerRefresh(lyr);
             expect(src.get('timestamp')).not.to.be(undefined);
+        });
+
+        it('#layerRefresh MVT', function () {
+
+            var lyr = new ol.layer.VectorTile({
+                isVt: true,
+                source: new ol.source.Vector({
+                    url: '/mapserver/?FORMAT=mvt'
+                })
+            });
+
+            var src = lyr.getSource();
+
+            var urlParts = src.getUrls()[0].split('?');
+            params = Ext.Object.fromQueryString(urlParts[1]);
+
+            expect(params.TIMESTAMP).to.be(undefined);
+            layerUtil.layerRefresh(lyr);
+            expect(params.TIMESTAMP).not.to.be(undefined);
         });
 
         it('#layerRefresh clustered WFS', function () {

--- a/test/spec/util/Layer.spec.js
+++ b/test/spec/util/Layer.spec.js
@@ -42,6 +42,7 @@ describe('CpsiMapview.util.Layer', function () {
             var lyr = new ol.layer.VectorTile({
                 isVt: true,
                 source: new ol.source.VectorTile({
+                    format: 'mvt',
                     url: '/mapserver/?FORMAT=mvt'
                 })
             });

--- a/test/spec/util/Layer.spec.js
+++ b/test/spec/util/Layer.spec.js
@@ -54,6 +54,9 @@ describe('CpsiMapview.util.Layer', function () {
 
             expect(params.TIMESTAMP).to.be(undefined);
             layerUtil.layerRefresh(lyr);
+
+            urlParts = src.getUrls()[0].split('?');
+            params = Ext.Object.fromQueryString(urlParts[1]);
             expect(params.TIMESTAMP).not.to.be(undefined);
         });
 

--- a/test/spec/util/WmsFilter.spec.js
+++ b/test/spec/util/WmsFilter.spec.js
@@ -1,8 +1,8 @@
-describe('CpsiMapview.util.WmsFilter', function() {
+describe('CpsiMapview.util.WmsFilter', function () {
     var cmp = CpsiMapview.util.WmsFilter;
 
-    describe('Basics', function() {
-        it('is defined', function() {
+    describe('Basics', function () {
+        it('is defined', function () {
             expect(cmp).not.to.be(undefined);
         });
     });
@@ -14,11 +14,12 @@ describe('CpsiMapview.util.WmsFilter', function() {
         });
 
         var params = lyr.getSource().getParams();
-        params.FILTER = '<Filter><fes:PropertyIsEqualTo><fes:ValueReference>IsStream</fes:ValueReference>' +
+        params.LAYERS = 'MyLayer';
+        params.FILTER = '<Filter><fes:PropertyIsEqualTo><fes:ValueReference>MyValue</fes:ValueReference>' +
             '<fes:Literal>true</fes:Literal></fes:PropertyIsEqualTo></Filter>';
 
-        var res = CpsiMapview.util.WmsFilter.getWmsFilterString(layer);
-        var exp = '(<Filter><fes:PropertyIsEqualTo><fes:ValueReference>IsStream</fes:ValueReference><fes:Literal>true</fes:Literal></fes:PropertyIsEqualTo></Filter>)';
+        var res = CpsiMapview.util.WmsFilter.getWmsFilterString(params);
+        var exp = '(<Filter><fes:PropertyIsEqualTo><fes:ValueReference>MyValue</fes:ValueReference><fes:Literal>true</fes:Literal></fes:PropertyIsEqualTo></Filter>)';
         expect(res).to.be(exp);
     });
 
@@ -27,12 +28,14 @@ describe('CpsiMapview.util.WmsFilter', function() {
         var lyr = new ol.layer.Image({
             isWms: true,
             source: new ol.source.ImageWMS({
-                'SERVICE': 'WMS',
-                'TRANSPARENT': true
+                params: {
+                    'SERVICE': 'WMS',
+                    'TRANSPARENT': true
+                }
             })
         });
 
-        var params = CpsiMapview.util.WmsFilter.getParams(lyr);
+        var params = CpsiMapview.util.WmsFilter.getWmsParams(lyr);
         expect(params.SERVICE).to.be('WMS');
         expect(params.TRANSPARENT).to.be(true);
     });
@@ -41,12 +44,13 @@ describe('CpsiMapview.util.WmsFilter', function() {
 
         var lyr = new ol.layer.VectorTile({
             isVt: true,
-            source: new ol.source.Vector({
+            source: new ol.source.VectorTile({
+                format: 'mvt',
                 url: '/mapserver/?FORMAT=mvt&WIDTH={width}'
             })
         });
 
-        var params = CpsiMapview.util.WmsFilter.getParams(lyr);
+        var params = CpsiMapview.util.WmsFilter.getWmsParams(lyr);
         expect(params.FORMAT).to.be('mvt');
         expect(params.WIDTH).to.be('{width}');
     });

--- a/test/spec/util/WmsFilter.spec.js
+++ b/test/spec/util/WmsFilter.spec.js
@@ -1,0 +1,54 @@
+describe('CpsiMapview.util.WmsFilter', function() {
+    var cmp = CpsiMapview.util.WmsFilter;
+
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(cmp).not.to.be(undefined);
+        });
+    });
+
+    describe('#getWmsFilterString', function () {
+
+        var lyr = new ol.layer.Image({
+            source: new ol.source.ImageWMS()
+        });
+
+        var params = lyr.getSource().getParams();
+        params.FILTER = '<Filter><fes:PropertyIsEqualTo><fes:ValueReference>IsStream</fes:ValueReference>' +
+            '<fes:Literal>true</fes:Literal></fes:PropertyIsEqualTo></Filter>';
+
+        var res = CpsiMapview.util.WmsFilter.getWmsFilterString(layer);
+        var exp = '(<Filter><fes:PropertyIsEqualTo><fes:ValueReference>IsStream</fes:ValueReference><fes:Literal>true</fes:Literal></fes:PropertyIsEqualTo></Filter>)';
+        expect(res).to.be(exp);
+    });
+
+    describe('#getWmsParams', function () {
+
+        var lyr = new ol.layer.Image({
+            isWms: true,
+            source: new ol.source.ImageWMS({
+                'SERVICE': 'WMS',
+                'TRANSPARENT': true
+            })
+        });
+
+        var params = CpsiMapview.util.WmsFilter.getParams(lyr);
+        expect(params.SERVICE).to.be('WMS');
+        expect(params.TRANSPARENT).to.be(true);
+    });
+
+    describe('#getWmsParams (MVT)', function () {
+
+        var lyr = new ol.layer.VectorTile({
+            isVt: true,
+            source: new ol.source.Vector({
+                url: '/mapserver/?FORMAT=mvt&WIDTH={width}'
+            })
+        });
+
+        var params = CpsiMapview.util.WmsFilter.getParams(lyr);
+        expect(params.FORMAT).to.be('mvt');
+        expect(params.WIDTH).to.be('{width}');
+    });
+
+});


### PR DESCRIPTION
This allows vtwms layers to be used in synch with the grids in the same way as wms layers. 