### PR TITLE
Ensure SLD is not loaded twice for switch layers

### DIFF
--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -164,7 +164,7 @@ Ext.define('CpsiMapview.factory.Layer', {
      * @param  {Object} layerConf The configuration object for this layer
      * @return {ol.layer.Base}    The created sub layer
      */
-    createSwitchLayer: function (layerConf) {
+    createSwitchLayer: function (layerConf, noStyle) {
         // compute switch resolution when layer is
         // initialised the first time
         if (!layerConf.switchResolution) {
@@ -188,6 +188,7 @@ Ext.define('CpsiMapview.factory.Layer', {
 
         if (resolution < layerConf.switchResolution) {
             var confBelowSwitchResolution = layerConf.layers[1];
+            confBelowSwitchResolution.noStyle = noStyle;
             // apply overall visibility to sub layer
             Ext.Object.merge(confBelowSwitchResolution, olVisibility);
             resultLayer = LayerFactory.createLayer(confBelowSwitchResolution);
@@ -197,6 +198,7 @@ Ext.define('CpsiMapview.factory.Layer', {
             );
         } else {
             var confAboveSwitchResolution = layerConf.layers[0];
+            confAboveSwitchResolution.noStyle = noStyle;
             // apply overall visibility to sub layer
             Ext.Object.merge(confAboveSwitchResolution, olVisibility);
             resultLayer = LayerFactory.createLayer(confAboveSwitchResolution);
@@ -595,7 +597,7 @@ Ext.define('CpsiMapview.factory.Layer', {
             wfsLayer.set('activatedStyle', style);
         }
 
-        if (sldUrl) {
+        if (sldUrl && !layerConf.noStyle) {
             // load and parse style and apply it to layer
             LayerFactory.loadSld(wfsLayer, sldUrl);
         }
@@ -823,7 +825,7 @@ Ext.define('CpsiMapview.factory.Layer', {
             sldUrl = vtLayer.get('stylesBaseUrl') + style;
             vtLayer.set('activatedStyle', style);
         }
-        if (sldUrl) {
+        if (sldUrl && !layerConf.noStyle) {
             // load and parse style and apply it to layer
             LayerFactory.loadSld(vtLayer, sldUrl);
         }

--- a/app/util/SwitchLayer.js
+++ b/app/util/SwitchLayer.js
@@ -97,7 +97,8 @@ Ext.define('CpsiMapview.util.SwitchLayer', {
         switchConfiguration.visibility = switchLayer.getVisible();
         // also apply current filter and selected style
 
-        var newLayer = LayerFactory.createSwitchLayer(switchConfiguration);
+        var noStyle = true;
+        var newLayer = LayerFactory.createSwitchLayer(switchConfiguration, noStyle);
 
         // add original tree config (from tree.json) to new layer
         var origTreeNodeConf = newLayer.get('_origTreeConf');
@@ -222,6 +223,8 @@ Ext.define('CpsiMapview.util.SwitchLayer', {
                 // apply tree node text from tree config
                 var origTreeNodeConf = node.getOlLayer().get('_origTreeConf');
                 node.set('text', origTreeNodeConf.text);
+                // also set original iconCls
+                node.set('iconCls', origTreeNodeConf.iconCls);
                 // trigger UI updates (e.g. tree node plugins)
                 node.triggerUIUpdate();
             }


### PR DESCRIPTION
This fixes a race condition where a user changes a style on a switch layer WMS and zooms in - the WFS layer is created and loads the default SLD, but also the switch layer sets the SLD based on the `activatedStyle` property. It is then random which one loads last and sets the style on the layer. 

An alternate approach of loading both WFS and WMS layers when the switch layer is first created was attempted in https://github.com/compassinformatics/cpsi-mapview/commit/c3930465490bd3850a3659ed71429c0a35f555fd but lead to further issues so was abandoned. 