### PR TITLE
Layertree: only show layers that user is allowed to see

### DIFF
--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -111,39 +111,6 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
     },
 
     /**
-     * Removes layers which the user is not allowed to see.
-     *
-     * @param {Array} children An array of layer children
-     * @return {Array} The modified children array
-     */
-    updateTreeChildrenByRole: function(children){
-        var me = this;
-        var result = [];
-        Ext.each(children, function(child){
-            var showNode = true;
-            if (child.leaf) {
-                var requiredRoles = child.requiredRoles;
-                // check if user is allowed to see layer
-                if (Ext.isArray(requiredRoles) && requiredRoles.length){
-                    showNode = false;
-                    Ext.each(requiredRoles, function(role){
-                        var userHasRole = CpsiMapview.util.RoleManager.checkRole(role);
-                        if (userHasRole){
-                            showNode = true;
-                        }
-                    });
-                }
-            } else {
-                child.children = me.updateTreeChildrenByRole(child.children);
-            }
-            if (showNode) {
-                result.push(child);
-            }
-        });
-        return result;
-    },
-
-    /**
      * This method will return an instance of the GeoExt class
      * `GeoExt.data.store.LayersTree` based on the connected OL #map. The layers
      * of the `ol.Map` are restructured and divided into groups based on the
@@ -161,7 +128,7 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
 
             // remove layers for which the user does not have the role to see it
             var modifiedTree = Ext.clone(treeJson);
-            modifiedTree.treeConfig.children = me.updateTreeChildrenByRole(modifiedTree.treeConfig.children);
+            modifiedTree.treeConfig.children = CpsiMapview.util.RoleManager.updateTreeChildrenByRole(modifiedTree.treeConfig.children);
 
             // save defaults for tree nodes from config
             me.treeConfDefaults = modifiedTree.defaults || {};

--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -118,7 +118,7 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
     },
 
     /**
-     * This method will assigns an instance of the GeoExt class
+     * This method assigns an instance of the GeoExt class
      * `GeoExt.data.store.LayersTree` based on the connected OL #map to the view. The layers
      * of the `ol.Map` are restructured and divided into groups based on the
      * JSON tree structure loaded in #loadTreeStructure. This assures that

--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -223,7 +223,15 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
             if (requiredRoles && Ext.isArray(requiredRoles) && requiredRoles.length){
                 var showNode = CpsiMapview.util.RoleManager.hasAtLeastOneRequiredRole(requiredRoles);
                 // needed to ensure layer shown/hidden on both tree and map
-                record.getOlLayer().setVisible(showNode);
+                // only show layer if it shall be visible initially
+                var olLayer = record.getOlLayer();
+                if (olLayer && olLayer.get('_origLayerConf') && olLayer.get('_origLayerConf').openLayers) {
+                    if (olLayer.get('_origLayerConf').openLayers.visibility) {
+                        olLayer.setVisible(true);
+                    } else {
+                        olLayer.setVisible(false);
+                    }
+                }
                 return showNode;
             }
             return true;

--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -124,7 +124,6 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
      * JSON tree structure loaded in #loadTreeStructure. This assures that
      * the layers will appear in different folders in this TreePanel
      * (as defined in the tree structure JSON).
-     *
      */
     makeLayerStore: function () {
         var me = this;
@@ -216,6 +215,9 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
     filterLayersByRole: function () {
         var me = this;
         var store = me.getView().getStore();
+        if (!store){
+            return;
+        }
         store.filterBy(function(record){
             var requiredRoles = record.get('requiredRoles');
             if (requiredRoles && Ext.isArray(requiredRoles) && requiredRoles.length){

--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -221,14 +221,7 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
         store.filterBy(function(record){
             var requiredRoles = record.get('requiredRoles');
             if (requiredRoles && Ext.isArray(requiredRoles) && requiredRoles.length){
-                // TODO: move to util
-                var showNode = false;
-                Ext.each(requiredRoles, function(role){
-                    var userHasRole = CpsiMapview.util.RoleManager.checkRole(role);
-                    if (userHasRole){
-                        showNode = true;
-                    }
-                });
+                var showNode = CpsiMapview.util.RoleManager.hasAtLeastOneRequiredRole(requiredRoles);
                 record.getOlLayer().setVisible(showNode);
                 return showNode;
             }

--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -125,8 +125,7 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
 
         var treeJsonPromise = me.loadTreeStructure();
         treeJsonPromise.then(function (treeJson) {
-
-            // remove layers for which the user does not have the role to see it
+            // remove layers that shall not be shown to the user
             var modifiedTree = Ext.clone(treeJson);
             modifiedTree.treeConfig.children = CpsiMapview.util.RoleManager.updateTreeChildrenByRole(modifiedTree.treeConfig.children);
 

--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -222,6 +222,7 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
             var requiredRoles = record.get('requiredRoles');
             if (requiredRoles && Ext.isArray(requiredRoles) && requiredRoles.length){
                 var showNode = CpsiMapview.util.RoleManager.hasAtLeastOneRequiredRole(requiredRoles);
+                // needed to ensure layer shown/hidden on both tree and map
                 record.getOlLayer().setVisible(showNode);
                 return showNode;
             }

--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -111,6 +111,39 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
     },
 
     /**
+     * Removes layers which the user is not allowed to see.
+     *
+     * @param {Array} children An array of layer children
+     * @return {Array} The modified children array
+     */
+    updateTreeChildrenByRole: function(children){
+        var me = this;
+        var result = [];
+        Ext.each(children, function(child){
+            var showNode = true;
+            if (child.leaf) {
+                var requiredRoles = child.requiredRoles;
+                // check if user is allowed to see layer
+                if (Ext.isArray(requiredRoles) && requiredRoles.length){
+                    showNode = false;
+                    Ext.each(requiredRoles, function(role){
+                        var userHasRole = CpsiMapview.util.RoleManager.checkRole(role);
+                        if (userHasRole){
+                            showNode = true;
+                        }
+                    });
+                }
+            } else {
+                child.children = me.updateTreeChildrenByRole(child.children);
+            }
+            if (showNode) {
+                result.push(child);
+            }
+        });
+        return result;
+    },
+
+    /**
      * This method will return an instance of the GeoExt class
      * `GeoExt.data.store.LayersTree` based on the connected OL #map. The layers
      * of the `ol.Map` are restructured and divided into groups based on the
@@ -125,11 +158,16 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
 
         var treeJsonPromise = me.loadTreeStructure();
         treeJsonPromise.then(function (treeJson) {
+
+            // remove layers for which the user does not have the role to see it
+            var modifiedTree = Ext.clone(treeJson);
+            modifiedTree.treeConfig.children = me.updateTreeChildrenByRole(modifiedTree.treeConfig.children);
+
             // save defaults for tree nodes from config
-            me.treeConfDefaults = treeJson.defaults || {};
+            me.treeConfDefaults = modifiedTree.defaults || {};
 
             // get the root layer group holding the grouped map layers
-            var rootLayerGroup = me.getGroupedLayers(treeJson.treeConfig);
+            var rootLayerGroup = me.getGroupedLayers(modifiedTree.treeConfig);
 
             me.map.set('layerTreeRoot', rootLayerGroup);
             me.map.getLayers().insertAt(0, rootLayerGroup);

--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -209,7 +209,7 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
 
 
     /**
-     * Ensures tree and map only contains layers for which
+     * Ensures tree and map only contain layers for which
      * the user has the required roles to see.
      */
     filterLayersByRole: function () {

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -128,6 +128,8 @@ Ext.define('CpsiMapview.factory.Layer', {
             mapLayer.set('helpUrl', layerConf.helpUrl);
         }
 
+        mapLayer.set('_origLayerConf', layerConf);
+
         return mapLayer;
     },
 

--- a/app/util/RoleManager.js
+++ b/app/util/RoleManager.js
@@ -29,7 +29,7 @@ Ext.define('CpsiMapview.util.RoleManager', {
      * Checks if user has at least one of the required roles.
      *
      * @param {String[]} requiredRoles The required roles.
-     * @return {Boolean} If user has at least one of the required roles.
+     * @return {Boolean} True, if user has at least one of the required roles. False, otherwise.
      */
     hasAtLeastOneRequiredRole: function (requiredRoles) {
         var result = false;

--- a/app/util/RoleManager.js
+++ b/app/util/RoleManager.js
@@ -23,5 +23,22 @@ Ext.define('CpsiMapview.util.RoleManager', {
         }
 
         return hasRole;
+    },
+
+    /**
+     * Checks if user has at least one of the required roles.
+     *
+     * @param {String[]} requiredRoles The required roles.
+     * @return {Boolean} If user has at least one of the required roles.
+     */
+    hasAtLeastOneRequiredRole: function (requiredRoles) {
+        var result = false;
+        Ext.each(requiredRoles, function(role){
+            var userHasRole = CpsiMapview.util.RoleManager.checkRole(role);
+            if (userHasRole){
+                result = true;
+            }
+        });
+        return result;
     }
 });

--- a/app/util/RoleManager.js
+++ b/app/util/RoleManager.js
@@ -23,6 +23,37 @@ Ext.define('CpsiMapview.util.RoleManager', {
         }
 
         return hasRole;
-    }
+    },
 
+    /**
+     * Removes layers which the user is not allowed to see.
+     *
+     * @param {Array} children An array of layer children
+     * @return {Array} The modified children array
+     */
+    updateTreeChildrenByRole: function(children){
+        var result = [];
+        Ext.each(children, function(child){
+            var showNode = true;
+            if (child.leaf) {
+                var requiredRoles = child.requiredRoles;
+                // check if user is allowed to see layer
+                if (Ext.isArray(requiredRoles) && requiredRoles.length){
+                    showNode = false;
+                    Ext.each(requiredRoles, function(role){
+                        var userHasRole = CpsiMapview.util.RoleManager.checkRole(role);
+                        if (userHasRole){
+                            showNode = true;
+                        }
+                    });
+                }
+            } else {
+                child.children = CpsiMapview.util.RoleManager.updateTreeChildrenByRole(child.children);
+            }
+            if (showNode) {
+                result.push(child);
+            }
+        });
+        return result;
+    }
 });

--- a/app/util/RoleManager.js
+++ b/app/util/RoleManager.js
@@ -23,37 +23,5 @@ Ext.define('CpsiMapview.util.RoleManager', {
         }
 
         return hasRole;
-    },
-
-    /**
-     * Removes layers which the user is not allowed to see.
-     *
-     * @param {Array} children An array of layer children
-     * @return {Array} The modified children array
-     */
-    updateTreeChildrenByRole: function(children){
-        var result = [];
-        Ext.each(children, function(child){
-            var showNode = true;
-            if (child.leaf) {
-                var requiredRoles = child.requiredRoles;
-                // check if user is allowed to see layer
-                if (Ext.isArray(requiredRoles) && requiredRoles.length){
-                    showNode = false;
-                    Ext.each(requiredRoles, function(role){
-                        var userHasRole = CpsiMapview.util.RoleManager.checkRole(role);
-                        if (userHasRole){
-                            showNode = true;
-                        }
-                    });
-                }
-            } else {
-                child.children = CpsiMapview.util.RoleManager.updateTreeChildrenByRole(child.children);
-            }
-            if (showNode) {
-                result.push(child);
-            }
-        });
-        return result;
     }
 });

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -28,6 +28,10 @@ Ext.define('CpsiMapview.view.LayerTree', {
         legendImgLookup: {}
     },
 
+    listeners: {
+        'cmv-init-layertree': 'filterLayersByRole'
+    },
+
     // So that instantiation works without errors, might be changed during
     // instantiation of the LayerTree.
     store: {},

--- a/test/spec/util/RoleManager.spec.js
+++ b/test/spec/util/RoleManager.spec.js
@@ -1,0 +1,127 @@
+describe('CpsiMapview.util.RoleManager', function () {
+    var cmp = CpsiMapview.util.RoleManager;
+
+    var input = [
+        {
+            'id': 'overlay-folder',
+            'title': 'Layers',
+            'expanded': true,
+            'checked': false,
+            'children': [
+                {
+                    'id': 'LA_SITES',
+                    'text': 'Local Authority Sites',
+                    'leaf': true,
+                    'requiredRoles': ['EDITOR_ROLE']
+                },
+                {
+                    'id': 'RUINS_WFS',
+                    'leaf': true,
+                    'text': 'Ruins',
+                    'qtip': 'Right-click for a layer grid',
+                    'requiredRoles': ['VIEWER_ROLE']
+                },
+                {
+                    'id': 'NODES_WFS',
+                    'leaf': true,
+                    'text': 'Nodes',
+                    'qtip': 'Used in the snapping tool example',
+                    'requiredRoles': ['VIEWER_ROLE', 'EDITOR_ROLE']
+                },
+                {
+                    'id': 'EDGES_WFS',
+                    'leaf': true,
+                    'text': 'Edges',
+                    'qtip': 'Used in the snapping tool example',
+                    'requiredRoles': ['ADMIN_ROLE']
+                }
+            ]
+        },
+        {
+            'id': 'base-folder',
+            'title': 'Base Layers',
+            'expanded': true,
+            'children': [
+                {
+                    'id': 'GREY_BACKGROUND',
+                    'leaf': true,
+                    'text': 'Grey Background',
+                    'qtip': 'This is the background layer',
+                    'cls': 'cpsi-tree-node-baselayer'
+                }
+            ]
+        }];
+
+    var expected =  [
+        {
+            'id': 'overlay-folder',
+            'title': 'Layers',
+            'expanded': true,
+            'checked': false,
+            'children': [
+                {
+                    'id': 'LA_SITES',
+                    'text': 'Local Authority Sites',
+                    'leaf': true,
+                    'requiredRoles': ['EDITOR_ROLE']
+                },
+                {
+                    'id': 'RUINS_WFS',
+                    'leaf': true,
+                    'text': 'Ruins',
+                    'qtip': 'Right-click for a layer grid',
+                    'requiredRoles': ['VIEWER_ROLE']
+                },
+                {
+                    'id': 'NODES_WFS',
+                    'leaf': true,
+                    'text': 'Nodes',
+                    'qtip': 'Used in the snapping tool example',
+                    'requiredRoles': ['VIEWER_ROLE', 'EDITOR_ROLE']
+                }
+            ]
+        },
+        {
+            'id': 'base-folder',
+            'title': 'Base Layers',
+            'expanded': true,
+            'children': [
+                {
+                    'id': 'GREY_BACKGROUND',
+                    'leaf': true,
+                    'text': 'Grey Background',
+                    'qtip': 'This is the background layer',
+                    'cls': 'cpsi-tree-node-baselayer'
+                }
+            ]
+        }];
+
+    describe('Basics', function () {
+        it('is defined', function () {
+            expect(cmp).not.to.be(undefined);
+        });
+    });
+
+    describe('Functions', function () {
+
+        it('#checkRole', function () {
+            var fn = cmp.checkRole;
+            expect(fn).not.to.be(undefined);
+        });
+
+        it('#updateTreeChildrenByRole', function () {
+            var fn = cmp.updateTreeChildrenByRole;
+            expect(fn).not.to.be(undefined);
+
+            // mock that user has roles: EDITOR_ROLE and VIEWER_ROLE
+            CpsiMapview.util.RoleManager.checkRole = function (role) {
+                return role === 'EDITOR_ROLE' || role === 'VIEWER_ROLE';
+            };
+
+            var resultString =JSON.stringify(fn(input));
+            var expectedString = JSON.stringify(expected);
+            expect(resultString).to.equal(expectedString);
+        });
+    });
+}
+);

--- a/test/spec/util/RoleManager.spec.js
+++ b/test/spec/util/RoleManager.spec.js
@@ -17,6 +17,20 @@ describe('CpsiMapview.util.RoleManager', function () {
         it('#hasAtLeastOneRequiredRole', function () {
             var fn = cmp.hasAtLeastOneRequiredRole;
             expect(fn).not.to.be(undefined);
+
+            // mock that user has roles: EDITOR_ROLE and VIEWER_ROLE
+            CpsiMapview.util.RoleManager.checkRole = function (role) {
+                return role === 'EDITOR_ROLE' || role === 'VIEWER_ROLE';
+            };
+
+            expect(fn(['EDITOR_ROLE'])).to.equal(true);
+            expect(fn(['VIEWER_ROLE'])).to.equal(true);
+            expect(fn(['ADMIN_ROLE'])).to.equal(false);
+
+            expect(fn(['EDITOR_ROLE','VIEWER_ROLE', 'ADMIN_ROLE'])).to.equal(true);
+            expect(fn(['EDITOR_ROLE','VIEWER_ROLE'])).to.equal(true);
+            expect(fn(['ADMIN_ROLE','DUMMY_ROLE'])).to.equal(false);
+            expect(fn([])).to.equal(false);
         });
     });
 }

--- a/test/spec/util/RoleManager.spec.js
+++ b/test/spec/util/RoleManager.spec.js
@@ -23,13 +23,17 @@ describe('CpsiMapview.util.RoleManager', function () {
                 return role === 'EDITOR_ROLE' || role === 'VIEWER_ROLE';
             };
 
+            // if a single role is required
             expect(fn(['EDITOR_ROLE'])).to.equal(true);
             expect(fn(['VIEWER_ROLE'])).to.equal(true);
             expect(fn(['ADMIN_ROLE'])).to.equal(false);
 
+            // if one of multiple roles are required
             expect(fn(['EDITOR_ROLE','VIEWER_ROLE', 'ADMIN_ROLE'])).to.equal(true);
             expect(fn(['EDITOR_ROLE','VIEWER_ROLE'])).to.equal(true);
             expect(fn(['ADMIN_ROLE','DUMMY_ROLE'])).to.equal(false);
+
+            // if an empty Array is provided
             expect(fn([])).to.equal(false);
         });
     });

--- a/test/spec/util/RoleManager.spec.js
+++ b/test/spec/util/RoleManager.spec.js
@@ -1,101 +1,6 @@
 describe('CpsiMapview.util.RoleManager', function () {
     var cmp = CpsiMapview.util.RoleManager;
 
-    var input = [
-        {
-            'id': 'overlay-folder',
-            'title': 'Layers',
-            'expanded': true,
-            'checked': false,
-            'children': [
-                {
-                    'id': 'LA_SITES',
-                    'text': 'Local Authority Sites',
-                    'leaf': true,
-                    'requiredRoles': ['EDITOR_ROLE']
-                },
-                {
-                    'id': 'RUINS_WFS',
-                    'leaf': true,
-                    'text': 'Ruins',
-                    'qtip': 'Right-click for a layer grid',
-                    'requiredRoles': ['VIEWER_ROLE']
-                },
-                {
-                    'id': 'NODES_WFS',
-                    'leaf': true,
-                    'text': 'Nodes',
-                    'qtip': 'Used in the snapping tool example',
-                    'requiredRoles': ['VIEWER_ROLE', 'EDITOR_ROLE']
-                },
-                {
-                    'id': 'EDGES_WFS',
-                    'leaf': true,
-                    'text': 'Edges',
-                    'qtip': 'Used in the snapping tool example',
-                    'requiredRoles': ['ADMIN_ROLE']
-                }
-            ]
-        },
-        {
-            'id': 'base-folder',
-            'title': 'Base Layers',
-            'expanded': true,
-            'children': [
-                {
-                    'id': 'GREY_BACKGROUND',
-                    'leaf': true,
-                    'text': 'Grey Background',
-                    'qtip': 'This is the background layer',
-                    'cls': 'cpsi-tree-node-baselayer'
-                }
-            ]
-        }];
-
-    var expected =  [
-        {
-            'id': 'overlay-folder',
-            'title': 'Layers',
-            'expanded': true,
-            'checked': false,
-            'children': [
-                {
-                    'id': 'LA_SITES',
-                    'text': 'Local Authority Sites',
-                    'leaf': true,
-                    'requiredRoles': ['EDITOR_ROLE']
-                },
-                {
-                    'id': 'RUINS_WFS',
-                    'leaf': true,
-                    'text': 'Ruins',
-                    'qtip': 'Right-click for a layer grid',
-                    'requiredRoles': ['VIEWER_ROLE']
-                },
-                {
-                    'id': 'NODES_WFS',
-                    'leaf': true,
-                    'text': 'Nodes',
-                    'qtip': 'Used in the snapping tool example',
-                    'requiredRoles': ['VIEWER_ROLE', 'EDITOR_ROLE']
-                }
-            ]
-        },
-        {
-            'id': 'base-folder',
-            'title': 'Base Layers',
-            'expanded': true,
-            'children': [
-                {
-                    'id': 'GREY_BACKGROUND',
-                    'leaf': true,
-                    'text': 'Grey Background',
-                    'qtip': 'This is the background layer',
-                    'cls': 'cpsi-tree-node-baselayer'
-                }
-            ]
-        }];
-
     describe('Basics', function () {
         it('is defined', function () {
             expect(cmp).not.to.be(undefined);
@@ -107,22 +12,6 @@ describe('CpsiMapview.util.RoleManager', function () {
         it('#checkRole', function () {
             var fn = cmp.checkRole;
             expect(fn).not.to.be(undefined);
-        });
-
-        it('#updateTreeChildrenByRole', function () {
-            var fn = cmp.updateTreeChildrenByRole;
-            expect(fn).not.to.be(undefined);
-
-            // mock that user has roles: EDITOR_ROLE and VIEWER_ROLE
-            CpsiMapview.util.RoleManager.checkRole = function (role) {
-                return role === 'EDITOR_ROLE' || role === 'VIEWER_ROLE';
-            };
-
-            // we expect that the item "EDGES_WFS" is removed from the result,
-            // because it requires the role "ADMIN_ROLE" which the user does not have
-            var resultString =JSON.stringify(fn(input));
-            var expectedString = JSON.stringify(expected);
-            expect(resultString).to.equal(expectedString);
         });
     });
 }

--- a/test/spec/util/RoleManager.spec.js
+++ b/test/spec/util/RoleManager.spec.js
@@ -28,7 +28,7 @@ describe('CpsiMapview.util.RoleManager', function () {
             expect(fn(['VIEWER_ROLE'])).to.equal(true);
             expect(fn(['ADMIN_ROLE'])).to.equal(false);
 
-            // if one of multiple roles are required
+            // if one of multiple roles is required
             expect(fn(['EDITOR_ROLE','VIEWER_ROLE', 'ADMIN_ROLE'])).to.equal(true);
             expect(fn(['EDITOR_ROLE','VIEWER_ROLE'])).to.equal(true);
             expect(fn(['ADMIN_ROLE','DUMMY_ROLE'])).to.equal(false);

--- a/test/spec/util/RoleManager.spec.js
+++ b/test/spec/util/RoleManager.spec.js
@@ -13,6 +13,11 @@ describe('CpsiMapview.util.RoleManager', function () {
             var fn = cmp.checkRole;
             expect(fn).not.to.be(undefined);
         });
+
+        it('#hasAtLeastOneRequiredRole', function () {
+            var fn = cmp.hasAtLeastOneRequiredRole;
+            expect(fn).not.to.be(undefined);
+        });
     });
 }
 );

--- a/test/spec/util/RoleManager.spec.js
+++ b/test/spec/util/RoleManager.spec.js
@@ -118,6 +118,8 @@ describe('CpsiMapview.util.RoleManager', function () {
                 return role === 'EDITOR_ROLE' || role === 'VIEWER_ROLE';
             };
 
+            // we expect that the item "EDGES_WFS" is removed from the result,
+            // because it requires the role "ADMIN_ROLE" which the user does not have
             var resultString =JSON.stringify(fn(input));
             var expectedString = JSON.stringify(expected);
             expect(resultString).to.equal(expectedString);


### PR DESCRIPTION
- fixes #562 
- works on login and logout
- also works for groups
- also tested on switch layers
- for testing:
  - set the cookie `roles` to something like `EDITOR_ROLE,DUMMY_ROLE` 
  - add the property `requiredRoles` to layer items in `tree.json`, like below :

```json
[...]
{
            "id": "LA_SITES",
            "text": "Local Authority Sites",
            "leaf": true,
            "requiredRoles": ["READER_ROLE"]
          },
          {
            "id": "RUINS_WFS",
            "leaf": true,
            "text": "Ruins",
            "qtip": "Right-click for a layer grid",
            "requiredRoles": ["ADMIN_ROLE"]
          },
          {
            "id": "my-group",
            "title": "My Group",
            "expanded": true,
            "checked": false,
            "requiredRoles": ["EDITOR_ROLE"],
            "children": [
              {
                "id": "EDGES_WFS",
                "leaf": true,
                "text": "Edges",
                "qtip": "Used in the snapping tool example"
              },
              {
                "id": "NODES_WFS",
                "leaf": true,
                "text": "Nodes",
                "qtip": "Used in the snapping tool example",
                "requiredRoles": ["ADMIN_ROLE"]
              }
            ]
          },
          {
            "id": "BOREHOLE_WMS",
            "leaf": true,
            "text": "Borehole WMS",
            "requiredRoles": ["EDITOR_ROLE"]
          },
          {
            "id": "BOREHOLE_WFS",
            "leaf": true,
            "text": "Borehole WFS (Time)",
            "qtip": "Filter records with the timeslider control",
            "requiredRoles": ["EDITOR_ROLE"]
          },
[...]
```