### PR TITLE
Ensure the loadWfs function exists before calling

### DIFF
--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -291,7 +291,9 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
             store.currentPage = 1;
         }
 
-        store.loadWfs();
+        if (store.loadWfs) {
+            store.loadWfs();
+        }
     },
 
     /**


### PR DESCRIPTION
This can be undefined if the grid has not been created and the store is not set (but updating an associated model attempts to reload the grid store). 