### PR TITLE
Parallel line

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cpsi-mapview 
+# cpsi-mapview
 
 [![Build Status](https://travis-ci.org/compassinformatics/cpsi-mapview.svg?branch=master)](https://travis-ci.org/compassinformatics/cpsi-mapview)
 [![Coverage Status](https://coveralls.io/repos/compassinformatics/cpsi-mapview/badge.svg?branch=master&service=github)](https://coveralls.io/github/compassinformatics/cpsi-mapview?branch=master)
@@ -47,6 +47,15 @@ mklink /D ext D:\Tools\Sencha\ext-6.2.0
 new-item -itemtype symboliclink -path . -name ext -value D:\Tools\Sencha\ext-6.2.0
 ```
 
+Build required turf library:
+
+```
+npm i
+npm run build:turf
+```
+
+This will create the required library turf.js (only the needed subset of functions) and put it in `lib/`.
+
 Start dev-server
 
 ```
@@ -90,7 +99,7 @@ npm run test:watch
 ```
 
 To open in a browser and leave the browser open (to review UI components, debug, etc.).
-`--auto-watch` prevents application JS files being cached. 
+`--auto-watch` prevents application JS files being cached.
 
 ```
 karma start --browsers Chrome --single-run=False --debug --auto-watch

--- a/app.json
+++ b/app.json
@@ -280,6 +280,9 @@
       "remote": true
     },
     {
+      "path": "./lib/turf.js"
+    },
+    {
       "path": "app.js",
       "bundle": true
     }

--- a/app/controller/window/ParallelLineWindow.js
+++ b/app/controller/window/ParallelLineWindow.js
@@ -1,0 +1,59 @@
+/**
+ * This class is the controller for the ParallelLine.
+ */
+Ext.define('CpsiMapview.controller.window.ParallelLine', {
+    extend: 'Ext.app.ViewController',
+
+    alias: 'controller.cmv_parallel_line_window',
+
+    requires: [
+        'BasiGX.view.component.Map'
+    ],
+
+    selectInteraction: null,
+
+    layer: null,
+
+    onSelectFeatureToggle: function (btn, toggled) {
+        var me = this;
+        var view = me.getView();
+        var vm = view.getViewModel();
+        var map = BasiGX.view.component.Map.guess().getMap();
+        if (toggled) {
+            var interactionConfig = view.interactionConfig ? view.interactionConfig : {};
+            this.selectInteraction = new ol.interaction.Select(interactionConfig);
+            this.selectInteraction.on('select', function (evt) {
+                var selectedFeature = evt.selected[0];
+                vm.set('selectedFeature', selectedFeature);
+            });
+            map.addInteraction(this.selectInteraction);
+
+        } else {
+            if (!this.selectInteraction) {
+                return;
+            }
+            map.removeInteraction(this.selectInteraction);
+            this.selectInteraction = null;
+        }
+    },
+
+    onParallelLineCreated: function (newLineFeature) {
+        if (this.layer === null) {
+            this.layer = new ol.layer.Vector();
+            var map = BasiGX.view.component.Map.guess().getMap();
+            if (map) {
+                map.addLayer(this.layer);
+            }
+        }
+        var source = new ol.source.Vector({
+            features: [newLineFeature]
+        });
+        this.layer.setSource(source);
+    },
+
+    onBeforeDestroy: function () {
+        // remove select interaction
+        this.onSelectFeatureToggle(null, false);
+    }
+
+});

--- a/app/model/window/ParallelLineWindow.js
+++ b/app/model/window/ParallelLineWindow.js
@@ -1,0 +1,9 @@
+Ext.define('CpsiMapview.model.window.ParallelLine', {
+    extend: 'Ext.app.ViewModel',
+
+    alias: 'viewmodel.cmv_parallel_line_window',
+
+    data: {
+        selectedFeature: null
+    }
+});

--- a/app/view/toolbar/MapTools.js
+++ b/app/view/toolbar/MapTools.js
@@ -22,7 +22,8 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
         'CpsiMapview.view.panel.TimeSlider',
         'CpsiMapview.view.panel.NumericAttributeSlider',
         'CpsiMapview.view.lineSliceGridExample.LineSliceGridButton',
-        'CpsiMapview.view.snappingExample.EdgeButton'
+        'CpsiMapview.view.snappingExample.EdgeButton',
+        'CpsiMapview.view.window.ParallelLine'
     ],
 
     controller: 'cmv_maptools',
@@ -144,6 +145,27 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
                 xtype: 'cmv_edgebutton',
                 tooltip: 'Snapping demo',
                 glyph: 'ea76@font-gis'
+            }, {
+                glyph: 'ea50@font-gis',
+                tooltip: 'Draw Parallel Lines',
+                toggleGroup: 'map',
+                listeners: {
+                    toggle: function (btn, toggled) {
+                        var parallelLineWindow;
+                        if (toggled) {
+                            parallelLineWindow = Ext.create({
+                                xtype: 'cmv_parallel_line_window',
+                            });
+                            parallelLineWindow.show();
+                        } else {
+                            parallelLineWindow = Ext.ComponentQuery.query(
+                                'cmv_parallel_line_window')[0];
+                            if (parallelLineWindow) {
+                                parallelLineWindow.destroy();
+                            }
+                        }
+                    }
+                }
             }]
         },
         '->',

