### PR TITLE
Set SLD version to 1.1.0

### DIFF
--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -947,7 +947,7 @@ Ext.define('CpsiMapview.factory.Layer', {
             method: 'GET',
             success: function (response) {
                 var sldXml = response.responseText;
-                var sldParser = new GeoStylerSLDParser.SldStyleParser();
+                var sldParser = new GeoStylerSLDParser.SldStyleParser({ sldVersion: '1.1.0'});
                 var olParser = new GeoStylerOpenlayersParser.OlStyleParser(ol);
 
                 sldParser.readStyle(sldXml)


### PR DESCRIPTION
The MapServer scripts used to generate SLD all use 1.1.0. Without setting the parser version polygons are not displayed correctly. 