### PR TITLE
Add customised combobox classes

### DIFF
--- a/app/form/field/Combo.js
+++ b/app/form/field/Combo.js
@@ -1,0 +1,49 @@
+/**
+ * A customised combobox which provides a consistent UX across the system
+ *
+ * @class CpsiMapview.form.field.Combo
+ */
+Ext.define('CpsiMapview.form.field.Combo', {
+    extend: 'Ext.form.field.ComboBox',
+    xtype: 'cmv_combo',
+    forceSelection: true, // ExtJS default is false
+    lastQuery: '',
+    enableKeyEvents: true, // ExtJS default is false
+    queryMode: 'local', // ExtJS default is 'remote'
+    typeAhead: true, // ExtJS default is false
+    selectOnFocus: true, // ExtJS default is false
+
+    /**
+     * Reset the combobox if the delete key is pressed
+    **/
+    listeners: {
+        specialkey: function (combo, e) {
+            if (e.keyCode == 46) {
+                combo.reset();
+            }
+        }
+    },
+
+    /**
+    * The following override fixes issues with ExtJS comboboxes and bindings
+    * A solution was found by debugging the following class: http://localhost:1841/ext/packages/core/src/mixin/Bindable.js
+    * It became apparent that a value was set on the combobox when the model was bound, but then subsequently
+    * wiped out when the store associated with the combobox was bound
+    * `setValueOnData` is called in http://localhost:1841/ext/classic/classic/src/form/field/ComboBox.js
+    * which should set the selection correctly
+    * however this is not the case as `lastSelection` is already set to the same value
+    * see comment // If the same set of records are selected, this setValue has been a no-op
+    * in http://localhost:1841/ext/packages/core/src/app/ViewModel.js
+    * @param {any} newStore
+    */
+    onBindStore: function (newStore) {
+
+        if (newStore.isEmptyStore !== true) {
+            var bindings = this.getBind();
+            if (bindings.store && bindings.selection) {
+                this.lastSelection = null;
+            }
+        }
+        return this.callParent(arguments);
+    }
+});

--- a/app/form/field/ComboLegacy.js
+++ b/app/form/field/ComboLegacy.js
@@ -1,0 +1,52 @@
+/**
+ * A combobox that allows any legacy lookup values to be displayed
+ * for existing records, but not selected for new records
+ *
+ * @class CpsiMapview.form.field.ComboLegacy
+ */
+Ext.define('CpsiMapview.form.field.ComboLegacy', {
+    extend: 'CpsiMapview.form.field.Combo',
+    xtype: 'cmv_combolegacy',
+
+    // the following property can be set to add a label to the combobox entries
+    legacyPostfix: ' - Legacy',
+
+    /**
+    * Attempt to prevent legacy values from being selected with the keyboard
+    * However using the select event stops the combobox being populated
+    * when a form is loaded
+    **/
+    //listeners: {
+    //    select: function (combo, record) {
+    //        if (record.get('isLegacy')) {
+    //            combo.clearValue();
+    //        }
+    //    }
+    //},
+
+    /**
+     * See https://docs.sencha.com/extjs/6.7.0/classic/Ext.XTemplate.html for docs on templates
+     * And the Sencha forums at https://www.sencha.com/forum/showthread.php?308501-Combo-box-TPL-if-condition
+     * and associated fiddle https://fiddle.sencha.com/#fiddle/14ud&view/editor
+     **/
+    initComponent: function () {
+        var me = this;
+        var itemTemplate = Ext.String.format(
+            '<tpl for=".">' +
+            '<tpl if="isLegacy === true">' +
+            '<li role="option" class="' + Ext.baseCSSPrefix + 'boundlist-item ' +
+            Ext.baseCSSPrefix + 'item-disabled ' +
+            Ext.baseCSSPrefix + 'boundlist-item-legacy"> ' +
+            '{{0}}' + me.legacyPostfix +
+            '</li>' +
+            '<tpl else>' +
+            '<li role="option" class="' + Ext.baseCSSPrefix + 'boundlist-item">' +
+            '{{0}}' +
+            '</li>' +
+            '</tpl>' +
+            '</tpl>', me.displayField);
+
+        me.tpl = itemTemplate;
+        me.callParent(arguments);
+    }
+});

--- a/test/spec/form/field/Combo.spec..js
+++ b/test/spec/form/field/Combo.spec..js
@@ -1,0 +1,12 @@
+describe('CpsiMapview.form.field.Combo', function () {
+
+    it('is defined', function () {
+        expect(CpsiMapview.form.field.Combo).not.to.be(undefined);
+    });
+
+    it('can be instantiated', function () {
+        var inst = Ext.create('CpsiMapview.form.field.Combo');
+        expect(inst).to.be.a(CpsiMapview.form.field.Combo);
+    });
+
+});

--- a/test/spec/form/field/ComboLegacy.spec.js
+++ b/test/spec/form/field/ComboLegacy.spec.js
@@ -1,0 +1,12 @@
+describe('CpsiMapview.form.field.ComboLegacy', function () {
+
+    it('is defined', function () {
+        expect(CpsiMapview.form.field.ComboLegacy).not.to.be(undefined);
+    });
+
+    it('can be instantiated', function () {
+        var inst = Ext.create('CpsiMapview.form.field.ComboLegacy');
+        expect(inst).to.be.a(CpsiMapview.form.field.ComboLegacy);
+    });
+
+});


### PR DESCRIPTION
These allow a consistent UX across the applications by using the same defaults, fix an issue with binding, and also includes a ComboLegacy class that allows legacy options that display for existing records, but cannot be selected for new records.

![image](https://user-images.githubusercontent.com/490840/173821903-e4ef6fad-761a-45f9-b39b-e725727bef4f.png)