--- a/app/view/toolbar/ParallelLineToolbar.js
+++ b/app/view/toolbar/ParallelLineToolbar.js
@@ -1,0 +1,165 @@
+/**
+ * This class is the toolbar for creating parallel lines.
+ * @class CpsiMapview.view.toolbar.ParallelLine
+ */
+Ext.define('CpsiMapview.view.toolbar.ParallelLine', {
+    extend: 'Ext.toolbar.Toolbar',
+    xtype: 'cmv_parallel_line_toolbar',
+
+    requires: [
+        'Ext.form.field.Number',
+        'BasiGX.view.component.Map'
+    ],
+
+    cls: 'cmv_parallel_line_toolbar',
+
+    viewModel: {
+        data: {
+            offsetLabel: 'Offset',
+            parallelTooltip: 'Create parallel line',
+            offset: 0,
+            feature: null,
+            parallelFeature: null
+        }
+    },
+
+    name: null,
+
+    /**
+     * @event parallelLineCreated
+     * Fires, when a new parallel line was created.
+     * @param {ol.Feature} parallelFeature The created parallel feature.
+     */
+
+    config: {
+        /**
+         * The feature to create the parallel line for.
+         */
+        feature: null,
+        /**
+         * The unit to use for calculating the offset. Can be one of
+         * 'degrees', 'radians', 'miles', 'kilometers', 'inches',
+         * 'yards', 'meters'.
+         *
+         * Defaults to 'meters'.
+         */
+        offsetUnit: 'meters'
+    },
+
+    items: [{
+        xtype: 'numberfield',
+        bind: {
+            fieldLabel: '{offsetLabel}',
+            value: '{offset}',
+        },
+        listeners: {
+            change: function () {
+                var toolbar = this.up('cmv_parallel_line_toolbar');
+
+                var vm = toolbar.getViewModel();
+                if (!vm) {
+                    return;
+                }
+                var parallelFeature = vm.get('parallelFeature');
+                if (!parallelFeature) {
+                    return;
+                }
+
+                toolbar.createParallelFeature();
+            }
+        }
+    }, {
+        glyph: 'ea50@font-gis',
+        bind: {
+            tooltip: '{parallelTooltip}',
+            disabled: '{!feature}'
+        },
+        handler: function() {
+            var toolbar = this.up('cmv_parallel_line_toolbar');
+            toolbar.createParallelFeature();
+        }
+    }],
+
+    applyFeature: function (feature) {
+        if (!feature) {
+            return;
+        }
+        var geometry = feature.getGeometry();
+        if (!geometry) {
+            console.warn('Feature has no geometry.');
+            return;
+        }
+
+        var geomType = geometry.getType();
+        if (geomType !== 'LineString' && geomType !== 'MultiLineString') {
+            console.warn('Unsupported feature geometry. Geometry must be of type "LineString" or "MultiLineString".');
+            return;
+        }
+        return feature;
+    },
+
+    updateFeature: function (newFeature) {
+        var vm = this.getViewModel();
+        if (!vm) {
+            return;
+        }
+        vm.set('feature', newFeature);
+        vm.set('parallelFeature', null);
+    },
+
+    applyOffsetUnit: function (offsetUnit) {
+        if (!offsetUnit) {
+            console.warn('offsetUnit is empty or undefined');
+            return;
+        }
+        var supportedUnits = [
+            'degrees', 'radians', 'miles', 'kilometers', 'inches',
+            'yards', 'meters'
+        ];
+        if (supportedUnits.indexOf(offsetUnit) === -1) {
+            console.warn(
+                'Provided offsetUnit not supported. Must be one of: ' + supportedUnits
+            );
+            return;
+        }
+        return offsetUnit;
+    },
+
+    /**
+     * Creates a parallel line for the given feature with given offset.
+     *
+     * Fires the parallelLineCreated event.
+     *
+     * @returns {void}
+     */
+    createParallelFeature: function() {
+        var vm = this.getViewModel();
+        if (!vm) {
+            return;
+        }
+        var feature = vm.get('feature');
+        if (!feature) {
+            return;
+        }
+
+        var offset = vm.get('offset');
+        if (offset === null) {
+            return;
+        }
+
+        var offsetUnit = this.getOffsetUnit();
+        var map = BasiGX.view.component.Map.guess().getMap();
+        var mapProj = map.getView().getProjection().getCode();
+        var format = new ol.format.GeoJSON({
+            featureProjection: mapProj,
+            dataProjection: 'EPSG:4326'
+        });
+        var geojsonFeature = format.writeFeatureObject(feature);
+        var parallelGeojsonFeature = turf.lineOffset(
+            geojsonFeature.geometry, offset, {units: offsetUnit}
+        );
+        var parallelFeature = format.readFeature(parallelGeojsonFeature);
+        vm.set('parallelFeature', parallelFeature);
+        this.fireEvent('parallelLineCreated', parallelFeature);
+    }
+});

