### PR TITLE
Allow connection to protected services

### DIFF
--- a/WEB-INF/web.xml
+++ b/WEB-INF/web.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+See https://docs.sencha.com/cmd/6.5.0/guides/advanced_cmd/cmd_reference.html#advanced_cmd-_-cmd_reference_-_sencha_app_watch
+-->
+<web-app
+  xmlns="http://java.sun.com/xml/ns/javaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+  metadata-complete="true"
+  version="2.5"
+>
+
+  <!-- ==================================================================== -->
+  <!-- Reverse HTTP Proxy for the Sencha Cmd web server, e.g.               -->
+  <!-- http://localhost:1841/mapserver2/?SERVICE=WMS will point to          -->
+  <!-- http://localhost/mapserver2/?SERVICE=WMS                             -->
+  <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  -->
+
+  <!-- Proxy to local .NET web services -->
+  <servlet>
+    <servlet-name>transparentReverseProxy2</servlet-name>
+    <servlet-class>org.eclipse.jetty.servlets.ProxyServlet$Transparent</servlet-class>
+    <init-param>
+      <param-name>ProxyTo</param-name>
+      <param-value>http://localhost/WebServices</param-value>
+    </init-param>
+    <init-param>
+      <param-name>Prefix</param-name>
+      <param-value>/WebServices</param-value>
+    </init-param>
+    <load-on-startup>1</load-on-startup>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>transparentReverseProxy2</servlet-name>
+    <url-pattern>/WebServices/*</url-pattern>
+  </servlet-mapping>
+
+
+  <!-- Proxy to local pmspy services -->
+  <servlet>
+    <servlet-name>transparentReverseProxy3</servlet-name>
+    <servlet-class>org.eclipse.jetty.servlets.ProxyServlet$Transparent</servlet-class>
+    <init-param>
+      <param-name>ProxyTo</param-name>
+      <param-value>http://localhost/pmspy</param-value>
+    </init-param>
+    <init-param>
+      <param-name>HostHeader</param-name>
+      <param-value>localhost</param-value>
+    </init-param>
+    <init-param>
+      <param-name>Prefix</param-name>
+      <param-value>/pmspy</param-value>
+    </init-param>
+    <load-on-startup>1</load-on-startup>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>transparentReverseProxy3</servlet-name>
+    <url-pattern>/pmspy/*</url-pattern>
+  </servlet-mapping>
+
+</web-app>

--- a/app/Application.js
+++ b/app/Application.js
@@ -16,6 +16,13 @@ Ext.define('CpsiMapview.Application', {
         appmixin: 'CpsiMapview.util.ApplicationMixin'
     },
 
+    /**
+     * Override the settings in CpsiMapview.util.ApplicationMixin
+     */
+    tokenName: 'pmstoken',
+    authenticationUrl: '/WebServices/authorization/authenticate',
+    tokenValidationUrl: '/WebServices/authorization/validateToken',
+
     requireLogin: false,
 
     name: 'CpsiMapview',
@@ -33,5 +40,34 @@ Ext.define('CpsiMapview.Application', {
 
     launch: function () {
         // TODO - Launch the application
+    },
+
+    rewriteRemoveServiceRequests: function (options) {
+
+        var me = this;
+        var hostname = window.location.hostname;
+        var regex = /compassinformatics.github.io/g;
+
+        var m = regex.exec(hostname);
+
+        if (m) {
+            var serviceUrls = ['/WebServices', '/pmspy'];
+
+            var urlTest = function (url) {
+                var ignoreCase = true;
+                return Ext.String.startsWith(options.url, url, ignoreCase);
+            };
+
+            if (Ext.Array.some(serviceUrls, urlTest) === true) {
+                options.url = 'https://pmstipperarydev.compass.ie' + options.url;
+            }
+        }
+    },
+
+    onAjaxBeforeRequest: function (conn, options) {
+        var me = this;
+        if (options.url) {
+            me.rewriteRemoveServiceRequests(options);
+        }
     }
 });

