### PR TITLE
Add Example Snapping Tool and Window

### DIFF
--- a/app/controller/button/DrawingButtonController.js
+++ b/app/controller/button/DrawingButtonController.js
@@ -217,7 +217,11 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
         // find all intersecting node points
         // https://openlayers.org/en/latest/apidoc/module-ol_source_Vector-VectorSource.html
         searchLayer.getSource().forEachFeatureIntersectingExtent(extent, function (feat) {
-            featureIds.push(feat.get('ObjectId'));
+            //<debug>
+            // this requires all GeoJSON features used for the layer to have an id property
+            Ext.Assert.truthy(feat.getId());
+            //</debug>
+            featureIds.push(feat.getId());
         });
 
         // cases where the same feature is loaded into the layer leading to duplicated Ids

--- a/app/view/snappingExample/EdgeButton.js
+++ b/app/view/snappingExample/EdgeButton.js
@@ -1,0 +1,75 @@
+Ext.define('CpsiMapview.view.snappingExample.EdgeModel', {
+    extend: 'Ext.data.Model',
+    requires: [
+        'CpsiMapview.field.Line'
+    ],
+    mixins: {
+        //eventsMixin: 'CpsiMapview.model.FeatureEventsMixin',
+        features: 'CpsiMapview.model.FeatureStoreMixin'
+    },
+    idProperty: 'edgeId',
+    fields: [
+        {
+            name: 'edgeId',
+            type: 'int',
+            defaultValue: null,
+            persist: false
+        },
+        {
+            name: 'startNodeId',
+            type: 'int',
+            allowNull: true,
+            defaultValue: null
+        },
+        {
+            name: 'endNodeId',
+            type: 'int',
+            allowNull: true,
+            defaultValue: null
+        },
+        {
+            name: 'startEdgeId',
+            type: 'int',
+            allowNull: true,
+            defaultValue: null
+        },
+        {
+            name: 'endEdgeId',
+            type: 'int',
+            allowNull: true,
+            defaultValue: null
+        },
+        {
+            name: 'startCoord',
+            type: 'auto',
+            allowNull: true,
+            defaultValue: null
+        },
+        {
+            name: 'endCoord',
+            type: 'auto',
+            allowNull: true,
+            defaultValue: null
+        },
+        {
+            name: 'geometry',
+            type: 'line'
+        },
+    ]
+});
+
+Ext.define('CpsiMapview.view.snappingExample.EdgeButton', {
+    extend: 'Ext.button.Button',
+    xtype: 'cmv_edgebutton',
+    handler: function () {
+        if (!this.window) {
+            var rec = Ext.create('CpsiMapview.view.snappingExample.EdgeModel', { edgeId: null });
+            this.window = Ext.create('CpsiMapview.view.snappingExample.EdgeWindow');
+
+            var vm = this.window.getViewModel();
+            vm.set('currentRecord', rec);
+
+        }
+        this.window.show();
+    }
+});