--- a/app/view/window/ParallelLineWindow.js
+++ b/app/view/window/ParallelLineWindow.js
@@ -1,0 +1,47 @@
+/**
+ * This is an example class for the usage of the ParallelLine toolbar.
+ * A new layer will be added to the map, that contains the latest created
+ * feature.
+ *
+ * @class CpsiMapview.view.window.ParallelLine
+ */
+Ext.define('CpsiMapview.view.window.ParallelLine', {
+    extend: 'Ext.window.Window',
+    xtype: 'cmv_parallel_line_window',
+
+    requires: [
+        'Ext.button.Button',
+        'CpsiMapview.view.toolbar.ParallelLine',
+        'CpsiMapview.controller.window.ParallelLine',
+        'CpsiMapview.model.window.ParallelLine'
+    ],
+
+    controller: 'cmv_parallel_line_window',
+
+    viewModel: 'cmv_parallel_line_window',
+
+    title: 'Parallel Line Example',
+
+    layer: null,
+
+    items: [{
+        xtype: 'button',
+        text: 'Select Feature (example button)',
+        enableToggle: true,
+        listeners: {
+            toggle: 'onSelectFeatureToggle'
+        }
+    }, {
+        xtype: 'cmv_parallel_line_toolbar',
+        bind: {
+            feature: '{selectedFeature}'
+        },
+        listeners: {
+            parallelLineCreated: 'onParallelLineCreated'
+        }
+    }],
+
+    listeners: {
+        beforedestroy: 'onBeforeDestroy'
+    }
+});

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "npm run lint && npm run jsonlint && karma start --single-run",
     "test:watch": "karma start karma-watch.conf.js",
     "test:coverage": "karma start karma.conf.js --single-run --reporters coverage",
-    "generate:docs": "jsduck --config=jsduck.json --output=docs-ext --title=\"MapView Documentation\" && cp -r docs-ext build/production/CpsiMapview/docs-ext"
+    "generate:docs": "jsduck --config=jsduck.json --output=docs-ext --title=\"MapView Documentation\" && cp -r docs-ext build/production/CpsiMapview/docs-ext",
+    "build:turf": "browserify turf-builder.js -s turf > lib/turf.js"
   },
   "repository": {
     "type": "git",
@@ -26,6 +27,7 @@
   "dependencies": {
     "@geoext/openlayers-legacy": "^6.5.4",
     "@ogc-schemas/ogc-schemas": "^3.0.0",
+    "@turf/line-offset": "^6.5.0",
     "eslint": "^7.29.0",
     "font-gis": "^1.0.4",
     "geostyler-openlayers-parser": "3.0.2",
@@ -35,6 +37,7 @@
     "proj4": "^2.7.4"
   },
   "devDependencies": {
+    "browserify": "^17.0.0",
     "karma": "^6.3.9",
     "karma-chrome-launcher": "^3.1.0",
     "karma-cli": "^2.0.0",

--- a/test/spec/view/toolbar/ParallelLine.spec.js
+++ b/test/spec/view/toolbar/ParallelLine.spec.js
@@ -1,0 +1,12 @@
+describe('CpsiMapview.view.toolbar.ParallelLine', function() {
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(CpsiMapview.view.toolbar.ParallelLine).not.to.be(undefined);
+        });
+
+        it('can be instantiated', function() {
+            var inst = Ext.create('CpsiMapview.view.toolbar.ParallelLine');
+            expect(inst).to.be.a(CpsiMapview.view.toolbar.ParallelLine);
+        });
+    });
+});

--- a/turf-builder.js
+++ b/turf-builder.js
@@ -1,0 +1,3 @@
+module.exports = {
+    lineOffset: require('@turf/line-offset')
+};


### PR DESCRIPTION
This adds the ParallelLine toolbar.

This toolbar expects a feature with a line geometry and provides an input field for specifying an offset and a trigger button to create a new feature that is parallel to the provided feature. The toolbar only fires an event `parallelLineCreated` that contains the newly created feature. Any handling with regard to adding the feature to a layer must be done in the wrapping component. `ParallelLineWindow` provides an example implementation for that.

Once a parallel line was created for the given feature, any changes in the offset will automatically fire the `parallelLineCreated` event again.

Example:

![compass-parallel-line](https://user-images.githubusercontent.com/12186477/181211518-d89b8dae-9128-4bc1-a48d-103dfc81eab5.gif)

Please note that depending on the offset and the feature's geometry, the geometry of the parallel feature might differ from its original geometry.

Example:

![compass-parallel-line-high-offset](https://user-images.githubusercontent.com/12186477/181211870-7a2309c7-02da-4b7e-958c-b15df1ced3da.gif)

This solves https://github.com/compassinformatics/cpsi-mapview/issues/569