### PR TITLE
Get parent window if control is in a sub-component

### DIFF
--- a/app/form/ValidationMessagesMixin.js
+++ b/app/form/ValidationMessagesMixin.js
@@ -27,16 +27,27 @@ Ext.define('CpsiMapview.form.ValidationMessagesMixin', {
 
         var me = this;
         var view = me.getView();
+
+        // if a control is in a grid, or sub-component
+        // ensure the parent window is set as the view
+        if (view.isXType('window') === false) {
+            view = view.up('window');
+            if (!view) {
+                //<debug>
+                Ext.log.warn('No parent view found for the control');
+                //</debug>
+                return;
+            }
+        }
+
         var saveButton = view.down('#saveButton');
 
-        //<debug>
         if (!saveButton) {
-            Ext.log.warn('No button with itmeId #saveButton found');
+            //<debug>
+            Ext.log.warn('No button with itemId #saveButton found');
+            //</debug>
             return;
         }
-        //</debug>
-
-
 
         // force re-validation - the model may not have been updated
         // but a related model e.g. a column may have been


### PR DESCRIPTION
The `ValidationMessagesMixin` gets the view from the form field which triggers the `onFieldChanged` event. 
In the case of a combobox in a grid, the `me.getView()` returns the grid component rather than the window (even though `me` is the same form controller in both cases) - the `saveButton` is not found. 

Unsure if `.getView` returning different views from the same controller is by design in ExtJS or not. 

Also ensure that the `debug` statements wraps the `log.warn` rather than the actual `return` statement or it is not called and an error is thrown. 

