### PR TITLE
Refresh layer node when using the Refresh plugin

### DIFF
--- a/app/util/Layer.js
+++ b/app/util/Layer.js
@@ -65,6 +65,14 @@ Ext.define('CpsiMapview.util.Layer', {
             // only refresh for other layers and sources (to not loose data)
             source.refresh();
         }
+
+        // also refresh the layer node, which updates any legend which may be broken
+        // if a user's access token expires
+        var treePanel = Ext.ComponentQuery.query('cmv_layertree:first')[0];
+        var node = treePanel.getNodeForLayer(layer);
+        if (node) {
+            node.triggerUIUpdate();
+        }
     },
 
     /**

--- a/app/util/Layer.js
+++ b/app/util/Layer.js
@@ -68,11 +68,7 @@ Ext.define('CpsiMapview.util.Layer', {
 
         // also refresh the layer node, which updates any legend which may be broken
         // if a user's access token expires
-        var treePanel = Ext.ComponentQuery.query('cmv_layertree:first')[0];
-        var node = treePanel.getNodeForLayer(layer);
-        if (node) {
-            node.triggerUIUpdate();
-        }
+        LayerUtil.updateLayerNodeUI(layer);
     },
 
     /**
@@ -85,6 +81,11 @@ Ext.define('CpsiMapview.util.Layer', {
         // we will only ever have one layer tree for an application
 
         var treePanel = Ext.ComponentQuery.query('cmv_layertree:first')[0];
+
+        if (!treePanel) {
+            Ext.log.warn('No cmv_layertree found in the application (updateLayerNodeUI)');
+        }
+
         var node = treePanel.getNodeForLayer(layer);
 
         if (!node) {
@@ -113,7 +114,9 @@ Ext.define('CpsiMapview.util.Layer', {
             node.set('glyph', 'f0b0@FontAwesome');
             node.addCls('cpsi-tree-node-filtered');
         } else {
-            node.set('glyph', null);
+            // revert to the original glyph if set on the layer
+            var glyph = layer.get('_origTreeConf') ? layer.get('_origTreeConf').glyph : null;
+            node.set('glyph', glyph);
             node.removeCls('cpsi-tree-node-filtered');
         }
 

--- a/app/util/Layer.js
+++ b/app/util/Layer.js
@@ -68,7 +68,8 @@ Ext.define('CpsiMapview.util.Layer', {
 
         // also refresh the layer node, which updates any legend which may be broken
         // if a user's access token expires
-        LayerUtil.updateLayerNodeUI(layer);
+        var layerUtil = CpsiMapview.util.Layer;
+        layerUtil.updateLayerNodeUI(layer);
     },
 
     /**

--- a/app/util/Layer.js
+++ b/app/util/Layer.js
@@ -85,6 +85,7 @@ Ext.define('CpsiMapview.util.Layer', {
 
         if (!treePanel) {
             Ext.log.warn('No cmv_layertree found in the application (updateLayerNodeUI)');
+            return;
         }
 
         var node = treePanel.getNodeForLayer(layer);


### PR DESCRIPTION
This will also update any associated legend image. Legend images can become broken if a user access token expires prior to requesting a layer, so this allows them to be re-requested. 

As part of this update, also fix a UI glitch where the original layer glyph was removed when applying and then removing a filter. 