### PR TITLE
Add window override to fix ghost position

### DIFF
--- a/app/overrides/Ext.window.Window.js
+++ b/app/overrides/Ext.window.Window.js
@@ -5,7 +5,7 @@
  * displayed (although this "bounces" the window back within the viewport rather than constraining the header)
  */
 Ext.override(Ext.window.Window, {
-    createGhost: function (cls) {
+    createGhost: function () {
 
         // original function
         //var ghost = this.callParent(arguments);

--- a/app/overrides/Ext.window.Window.js
+++ b/app/overrides/Ext.window.Window.js
@@ -1,0 +1,25 @@
+﻿/**
+ * Ensure dragging a window works correctly when the initial defaultAlign is not the default 'c-c'
+ * See https://forum.sencha.com/forum/showthread.php?469839-6-5-3-Classic-Window-quot-jumps-quot-when-dragged-with-constrainHeader-true
+ * An alternate solution is to set constrainHeader: false in the window and then set win.constrainHeader = true after the window is
+ * displayed (although this "bounces" the window back within the viewport rather than constraining the header)
+ */
+Ext.override(Ext.window.Window, {
+    createGhost: function (cls) {
+
+        // original function
+        //var ghost = this.callParent(arguments);
+
+        //ghost.xtype = 'window';
+        //ghost.focusOnToFront = false;
+
+        //return ghost;
+
+        var ghost = this.callParent(arguments);
+        var me = this;
+        ghost.x = me.getX();
+        ghost.y = me.getY();
+
+        return ghost;
+    }
+});


### PR DESCRIPTION
Ensure dragging a window works correctly when the initial `defaultAlign` is not the default `'c-c'`