### PR TITLE
Add new Help menuitem

### DIFF
--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -124,6 +124,8 @@ Ext.define('CpsiMapview.factory.Layer', {
             mapLayer.set('grouping', layerConf.grouping);
             // if layer has metadata
             mapLayer.set('hasMetadata', layerConf.hasMetadata);
+            // if a layer has its own help page
+            mapLayer.set('helpUrl', layerConf.helpUrl);
         }
 
         return mapLayer;

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -87,7 +87,8 @@ Ext.define('CpsiMapview.view.LayerTree', {
                         'cmv_menuitem_layeropacity',
                         'cmv_menuitem_layergrid',
                         'cmv_menuitem_layermetadata',
-                        'cmv_menuitem_layerfilterreset'
+                        'cmv_menuitem_layerfilterreset',
+                        'cmv_menuitem_layerhelp'
                     ]
                 }, {
                     ptype: 'cmv_tree_inresolutionrange'

--- a/app/view/menuitem/LayerHelp.js
+++ b/app/view/menuitem/LayerHelp.js
@@ -1,0 +1,74 @@
+/**
+ * MenuItem to open a help page associated with a layer
+ *
+ * @class CpsiMapview.view.menuitem.LayerHelp
+ */
+Ext.define('CpsiMapview.view.menuitem.LayerHelp', {
+    extend: 'Ext.menu.Item',
+    xtype: 'cmv_menuitem_layerhelp',
+    mixins: ['CpsiMapview.form.HelpMixin'],
+    requires: [
+        'CpsiMapview.util.Grid'
+    ],
+
+    /**
+     * The connected layer for this item.
+     *
+     * @cfg {ol.layer.Base}
+     */
+    layer: null,
+
+    /**
+     * Text shown in this MenuItem
+     * @cfg {String}
+     */
+    text: 'Help',
+
+    /**
+     * An empty view model to store a helpUrl
+    */
+    viewModel: {},
+
+    /**
+     * @private
+     */
+    initComponent: function () {
+
+        var me = this;
+        var showHelp = false;
+
+        var helpUrl = null;
+
+        // check if there is a helpUrl added directly to the layer config
+        if (me.layer.get('helpUrl')) {
+            helpUrl = me.layer.get('helpUrl');
+        } else {
+            // also check if there is a helpUrl specified in an associated layer grid
+            var gridWindow = CpsiMapview.util.Grid.getGridWindow(me.layer);
+
+            if (gridWindow) {
+                var grid = gridWindow.down('grid');
+                helpUrl = grid.getViewModel().get('helpUrl');
+            }
+        }
+
+        if (helpUrl) {
+            var vm = me.getViewModel();
+            vm.set('helpUrl', helpUrl);
+            showHelp = true;
+        }
+
+        me.handler = me.handlerFunc;
+        me.callParent();
+        me.setHidden(!showHelp);
+    },
+
+    /**
+     * Executed when this menu item is clicked.
+     * Opens the help page associated with the layer
+     */
+    handlerFunc: function () {
+        var me = this;
+        me.onHelp();
+    }
+});

--- a/test/spec/view/menuitem/LayerHelp.spec.js
+++ b/test/spec/view/menuitem/LayerHelp.spec.js
@@ -1,0 +1,29 @@
+describe('CpsiMapview.view.menuitem.LayerHelp', function() {
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(CpsiMapview.view.menuitem.LayerHelp).not.to.be(undefined);
+        });
+
+        it('can be instantiated', function () {
+
+            var layer = new ol.layer.Image();
+            var inst = Ext.create('CpsiMapview.view.menuitem.LayerHelp', { layer: layer });
+            expect(inst).to.be.a(CpsiMapview.view.menuitem.LayerHelp);
+        });
+
+        it('is hidden when a helpUrl is not set on a layer', function () {
+
+            var layer = new ol.layer.Image();
+            var inst = Ext.create('CpsiMapview.view.menuitem.LayerHelp', { layer: layer });
+            expect(inst.hidden).to.be(true);
+        });
+
+        it('is visible when a helpUrl is set on a layer', function () {
+
+            var layer = new ol.layer.Image();
+            layer.set('helpUrl', 'test.html');
+            var inst = Ext.create('CpsiMapview.view.menuitem.LayerHelp', { layer: layer });
+            expect(inst.hidden).to.be(false);
+        });
+    });
+});


### PR DESCRIPTION
Adds a new layer context-menu item "Help" that opens a help page in a new browser window.

The `helpUrl` can be set either in the layer configuration, and if this is missing and there is a grid associated with the layer (via the `gridXType` config option) and the grid view model with a `helpUrl` property then this is used. 

![image](https://user-images.githubusercontent.com/490840/154257903-2bbfcfdb-c77c-4c56-a40f-cc176122af5e.png)
