### PR TITLE
Update GeoStyler libs and move libs off CDNs

### DIFF
--- a/app.json
+++ b/app.json
@@ -210,6 +210,8 @@
   "js": [
     {
       "path": "./node_modules/@geoext/openlayers-legacy/dist/ol.js"
+      // for debugging
+      //"path": "./node_modules/@geoext/openlayers-legacy/dist/ol-debug.js"
     },
     {
       "path": "./node_modules/geostyler-sld-parser/browser/sldStyleParser.js"
@@ -218,58 +220,60 @@
       "path": "./node_modules/geostyler-openlayers-parser/browser/olStyleParser.js"
     },
     {
-      "path": "https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.7.4/proj4.js"
+      "path": "./node_modules/proj4/dist/proj4.js",
+      "compress": false
     },
     {
-      "path": "https://cdn.jsdelivr.net/npm/jsonix@3.0.0/jsonix.min.js"
+      "path": "./node_modules/jsonix/jsonix.js",
+      "compress": false
     },
     {
-      "path": "https://cdn.jsdelivr.net/gh/highsource/ogc-schemas@2.6.1/scripts/lib/SLD_1_0_0_GeoServer.js"
+      "path": "node_modules/w3c-schemas/lib/XLink_1_0.js"
     },
     {
-      "path": "https://cdn.jsdelivr.net/gh/highsource/ogc-schemas@2.6.1/scripts/lib/Filter_1_0_0.js"
+      "path": "node_modules/@ogc-schemas/ogc-schemas/lib/ISO19139_GSS_20060504.js"
     },
     {
-      "path": "https://cdn.jsdelivr.net/gh/highsource/ogc-schemas@2.6.1/scripts/lib/GML_2_1_2.js"
+      "path": "node_modules/@ogc-schemas/ogc-schemas/lib/ISO19139_GSR_20060504.js"
     },
     {
-      "path": "https://cdn.jsdelivr.net/gh/highsource/ogc-schemas@2.6.1/scripts/lib/GML_3_1_1.js"
+      "path": "node_modules/@ogc-schemas/ogc-schemas/lib/ISO19139_GTS_20060504.js"
     },
     {
-      "path": "https://cdn.jsdelivr.net/gh/highsource/ogc-schemas@2.6.1/scripts/lib/OWS_1_1_0.js"
+      "path": "node_modules/@ogc-schemas/ogc-schemas/lib/ISO19139_GMD_20060504.js"
     },
     {
-      "path": "https://cdn.jsdelivr.net/gh/highsource/ogc-schemas@2.6.1/scripts/lib/SMIL_2_0.js"
+      "path": "node_modules/@ogc-schemas/ogc-schemas/lib/ISO19139_GCO_20060504.js"
     },
     {
-      "path": "https://cdn.jsdelivr.net/gh/highsource/ogc-schemas@2.6.1/scripts/lib/SMIL_2_0_Language.js"
+      "path": "node_modules/@ogc-schemas/ogc-schemas/lib/GML_3_2_0.js"
     },
     {
-      "path": "https://cdn.jsdelivr.net/gh/highsource/ogc-schemas@2.6.1/scripts/lib/WCS_1_1.js"
+      "path": "node_modules/@ogc-schemas/ogc-schemas/lib/Filter_1_0_0.js"
     },
     {
-      "path": "https://cdn.jsdelivr.net/gh/highsource/ogc-schemas@2.6.1/scripts/lib/WPS_1_0_0.js"
+      "path": "node_modules/@ogc-schemas/ogc-schemas/lib/SLD_1_0_0.js"
     },
     {
-      "path": "https://cdn.jsdelivr.net/gh/highsource/w3c-schemas@1.4.0/scripts/lib/XLink_1_0.js"
+      "path": "node_modules/@ogc-schemas/ogc-schemas/lib/SMIL_2_0.js"
     },
     {
-        "path": "https://cdn.jsdelivr.net/gh/highsource/ogc-schemas@2.6.1/scripts/lib/ISO19139_GSS_20060504.js"
+      "path": "node_modules/@ogc-schemas/ogc-schemas/lib/SMIL_2_0_Language.js"
     },
     {
-        "path": "https://cdn.jsdelivr.net/gh/highsource/ogc-schemas@2.6.1/scripts/lib/ISO19139_GSR_20060504.js"
+      "path": "node_modules/@ogc-schemas/ogc-schemas/lib/GML_2_1_2.js"
     },
     {
-        "path": "https://cdn.jsdelivr.net/gh/highsource/ogc-schemas@2.6.1/scripts/lib/ISO19139_GTS_20060504.js"
+      "path": "node_modules/@ogc-schemas/ogc-schemas/lib/GML_3_1_1.js"
     },
     {
-        "path": "https://cdn.jsdelivr.net/gh/highsource/ogc-schemas@2.6.1/scripts/lib/ISO19139_GMD_20060504.js"
+      "path": "node_modules/@ogc-schemas/ogc-schemas/lib/WPS_1_0_0.js"
     },
     {
-        "path": "https://cdn.jsdelivr.net/gh/highsource/ogc-schemas@2.6.1/scripts/lib/ISO19139_GCO_20060504.js"
+      "path": "node_modules/@ogc-schemas/ogc-schemas/lib/OWS_1_1_0.js"
     },
     {
-        "path": "https://cdn.jsdelivr.net/gh/highsource/ogc-schemas@2.6.1/scripts/lib/GML_3_2_0.js"
+      "path": "node_modules/@ogc-schemas/ogc-schemas/lib/WCS_1_1.js"
     },
     {
       "path": "https://maps.googleapis.com/maps/api/js?v=quarterly&key=AIzaSyCmQRf1m6EISENeiijFjza18iIyrIQiArQ",

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -953,7 +953,7 @@ Ext.define('CpsiMapview.factory.Layer', {
                 sldParser.readStyle(sldXml)
                     .then(function (gs) {
 
-                        olParser.writeStyle(gs).then(function (olStyleFunc) {
+                        olParser.writeStyle(gs.output).then(function (olStyleFunc) {
                             var source = mapLayer.getSource();
                             if (source instanceof ol.source.Cluster) {
 
@@ -961,7 +961,6 @@ Ext.define('CpsiMapview.factory.Layer', {
                                 // for any grouped features
 
                                 var styleCache = {}; // cache styles per featCount
-
                                 var styleFuncWrapper = function (feature, resolution) {
                                     var featCount = feature.get('features').length;
                                     var style;
@@ -969,7 +968,7 @@ Ext.define('CpsiMapview.factory.Layer', {
                                     if (featCount === 1) {
                                         // call the standard style function
                                         var feat = feature.get('features')[0];
-                                        style = olStyleFunc(feat, resolution);
+                                        style = olStyleFunc.output(feat, resolution);
                                     } else {
                                         // use a clustered style
                                         style = styleCache[featCount];
@@ -982,7 +981,7 @@ Ext.define('CpsiMapview.factory.Layer', {
                                 };
                                 mapLayer.setStyle(styleFuncWrapper);
                             } else {
-                                mapLayer.setStyle(olStyleFunc);
+                                mapLayer.setStyle(olStyleFunc.output);
                             }
                         });
                     }, function () {

--- a/package.json
+++ b/package.json
@@ -25,11 +25,14 @@
   "homepage": "https://github.com/compassinformatics/cpsi-mapview#readme",
   "dependencies": {
     "@geoext/openlayers-legacy": "^6.5.4",
-    "eslint": "^6.8.0",
+    "@ogc-schemas/ogc-schemas": "^3.0.0",
+    "eslint": "^7.29.0",
     "font-gis": "^1.0.4",
-    "geostyler-openlayers-parser": "2.3.1",
-    "geostyler-sld-parser": "2.3.0",
-    "jsonlint": "^1.6.3"
+    "geostyler-openlayers-parser": "3.0.2",
+    "geostyler-sld-parser": "3.2.2",
+    "jsonix": "^3.0.0",
+    "jsonlint": "^1.6.3",
+    "proj4": "^2.7.4"
   },
   "devDependencies": {
     "karma": "^6.3.9",


### PR DESCRIPTION
Requires new `olStyleFunc.output` rather than `olStyleFunc` (since v.3.0.0 of GeoStyler parsers - see https://github.com/geostyler/geostyler-sld-parser/releases/tag/v3.0.0)