--- a/app/Application.js
+++ b/app/Application.js
@@ -44,7 +44,6 @@ Ext.define('CpsiMapview.Application', {
 
     rewriteRemoveServiceRequests: function (options) {
 
-        var me = this;
         var hostname = window.location.hostname;
         var regex = /compassinformatics.github.io/g;
 

--- a/app/controller/button/LoginButtonController.js
+++ b/app/controller/button/LoginButtonController.js
@@ -28,9 +28,22 @@ Ext.define('CpsiMapview.controller.button.LoginButtonController', {
         if (app && app.loginWindow) {
             loginWin = app.loginWindow;
         } else {
-            loginWin = Ext.create('CpsiMapview.view.form.Login');
+            var viewModel = {};
+            if (app) {
+                viewModel = {
+                    tokenName: app.tokenName,
+                    serviceUrl: app.authenticationUrl,
+                    validateUrl: app.tokenValidationUrl,
+                    minimumRequiredRole: app.minimumRequiredRole
+                }
+            }
+            loginWin = Ext.create('CpsiMapview.view.form.Login', {
+                viewModel: viewModel
+            });
+            if (app) {
+                app.loginWindow = loginWin;
+            }
         }
-
         loginWin.getController().logout();
         loginWin.show();
     },

--- a/app/controller/button/LoginButtonController.js
+++ b/app/controller/button/LoginButtonController.js
@@ -35,7 +35,7 @@ Ext.define('CpsiMapview.controller.button.LoginButtonController', {
                     serviceUrl: app.authenticationUrl,
                     validateUrl: app.tokenValidationUrl,
                     minimumRequiredRole: app.minimumRequiredRole
-                }
+                };
             }
             loginWin = Ext.create('CpsiMapview.view.form.Login', {
                 viewModel: viewModel

--- a/app/model/toolbar/MapTools.js
+++ b/app/model/toolbar/MapTools.js
@@ -1,0 +1,9 @@
+Ext.define('CpsiMapview.model.toolbar.MapToolsModel', {
+    extend: 'Ext.app.ViewModel',
+
+    alias: 'viewmodel.cmv_maptools',
+
+    data: {
+        loggedIn: false // used to keep track of if a user is logged in or not
+    }
+});

--- a/app/util/ApplicationMixin.js
+++ b/app/util/ApplicationMixin.js
@@ -90,6 +90,16 @@ Ext.define('CpsiMapview.util.ApplicationMixin', {
      */
     tokenName: 'cookietoken',
 
+    /**
+     * URL for logging into the application
+     */
+    authenticationUrl: '/WebServices/authorization/authenticate',
+
+    /**
+     * URL for validating application tokens
+     */
+    tokenValidationUrl: '/WebServices/authorization/validateToken',
+
     errorCode: {
         None: 0,
         AccountLockedOut: 1,
@@ -265,9 +275,9 @@ Ext.define('CpsiMapview.util.ApplicationMixin', {
         if (!me.loginWindow) {
             me.loginWindow = Ext.create('CpsiMapview.view.form.Login', {
                 viewModel: {
-                    tokenName: this.tokenName,
-                    serviceUrl: '/WebServices/authorization/authenticate',
-                    validateUrl: '/WebServices/authorization/validateToken',
+                    tokenName: me.tokenName,
+                    serviceUrl: me.authenticationUrl,
+                    validateUrl: me.tokenValidationUrl,
                     minimumRequiredRole: me.minimumRequiredRole
                 }
             });

--- a/app/view/toolbar/MapTools.js
+++ b/app/view/toolbar/MapTools.js
@@ -16,6 +16,7 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
         'CpsiMapview.model.button.MeasureButton',
         'CpsiMapview.controller.button.MeasureButtonController',
         'CpsiMapview.controller.toolbar.MapTools',
+        'CpsiMapview.model.toolbar.MapToolsModel',
         'CpsiMapview.view.combo.Gazetteer',
         'CpsiMapview.view.button.StreetViewTool',
         'CpsiMapview.view.panel.TimeSlider',
@@ -24,6 +25,7 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
     ],
 
     controller: 'cmv_maptools',
+    viewModel: 'cmv_maptools',
 
     dock: 'top',
 
@@ -89,7 +91,7 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
                 toggleGroup: 'map',
                 tooltip: 'Point',
                 glyph: 'ea52@font-gis',
-                apiUrl: 'https://pmstipperarydev.compass.ie/pmspy/netsolver',
+                apiUrl: '/pmspy/netsolver',
                 groups: true,
                 pointExtentBuffer: 50,
                 listeners: {
@@ -111,7 +113,7 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
                 type: 'Polygon',
                 tooltip: 'Polygon',
                 glyph: 'ea03@font-gis',
-                apiUrl: 'https://pmstipperarydev.compass.ie/WebServices/roadschedule/cutWithPolygon',
+                apiUrl: '/WebServices/roadschedule/cutWithPolygon',
                 listeners: {
                     responseFeatures: function () {
                         this.getController().onResponseFeatures();
@@ -123,7 +125,7 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
                 toggleGroup: 'map',
                 type: 'Circle',
                 tooltip: 'Circle',
-                apiUrl: 'https://pmstipperarydev.compass.ie/WebServices/roadschedule/cutWithPolygon',
+                apiUrl: '/WebServices/roadschedule/cutWithPolygon',
                 listeners: {
                     responseFeatures: function () {
                         this.getController().onResponseFeatures();
@@ -155,7 +157,7 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
                 xtype: 'gx_geocoder_combo'
             }, {
                 xtype: 'cmv_gazetteer_combo', // custom CPSI gazetteer
-                url: 'https://pmstipperarydev.compass.ie/WebServices/townland/gazetteer/',
+                url: '/WebServices/townland/gazetteer/',
                 proxyRootProperty: 'data',
                 displayValueMapping: 'name',
                 emptyText: 'Townland...'


### PR DESCRIPTION
This update allows the demo application to connect to a set of development backend services. These include:

- authentication (to return a token that can then be used to access further services)
- backend Python tools to create routes

When working locally with the Sencha development server the following command should be used to run the demo app:

`sencha app watch  --j2ee`

This flag allows the `WEB-INF/web.xml` file to be used which proxies service calls to the backend development server. 
It does not seem possible to proxy back to the development server directly using https, so an additional local proxy is added, to make the following URLs available at http://localhost/WebServices and http://localhost/pmspy. 
These could be added to https://github.com/compassinformatics/cpsi-mapview/blob/master/nginx.conf and then will be available via Docker. 

On the live demo at https://compassinformatics.github.io/cpsi-mapview/#map=11/-862962.16/6899723.27/0 URLs are rewritten in the custom `Application.js` file to point to the development server directly. 