### PR TITLE
Add a new example pan tool 

### DIFF
--- a/app/util/ApplicationMixin.js
+++ b/app/util/ApplicationMixin.js
@@ -214,12 +214,14 @@ Ext.define('CpsiMapview.util.ApplicationMixin', {
     /**
      * Whenever any tools that are part of the 'map' toggleGroup are toggled
      * we check to see if any tools are still active.
+     * As the 'pan' tool is simply a button with no associated tool we can exclude this
+     * from the search
      * The defaultClickEnabled value is then used to check if the
      * default CpsiMapview.plugin.FeatureInfoWindow tool should be active
      * */
     onMapToolsToggle: function () {
 
-        var buttonsInToggleGroup = Ext.ComponentQuery.query('button[toggleGroup=map]');
+        var buttonsInToggleGroup = Ext.ComponentQuery.query('button[toggleGroup=map][name!=pan]');
         var pressedStates = Ext.Array.pluck(buttonsInToggleGroup, 'pressed');
         var uniquePressedStates = Ext.Array.unique(pressedStates);
         var activeTools = Ext.Array.contains(uniquePressedStates, true);

--- a/app/view/button/DigitizeButton.js
+++ b/app/view/button/DigitizeButton.js
@@ -136,7 +136,7 @@ Ext.define('CpsiMapview.view.button.DigitizeButton', {
      * The name of the toggleGroup
      * Activates the toggle behaviour of the button
      */
-    toggleGroup: 'digitize',
+    toggleGroup: 'map',
 
     /**
      * Register the listeners and redirect them

--- a/app/view/toolbar/MapTools.js
+++ b/app/view/toolbar/MapTools.js
@@ -39,6 +39,12 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
                     xtype: 'basigx-button-zoomtoextent',
                     extent: [-1210762, 6688545, -600489, 7490828]
                 }, {
+                    xtype: 'button',
+                    toggleGroup: 'map',
+                    name: 'pan',
+                    tooltip: 'Pan the map',
+                    glyph: 'xf256@FontAwesome',
+                }, {
                     xtype: 'basigx-button-zoomin',
                     toggleGroup: 'map'
                 }, {


### PR DESCRIPTION
Add a new example pan tool (which is simply a button that deactivates other tools, as pan is the default OL action), and exclude this when searching to see if any tools are active. 