--- a/app/view/snappingExample/EdgeWindow.js
+++ b/app/view/snappingExample/EdgeWindow.js
@@ -1,0 +1,148 @@
+﻿Ext.define('CpsiMapview.view.snappingExample.EdgeWindow', {
+    extend: 'CpsiMapview.view.window.MinimizableWindow',
+    xtype: ['cmv_edgewindow'],
+    requires: [
+        'Ext.tab.Panel',
+        'CpsiMapview.view.snappingExample.EdgeWindowController',
+        'CpsiMapview.view.snappingExample.EdgeWindowViewModel',
+        'CpsiMapview.view.tool.DrawingButton',
+        'CpsiMapview.form.RightInfoField'
+    ],
+    controller: 'cmv_edgewindowcontroller',
+    viewModel: {
+        type: 'cmv_edgewindowviewmodel'
+    },
+    mixins: {
+        editFormMixin: 'CpsiMapview.form.ViewMixin'
+    },
+    title: 'Snapping Example',
+    modelValidation: true,
+    width: 580,
+    height: 360,
+    resizable: false,
+    maximizable: true,
+    frame: false,
+    border: false,
+    layout: {
+        type: 'vbox',
+        align: 'stretch'
+    },
+
+    customButtons: [
+        {
+            index: 2,
+            button: {
+                xtype: 'cmv_drawing_button',
+                itemId: 'drawNetworkEdge',
+                text: 'Draw Edge',
+                toggleGroup: 'map',
+                iconCls: 'icon-line3',
+                glyph: null,
+                tooltip: 'Create new features to join the network',
+                bind: {
+                    drawLayer: '{resultLayer}' // bind the draw layer to the model's featurestore / layer
+                },
+                snappingLayerKeys: ['EDGES_WFS', 'NODES_WFS'],
+                nodeLayerKey: 'NODES_WFS',
+                edgeLayerKey: 'EDGES_WFS'
+            }
+        }
+    ],
+
+    items: [{
+        xtype: 'tabpanel',
+        anchor: '100% 100%',
+        defaults: {
+            padding: '5 5 5 5'
+        },
+        items: [
+            {
+                tabConfig: {
+                    title: 'General'
+                },
+                layout: {
+                    type: 'anchor',
+                },
+                items: [
+                    {
+                        xtype: 'fieldset',
+                        title: 'Details',
+                        anchor: '100%',
+                        layout: {
+                            type: 'table',
+                            columns: 2
+                        },
+                        items: [{
+                            xtype: 'cmv_rightinfofield',
+                            colspan: 1,
+                            width: 300,
+                            field: {
+                                xtype: 'displayfield',
+                                labelWidth: 100,
+                                width: 200,
+                                fieldLabel: 'Start Node ID',
+                                infoIconTooltip: 'Database Identifier',
+                                bind: {
+                                    value: '{currentRecord.startNodeId}'
+                                }
+                            }
+                        },
+                        {
+                            xtype: 'cmv_rightinfofield',
+                            colspan: 1,
+                            width: 300,
+                            field: {
+                                xtype: 'displayfield',
+                                labelWidth: 100,
+                                width: 200,
+                                fieldLabel: 'End Node ID',
+                                infoIconTooltip: 'Database Identifier',
+                                bind: {
+                                    value: '{currentRecord.endNodeId}'
+                                }
+                            }
+                        },
+                        {
+                            xtype: 'cmv_rightinfofield',
+                            colspan: 1,
+                            width: 300,
+                            field: {
+                                xtype: 'displayfield',
+                                labelWidth: 100,
+                                width: 200,
+                                fieldLabel: 'Start Edge ID',
+                                infoIconTooltip: 'Database Identifier',
+                                bind: {
+                                    value: '{currentRecord.startEdgeId}'
+                                }
+                            }
+                        },
+                        {
+                            xtype: 'cmv_rightinfofield',
+                            colspan: 1,
+                            width: 300,
+                            field: {
+                                xtype: 'displayfield',
+                                labelWidth: 100,
+                                width: 200,
+                                fieldLabel: 'End Edge ID',
+                                infoIconTooltip: 'Database Identifier',
+                                bind: {
+                                    value: '{currentRecord.endEdgeId}'
+                                }
+                            }
+                        },
+                        {
+                            xtype: 'displayfield',
+                            colspan: 2,
+                            width: 300,
+                            value: 'Hold down CTRL to modify vertices'
+                        }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+    ]
+});

--- a/app/view/snappingExample/EdgeWindowController.js
+++ b/app/view/snappingExample/EdgeWindowController.js
@@ -1,0 +1,70 @@
+﻿Ext.define('CpsiMapview.view.snappingExample.EdgeWindowController', {
+    extend: 'CpsiMapview.controller.window.MinimizableWindow',
+    alias: 'controller.cmv_edgewindowcontroller',
+    mixins: [
+        'CpsiMapview.form.ControllerMixin',
+        'CpsiMapview.form.LayersMixin'
+    ],
+    // we need to add listen in the controller itself rather than in a mixin
+    // or the function won't be called
+    listen: {
+        component: {
+            'field': {
+                change: 'onFieldChanged' // listen to all field change events to update button
+            },
+            'cmv_edgewindow': {
+                savesucceeded: 'onAfterSaveSucceded'
+            }
+        }
+    },
+
+    /**
+     * Function to call prior to saving - confirm with the user that they want to create new nodes
+     * */
+    beforeSave: function () {
+
+        var me = this;
+        var rec = me.getViewModel().get('currentRecord');
+
+        var noStartFeature = false;
+
+        if (!rec.get('startNodeId') && !rec.get('startEdgeId') && !rec.get('startPolygonId')) {
+            noStartFeature = true;
+            Ext.Msg.confirm('Create new Source', 'No feature is connected at the start of the edge. Are you sure you want to create a new source?',
+                function (buttonId) {
+                    if (buttonId == 'yes') {
+                        // call saveRecord directly as beforeSave returns a value instantly
+                        me.saveRecord();
+                    }
+                });
+            return false;
+        }
+
+        if (!rec.get('endNodeId') && !rec.get('endEdgeId') && !rec.get('endPolygonId')) {
+
+            if (noStartFeature === true) {
+                Ext.Msg.alert('No Attached Features', 'No features are attached at the start or end of this line!');
+            }
+
+            Ext.Msg.confirm('Create new Source', 'No feature is connected at the end of the edge. Are you sure you want to create a new source?',
+                function (buttonId) {
+                    if (buttonId == 'yes') {
+                        me.saveRecord();
+                    }
+                });
+            return false;
+        }
+
+        return true; // go ahead with the save
+    },
+
+    /**
+     * Ensure the window is closed so users don't keep reusing the same form to add new edges
+     * wiping out previous edges
+     * */
+    onAfterSaveSucceded: function () {
+        var me = this;
+        var win = me.getView();
+        win.close();
+    }
+});

--- a/app/view/snappingExample/EdgeWindowViewModel.js
+++ b/app/view/snappingExample/EdgeWindowViewModel.js
@@ -1,0 +1,57 @@
+﻿Ext.define('CpsiMapview.view.snappingExample.EdgeWindowViewModel', {
+    extend: 'Ext.app.ViewModel',
+    alias: 'viewmodel.cmv_edgewindowviewmodel',
+    mixins: [
+        'CpsiMapview.form.ViewModelMixin'
+    ],
+    data: {
+        featureStoreName: 'geometry',
+        hideSaveButton: true,
+        hideDeleteButton: true
+    },
+    formulas: {
+
+        valid: function (get) {
+            get('timestamp');
+            get('currentRecord.geometry'); // required so that if edges are added the form becomes valid
+
+            var ctlr = this.getView().getController();
+            if (ctlr) {
+                return ctlr.checkValid(get('currentRecord'));
+            } else {
+                return false;
+            }
+        },
+
+        /**
+        * Executed once result layer is available.
+        * Creates a listener if the point geometry is changed.
+        */
+        onResultLayer: {
+            bind: '{resultLayer}',
+
+            get: function (resultLayer) {
+                var me = this;
+                var source = resultLayer.getSource();
+
+                source.on('localdrawend', function (event) {
+                    var rec = me.get('currentRecord');
+                    var result = event.result;
+                    rec.set(result);
+                });
+
+                source.on('clear', function () {
+                    var rec = me.get('currentRecord');
+                    rec.set({
+                        startCoord: null,
+                        endCoord: null,
+                        startNodeId: null,
+                        endNodeId: null,
+                        startEdgeId: null,
+                        endEdgeId: null
+                    });
+                });
+            }
+        }
+    }
+});

--- a/app/view/toolbar/MapTools.js
+++ b/app/view/toolbar/MapTools.js
@@ -21,7 +21,8 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
         'CpsiMapview.view.button.StreetViewTool',
         'CpsiMapview.view.panel.TimeSlider',
         'CpsiMapview.view.panel.NumericAttributeSlider',
-        'CpsiMapview.view.lineSliceGridExample.LineSliceGridButton'
+        'CpsiMapview.view.lineSliceGridExample.LineSliceGridButton',
+        'CpsiMapview.view.snappingExample.EdgeButton'
     ],
 
     controller: 'cmv_maptools',
@@ -139,6 +140,10 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
                 text: '',
                 tooltip: 'Linear Reference demo',
                 glyph: 'ea78@font-gis',
+            }, {
+                xtype: 'cmv_edgebutton',
+                tooltip: 'Snapping demo',
+                glyph: 'ea76@font-gis'
             }]
         },
         '->',

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -357,6 +357,28 @@
     },
     {
       "layerType": "wfs",
+      "layerKey": "EDGES_WFS",
+      "featureType": "edges",
+      "noCluster": true,
+      "idProperty": "EdgeId",
+      "openLayers": {
+        "visibility": false,
+        "maxScale": 800000
+      }
+    },
+    {
+      "layerType": "wfs",
+      "layerKey": "NODES_WFS",
+      "featureType": "nodes",
+      "noCluster": true,
+      "idProperty": "NodeId",
+      "openLayers": {
+        "visibility": false,
+        "maxScale": 800000
+      }
+    },
+    {
+      "layerType": "wfs",
       "gridXType": "cmv_examplegrid",
       "gridFilters": [
         {

--- a/resources/data/layers/tree.json
+++ b/resources/data/layers/tree.json
@@ -23,6 +23,18 @@
             "qtip": "Right-click for a layer grid"
           },
           {
+            "id": "NODES_WFS",
+            "leaf": true,
+            "text": "Nodes",
+            "qtip": "Used in the snapping tool example"
+          },
+          {
+            "id": "EDGES_WFS",
+            "leaf": true,
+            "text": "Edges",
+            "qtip": "Used in the snapping tool example"
+          },
+          {
             "id": "BOREHOLE_WMS",
             "leaf": true,
             "text": "Borehole WMS"


### PR DESCRIPTION
This pull request adds 2 vector layers - nodes and edges, that can be used with a new example snapping form and tool. 
Clicking the button highlighted below opens a new "Snapping Example" window. 
Activating the "Draw Edge" tool then allows a user to turn on the Nodes and Edges layers and connect them. The start and end features are then displayed in the form. 

![image](https://user-images.githubusercontent.com/490840/180787063-2b2197ef-9909-487f-b457-6fc26aa4e102.png)

![image](https://user-images.githubusercontent.com/490840/180787150-a91c670d-92e9-4488-a515-5d4f19e18f64.png)

![image](https://user-images.githubusercontent.com/490840/180786805-4c94ce17-6ddd-4be4-a61c-9ed821a35137.png)

Note, this pull request relies on https://github.com/compassinformatics/mapview-demo/pull/5 (already deployed to the development MapServer). 

TODO (in subsequent pull requests):

- add WFS styling to the new layers
- add unit tests
- add icon to the "Draw Edge" button