### PR TITLE
Use querystring to pass token for protected services

### DIFF
--- a/app/Application.js
+++ b/app/Application.js
@@ -46,8 +46,7 @@ Ext.define('CpsiMapview.Application', {
 
         var me = this;
         var hostname = window.location.hostname;
-        var regex = /compassinformatics.github.io/g;
-        var regex = /localhost/g;
+        var regex = /compassinformatics.github.io/g; // /localhost/g;
         var m = regex.exec(hostname);
         var serviceUrl = options.url;
 
@@ -60,12 +59,9 @@ Ext.define('CpsiMapview.Application', {
             };
 
             if (Ext.Array.some(serviceUrls, urlTest) === true) {
-
-
-                debugger;
                 var tokenValue = Ext.util.Cookies.get(me.tokenName);
                 if (tokenValue) {
-                    var token = Ext.String.format("token={0}", tokenValue)
+                    var token = Ext.String.format('token={0}', tokenValue);
                     serviceUrl = Ext.String.urlAppend(serviceUrl, token);
                 }
                 serviceUrl = 'https://pmstipperarydev.compass.ie' + serviceUrl;


### PR DESCRIPTION
A follow-on pull request to #571 - this sends the token via the querystring rather than by cookies which are blocked by CORs. 
Note this will only work for the Python services, not any .NET services such as the custom gazetteer which is currently broken in the online demo (or any service calls to `/WebServices/`. 
