### PR TITLE
Drawing Tool Improvements

### DIFF
--- a/app/controller/button/DrawingButtonController.js
+++ b/app/controller/button/DrawingButtonController.js
@@ -169,19 +169,20 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
             // remember if we have hit a referenced layer
             var nodeLayerHit = false;
             var edgeLayerHit = false;
+            var polygonLayerHit = false;
             var selfHit = false;
 
             var snappedEdgeFeature;
             me.map.forEachFeatureAtPixel(pixel, function (foundFeature, layer) {
+                snappedEdgeFeature = foundFeature;
                 if (layer) {
                     var key = layer.get('layerKey');
                     if (key === view.getNodeLayerKey()) {
                         nodeLayerHit = true;
                     } else if (key === view.getEdgeLayerKey()) {
                         edgeLayerHit = true;
-                        snappedEdgeFeature = foundFeature;
                     } else if (key === view.getPolygonLayerKey()) {
-                        // TODO: handle polygon hit
+                        polygonLayerHit = true;
                     } else if (me.drawLayer === layer) {
                         // snapping to self drawn feature
                         selfHit = true;
@@ -213,6 +214,8 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
                 } else {
                     return view.getSnappedEdgeStyle();
                 }
+            } else if (polygonLayerHit) {
+                return view.getSnappedEdgeStyle();
             } else if (selfHit) {
                 return view.getModifySnapPointStyle();
             } else {

--- a/app/controller/button/DrawingButtonController.js
+++ b/app/controller/button/DrawingButtonController.js
@@ -45,7 +45,7 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
     snapInteraction: null,
 
     /**
-     * If user has started to edit a line i.d. the first point of a line is already set
+     * If user has started to edit a line, this means the first point of a line is already set
      */
     editingIsActive: false,
 

--- a/app/controller/button/DrawingButtonController.js
+++ b/app/controller/button/DrawingButtonController.js
@@ -103,8 +103,6 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
             return ol.events.condition.primaryAction(evt) && ol.events.condition.noModifierKeys(evt);
         };
 
-        me.prepareDrawingStyles();
-
         var source = layer.getSource();
         var collection = source.getFeaturesCollection();
         var drawInteractionConfig = {
@@ -139,10 +137,8 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
         view.getDrawStyleStartPoint().setGeometry(function (feature) {
             var geom = feature.getGeometry();
             var coords = geom.getCoordinates();
-            if (me.editingIsActive) {
-                var firstCoord = coords[0];
-                return new ol.geom.Point(firstCoord);
-            }
+            var firstCoord = coords[0];
+            return new ol.geom.Point(firstCoord);
         });
         view.getDrawStyleEndPoint().setGeometry(function (feature) {
             var coords = feature.getGeometry().getCoordinates();
@@ -165,13 +161,6 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
     getDrawStyleFunction: function() {
         var me = this;
         var view = me.getView();
-
-        var drawStyle = [
-            view.getDrawBeforeEditingPoint(),
-            view.getDrawStyleStartPoint(),
-            view.getDrawStyleLine(),
-            view.getDrawStyleEndPoint(),
-        ];
 
         return function (feature) {
             var coordinate = feature.getGeometry().getCoordinates();
@@ -218,7 +207,7 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
             } else if (selfHit) {
                 return view.getModifySnapPointStyle();
             } else {
-                return drawStyle;
+                return me.defaultdrawStyle;
             }
         };
     },
@@ -558,6 +547,17 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
                 me.drawLayer = view.drawLayer;
             }
         }
+
+        me.prepareDrawingStyles();
+
+        // set initial style for drawing features
+        me.defaultdrawStyle = [
+            view.getDrawBeforeEditingPoint(),
+            view.getDrawStyleStartPoint(),
+            view.getDrawStyleLine(),
+            view.getDrawStyleEndPoint(),
+        ];
+        me.drawLayer.setStyle(me.defaultdrawStyle);
 
         me.setDrawInteraction(me.drawLayer);
         me.setModifyInteraction(me.drawLayer);

--- a/app/controller/button/DrawingButtonController.js
+++ b/app/controller/button/DrawingButtonController.js
@@ -174,12 +174,12 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
 
             var snappedEdgeFeature;
             me.map.forEachFeatureAtPixel(pixel, function (foundFeature, layer) {
-                snappedEdgeFeature = foundFeature;
                 if (layer) {
                     var key = layer.get('layerKey');
                     if (key === view.getNodeLayerKey()) {
                         nodeLayerHit = true;
                     } else if (key === view.getEdgeLayerKey()) {
+                        snappedEdgeFeature = foundFeature;
                         edgeLayerHit = true;
                     } else if (key === view.getPolygonLayerKey()) {
                         polygonLayerHit = true;
@@ -205,6 +205,7 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
                     var verticesMultiPoint = new ol.geom.MultiPoint(coords);
                     var snappedEdgeVertexStyle = view.getSnappedEdgeVertexStyle().clone();
                     snappedEdgeVertexStyle.setGeometry(verticesMultiPoint);
+                    snappedEdgeVertexStyle.setZIndex(-Infinity);
 
                     // combine style for snapped point and vertices of snapped edge
                     return [
@@ -215,7 +216,7 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
                     return view.getSnappedEdgeStyle();
                 }
             } else if (polygonLayerHit) {
-                return view.getSnappedEdgeStyle();
+                return view.getSnappedPolygonStyle();
             } else if (selfHit) {
                 return view.getModifySnapPointStyle();
             } else {

--- a/app/controller/button/DrawingButtonController.js
+++ b/app/controller/button/DrawingButtonController.js
@@ -114,7 +114,7 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
         };
 
         me.drawInteraction = new ol.interaction.Draw(drawInteractionConfig);
-        me.drawInteraction.on('drawstart',me.handleDrawStart);
+        me.drawInteraction.on('drawstart', me.handleDrawStart);
         me.drawInteraction.on('drawend', me.handleDrawEnd);
 
         me.map.addInteraction(me.drawInteraction);

--- a/app/controller/button/DrawingButtonController.js
+++ b/app/controller/button/DrawingButtonController.js
@@ -167,40 +167,33 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
             var pixel = me.map.getPixelFromCoordinate(coordinate);
 
             // remember if we have hit a referenced layer
-            var nodeLayerHit = false;
-            var edgeLayerHit = false;
-            var polygonLayerHit = false;
-            var selfHit = false;
 
-            var snappedEdgeFeature;
+            var node, edge, polygon, self;
+
             me.map.forEachFeatureAtPixel(pixel, function (foundFeature, layer) {
                 if (layer) {
                     var key = layer.get('layerKey');
                     if (key === view.getNodeLayerKey()) {
-                        nodeLayerHit = true;
+                        node = foundFeature;
                     } else if (key === view.getEdgeLayerKey()) {
-                        snappedEdgeFeature = foundFeature;
-                        edgeLayerHit = true;
+                        edge = foundFeature;
                     } else if (key === view.getPolygonLayerKey()) {
-                        polygonLayerHit = true;
+                        polygon = foundFeature;
                     } else if (me.drawLayer === layer) {
                         // snapping to self drawn feature
-                        selfHit = true;
+                        self = foundFeature;
                     }
                 }
             });
 
-            if (nodeLayerHit) {
+            if (node) {
                 return view.getSnappedNodeStyle();
-            } else if (edgeLayerHit) {
+            } else if (edge) {
                 if (view.getShowVerticesOfSnappedEdge()) {
-                    if (!snappedEdgeFeature) {
-                        return;
-                    }
                     // Prepare style for vertices of snapped edge
                     // we create a MultiPoint from the edge's vertices
                     // and set it as geometry in our style function
-                    var geom = snappedEdgeFeature.getGeometry();
+                    var geom = edge.getGeometry();
                     var coords = geom.getCoordinates();
                     var verticesMultiPoint = new ol.geom.MultiPoint(coords);
                     var snappedEdgeVertexStyle = view.getSnappedEdgeVertexStyle().clone();
@@ -215,9 +208,9 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
                 } else {
                     return view.getSnappedEdgeStyle();
                 }
-            } else if (polygonLayerHit) {
+            } else if (polygon) {
                 return view.getSnappedPolygonStyle();
-            } else if (selfHit) {
+            } else if (self) {
                 return view.getModifySnapPointStyle();
             } else {
                 return me.defaultdrawStyle;

--- a/app/controller/button/DrawingButtonController.js
+++ b/app/controller/button/DrawingButtonController.js
@@ -188,22 +188,25 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
             if (nodeLayerHit) {
                 return view.getSnappedNodeStyle();
             } else if (edgeLayerHit) {
-                if (!snappedEdgeFeature) {
-                    return;
+                if (view.getShowVerticesOfSnappedEdge()) {
+                    // Prepare style for vertices of snapped edge
+                    if (!snappedEdgeFeature) {
+                        return;
+                    }
+                    var geom = snappedEdgeFeature.getGeometry();
+                    var coords = geom.getCoordinates();
+                    var verticesMultiPoint = new ol.geom.MultiPoint(coords);
+                    var vertexStyle = view.getSnappedEdgeVertexStyle();
+                    vertexStyle.setGeometry(verticesMultiPoint);
+
+                    // combine style for snapped point and vertices of snapped edge
+                    return [
+                        vertexStyle,
+                        view.getSnappedEdgeStyle()
+                    ];
+                } else {
+                    return view.getSnappedEdgeStyle();
                 }
-
-                // Prepare style for vertices of snapped edge
-                var geom = snappedEdgeFeature.getGeometry();
-                var coords = geom.getCoordinates();
-                var verticesMultiPoint = new ol.geom.MultiPoint(coords);
-                var vertexStyle = view.getSnappedEdgeVertexStyle();
-                vertexStyle.setGeometry(verticesMultiPoint);
-
-                // combine style for snapped point and vertices of snapped edge
-                return [
-                    vertexStyle,
-                    view.getSnappedEdgeStyle()
-                ];
             } else if (selfHit) {
                 return view.getModifySnapPointStyle();
             } else {

--- a/app/controller/button/DrawingButtonController.js
+++ b/app/controller/button/DrawingButtonController.js
@@ -203,7 +203,7 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
                     var geom = snappedEdgeFeature.getGeometry();
                     var coords = geom.getCoordinates();
                     var verticesMultiPoint = new ol.geom.MultiPoint(coords);
-                    var snappedEdgeVertexStyle = view.getSnappedEdgeVertexStyle();
+                    var snappedEdgeVertexStyle = view.getSnappedEdgeVertexStyle().clone();
                     snappedEdgeVertexStyle.setGeometry(verticesMultiPoint);
 
                     // combine style for snapped point and vertices of snapped edge

--- a/app/util/Style.js
+++ b/app/util/Style.js
@@ -84,14 +84,25 @@ Ext.define('CpsiMapview.util.Style', {
     createBlackCross: function () {
         return new ol.style.Style({
             image: new ol.style.RegularShape({
-                fill: new ol.style.Fill({
-                    color: 'black'
-                }),
                 stroke: new ol.style.Stroke({
                     color: 'black',
-                    width: 3
+                    width: 1
                 }),
                 points: 4,
+                radius: 10,
+                radius2: 0,
+                angle: 0,
+            })
+        });
+    },
+    createBlackStar: function () {
+        return new ol.style.Style({
+            image: new ol.style.RegularShape({
+                stroke: new ol.style.Stroke({
+                    color: 'black',
+                    width: 1
+                }),
+                points: 5,
                 radius: 10,
                 radius2: 0,
                 angle: 0,
@@ -102,12 +113,9 @@ Ext.define('CpsiMapview.util.Style', {
     createBlackRotatedCross: function () {
         return new ol.style.Style({
             image: new ol.style.RegularShape({
-                fill: new ol.style.Fill({
-                    color: 'black'
-                }),
                 stroke: new ol.style.Stroke({
                     color: 'black',
-                    width: 3
+                    width: 1
                 }),
                 points: 4,
                 radius: 10,

--- a/app/util/Style.js
+++ b/app/util/Style.js
@@ -9,6 +9,113 @@ Ext.define('CpsiMapview.util.Style', {
 
     singleton: true,
 
+    blackCircle: new ol.style.Style({
+        image: new ol.style.Circle({
+            radius: 5,
+            fill: new ol.style.Fill({
+                color: 'black'
+            })
+        })
+    }),
+
+    greenTriangle: new ol.style.Style({
+        image: new ol.style.RegularShape({
+            fill: new ol.style.Fill({
+                color: 'green'
+            }),
+            stroke: new ol.style.Stroke({
+                color: 'green',
+                width: 3
+            }),
+            points: 3,
+            radius: 5,
+            rotation: 0,
+            angle: 0,
+        })
+    }),
+
+    redSquare: new ol.style.Style({
+        image: new ol.style.RegularShape({
+            fill: new ol.style.Fill({
+                color: 'red'
+            }),
+            stroke: new ol.style.Stroke({
+                color: 'red',
+                width: 3
+            }),
+            points: 4,
+            radius: 5,
+            angle: Math.PI / 4,
+        })
+    }),
+
+    yellowSquare: new ol.style.Style({
+        image: new ol.style.RegularShape({
+            fill: new ol.style.Fill({
+                color: 'yellow'
+            }),
+            stroke: new ol.style.Stroke({
+                color: 'black',
+                width: 3
+            }),
+            points: 4,
+            radius: 10,
+            angle: Math.PI / 4,
+        })
+    }),
+
+    orangeLine: new ol.style.Style({
+        stroke: new ol.style.Stroke({
+            color: 'orange',
+            width: 2
+        })
+    }),
+
+    blackCross: new ol.style.Style({
+        image: new ol.style.RegularShape({
+            fill: new ol.style.Fill({
+                color: 'black'
+            }),
+            stroke: new ol.style.Stroke({
+                color: 'black',
+                width: 3
+            }),
+            points: 4,
+            radius: 10,
+            radius2: 0,
+            angle: 0,
+        })
+    }),
+
+    blackRotatedCross: new ol.style.Style({
+        image: new ol.style.RegularShape({
+            fill: new ol.style.Fill({
+                color: 'black'
+            }),
+            stroke: new ol.style.Stroke({
+                color: 'black',
+                width: 3
+            }),
+            points: 4,
+            radius: 10,
+            radius2: 0,
+            angle: Math.PI / 4
+        })
+    }),
+
+    whiteCircle: new ol.style.Style({
+        image: new ol.style.Circle({
+            radius: 3,
+            fill: new ol.style.Fill({
+                color: 'white',
+            }),
+            stroke: new ol.style.Stroke({
+                color: 'black',
+                width: 1
+            }),
+        })
+    }),
+
     /**
      * Returns the human readable label for the given layer style.
      * If WFS or VT we remove the '_' and the .xml file ending. For other layer

--- a/app/util/Style.js
+++ b/app/util/Style.js
@@ -9,112 +9,128 @@ Ext.define('CpsiMapview.util.Style', {
 
     singleton: true,
 
-    blackCircle: new ol.style.Style({
-        image: new ol.style.Circle({
-            radius: 5,
-            fill: new ol.style.Fill({
-                color: 'black'
+    createBlackCircle: function () {
+        return new ol.style.Style({
+            image: new ol.style.Circle({
+                radius: 5,
+                fill: new ol.style.Fill({
+                    color: 'black'
+                })
             })
-        })
-    }),
+        });
+    },
 
-    greenTriangle: new ol.style.Style({
-        image: new ol.style.RegularShape({
-            fill: new ol.style.Fill({
-                color: 'green'
-            }),
+    createGreenTriangle: function () {
+        return new ol.style.Style({
+            image: new ol.style.RegularShape({
+                fill: new ol.style.Fill({
+                    color: 'green'
+                }),
+                stroke: new ol.style.Stroke({
+                    color: 'green',
+                    width: 3
+                }),
+                points: 3,
+                radius: 5,
+                rotation: 0,
+                angle: 0,
+            })
+        });
+    },
+
+    createRedSquare: function () {
+        return new ol.style.Style({
+            image: new ol.style.RegularShape({
+                fill: new ol.style.Fill({
+                    color: 'red'
+                }),
+                stroke: new ol.style.Stroke({
+                    color: 'red',
+                    width: 3
+                }),
+                points: 4,
+                radius: 5,
+                angle: Math.PI / 4,
+            })
+        });
+    },
+
+    createYellowSquare: function () {
+        return new ol.style.Style({
+            image: new ol.style.RegularShape({
+                fill: new ol.style.Fill({
+                    color: 'yellow'
+                }),
+                stroke: new ol.style.Stroke({
+                    color: 'black',
+                    width: 3
+                }),
+                points: 4,
+                radius: 10,
+                angle: Math.PI / 4,
+            })
+        });
+    },
+
+    createOrangeLine: function () {
+        return new ol.style.Style({
             stroke: new ol.style.Stroke({
-                color: 'green',
-                width: 3
-            }),
-            points: 3,
-            radius: 5,
-            rotation: 0,
-            angle: 0,
-        })
-    }),
+                color: 'orange',
+                width: 2
+            })
+        });
+    },
 
-    redSquare: new ol.style.Style({
-        image: new ol.style.RegularShape({
-            fill: new ol.style.Fill({
-                color: 'red'
-            }),
-            stroke: new ol.style.Stroke({
-                color: 'red',
-                width: 3
-            }),
-            points: 4,
-            radius: 5,
-            angle: Math.PI / 4,
-        })
-    }),
+    createBlackCross: function () {
+        return new ol.style.Style({
+            image: new ol.style.RegularShape({
+                fill: new ol.style.Fill({
+                    color: 'black'
+                }),
+                stroke: new ol.style.Stroke({
+                    color: 'black',
+                    width: 3
+                }),
+                points: 4,
+                radius: 10,
+                radius2: 0,
+                angle: 0,
+            })
+        });
+    },
 
-    yellowSquare: new ol.style.Style({
-        image: new ol.style.RegularShape({
-            fill: new ol.style.Fill({
-                color: 'yellow'
-            }),
-            stroke: new ol.style.Stroke({
-                color: 'black',
-                width: 3
-            }),
-            points: 4,
-            radius: 10,
-            angle: Math.PI / 4,
-        })
-    }),
+    createBlackRotatedCross: function () {
+        return new ol.style.Style({
+            image: new ol.style.RegularShape({
+                fill: new ol.style.Fill({
+                    color: 'black'
+                }),
+                stroke: new ol.style.Stroke({
+                    color: 'black',
+                    width: 3
+                }),
+                points: 4,
+                radius: 10,
+                radius2: 0,
+                angle: Math.PI / 4
+            })
+        });
+    },
 
-    orangeLine: new ol.style.Style({
-        stroke: new ol.style.Stroke({
-            color: 'orange',
-            width: 2
-        })
-    }),
-
-    blackCross: new ol.style.Style({
-        image: new ol.style.RegularShape({
-            fill: new ol.style.Fill({
-                color: 'black'
-            }),
-            stroke: new ol.style.Stroke({
-                color: 'black',
-                width: 3
-            }),
-            points: 4,
-            radius: 10,
-            radius2: 0,
-            angle: 0,
-        })
-    }),
-
-    blackRotatedCross: new ol.style.Style({
-        image: new ol.style.RegularShape({
-            fill: new ol.style.Fill({
-                color: 'black'
-            }),
-            stroke: new ol.style.Stroke({
-                color: 'black',
-                width: 3
-            }),
-            points: 4,
-            radius: 10,
-            radius2: 0,
-            angle: Math.PI / 4
-        })
-    }),
-
-    whiteCircle: new ol.style.Style({
-        image: new ol.style.Circle({
-            radius: 3,
-            fill: new ol.style.Fill({
-                color: 'white',
-            }),
-            stroke: new ol.style.Stroke({
-                color: 'black',
-                width: 1
-            }),
-        })
-    }),
+    createWhiteCircle: function () {
+        return new ol.style.Style({
+            image: new ol.style.Circle({
+                radius: 3,
+                fill: new ol.style.Fill({
+                    color: 'white',
+                }),
+                stroke: new ol.style.Stroke({
+                    color: 'black',
+                    width: 1
+                }),
+            })
+        });
+    },
 
     /**
      * Returns the human readable label for the given layer style.

--- a/app/view/button/DrawingButton.js
+++ b/app/view/button/DrawingButton.js
@@ -60,7 +60,124 @@ Ext.define('CpsiMapview.view.tool.DrawingButton', {
          * The vector layer key of a polygon layer to snap the start and ends
          * of newly drawn lines to, and return the polygon ids
          */
-        polygonLayerKey: null
+        polygonLayerKey: null,
+
+        /**
+         * Style of the editing cursor, before first point is set.
+         */
+        drawBeforeEditingPoint: new ol.style.Style({
+            image: new ol.style.Circle({
+                radius: 5,
+                fill: new ol.style.Fill({
+                    color: 'black'
+                })
+            })
+        }),
+
+        /**
+         * Style of the first point of the drawn line.
+         */
+        drawStyleStartPoint: new ol.style.Style({
+            image: new ol.style.RegularShape({
+                fill: new ol.style.Fill({
+                    color: 'green'
+                }),
+                stroke: new ol.style.Stroke({
+                    color: 'green',
+                    width: 3
+                }),
+                points: 3,
+                radius: 5,
+                rotation: 0,
+                angle: 0,
+            })
+        }),
+
+        /**
+         * Style of the last point of the currently drawn line.
+         */
+        drawStyleEndPoint: new ol.style.Style({
+            image: new ol.style.RegularShape({
+                fill: new ol.style.Fill({
+                    color: 'red'
+                }),
+                stroke: new ol.style.Stroke({
+                    color: 'red',
+                    width: 3
+                }),
+                points: 4,
+                radius: 5,
+                angle: Math.PI / 4,
+            })
+        }),
+
+        /**
+         * The style of the point to modify.
+         */
+        modifySnapPointStyle: new ol.style.Style({
+            image: new ol.style.RegularShape({
+                fill: new ol.style.Fill({
+                    color: 'yellow'
+                }),
+                stroke: new ol.style.Stroke({
+                    color: 'black',
+                    width: 3
+                }),
+                points: 4,
+                radius: 10,
+                angle: Math.PI / 4,
+            })
+        }),
+
+        /**
+         * The style of the line to draw (without start and endpoint)
+         */
+        drawStyleLine: new ol.style.Style({
+            stroke: new ol.style.Stroke({
+                color: 'orange',
+                width: 2
+            })
+        }),
+
+        /**
+         * The style of the point when snapped to the referenced
+         * node layer.
+         */
+        snappedNodeStyle: new ol.style.Style({
+            image: new ol.style.RegularShape({
+                fill: new ol.style.Fill({
+                    color: 'black'
+                }),
+                stroke: new ol.style.Stroke({
+                    color: 'black',
+                    width: 3
+                }),
+                points: 4,
+                radius: 10,
+                radius2: 0,
+                angle: 0,
+            })
+        }),
+
+        /**
+         * The style of the point when snapped to the referenced
+         * edge layer.
+         */
+        snappedEdgeStyle: new ol.style.Style({
+            image: new ol.style.RegularShape({
+                fill: new ol.style.Fill({
+                    color: 'black'
+                }),
+                stroke: new ol.style.Stroke({
+                    color: 'black',
+                    width: 3
+                }),
+                points: 4,
+                radius: 10,
+                radius2: 0,
+                angle: Math.PI / 4
+            })
+        })
     },
 
     /**

--- a/app/view/button/DrawingButton.js
+++ b/app/view/button/DrawingButton.js
@@ -63,6 +63,11 @@ Ext.define('CpsiMapview.view.tool.DrawingButton', {
         polygonLayerKey: null,
 
         /**
+         * If the vertices of the snapped edge shall be shown.
+         */
+        showVerticesOfSnappedEdge: true,
+
+        /**
          * Style of the editing cursor, before first point is set.
          */
         drawBeforeEditingPoint: new ol.style.Style({

--- a/app/view/button/DrawingButton.js
+++ b/app/view/button/DrawingButton.js
@@ -177,6 +177,22 @@ Ext.define('CpsiMapview.view.tool.DrawingButton', {
                 radius2: 0,
                 angle: Math.PI / 4
             })
+        }),
+
+        /**
+         * The style snapped edge's vertices.
+         */
+        snappedEdgeVertexStyle: new ol.style.Style({
+            image: new ol.style.Circle({
+                radius: 3,
+                fill: new ol.style.Fill({
+                    color: 'white',
+                }),
+                stroke: new ol.style.Stroke({
+                    color: 'black',
+                    width: 1
+                }),
+            })
         })
     },
 

--- a/app/view/button/DrawingButton.js
+++ b/app/view/button/DrawingButton.js
@@ -105,6 +105,12 @@ Ext.define('CpsiMapview.view.tool.DrawingButton', {
         snappedEdgeStyle: CpsiMapview.util.Style.createBlackRotatedCross(),
 
         /**
+         * The style of the point when snapped to the referenced
+         * polygon layer.
+         */
+        snappedPolygonStyle: CpsiMapview.util.Style.createBlackStar(),
+
+        /**
          * The style of the snapped edge's vertices.
          */
         snappedEdgeVertexStyle: CpsiMapview.util.Style.createWhiteCircle()

--- a/app/view/button/DrawingButton.js
+++ b/app/view/button/DrawingButton.js
@@ -70,140 +70,44 @@ Ext.define('CpsiMapview.view.tool.DrawingButton', {
         /**
          * Style of the editing cursor, before first point is set.
          */
-        drawBeforeEditingPoint: new ol.style.Style({
-            image: new ol.style.Circle({
-                radius: 5,
-                fill: new ol.style.Fill({
-                    color: 'black'
-                })
-            })
-        }),
+        drawBeforeEditingPoint: CpsiMapview.util.Style.blackCircle,
 
         /**
          * Style of the first point of the drawn line.
          */
-        drawStyleStartPoint: new ol.style.Style({
-            // triangle
-            image: new ol.style.RegularShape({
-                fill: new ol.style.Fill({
-                    color: 'green'
-                }),
-                stroke: new ol.style.Stroke({
-                    color: 'green',
-                    width: 3
-                }),
-                points: 3,
-                radius: 5,
-                rotation: 0,
-                angle: 0,
-            })
-        }),
+        drawStyleStartPoint: CpsiMapview.util.Style.greenTriangle,
 
         /**
          * Style of the last point of the currently drawn line.
          */
-        drawStyleEndPoint: new ol.style.Style({
-            // square
-            image: new ol.style.RegularShape({
-                fill: new ol.style.Fill({
-                    color: 'red'
-                }),
-                stroke: new ol.style.Stroke({
-                    color: 'red',
-                    width: 3
-                }),
-                points: 4,
-                radius: 5,
-                angle: Math.PI / 4,
-            })
-        }),
+        drawStyleEndPoint: CpsiMapview.util.Style.redSquare,
 
         /**
          * The style of the point to modify.
          */
-        modifySnapPointStyle: new ol.style.Style({
-            // square
-            image: new ol.style.RegularShape({
-                fill: new ol.style.Fill({
-                    color: 'yellow'
-                }),
-                stroke: new ol.style.Stroke({
-                    color: 'black',
-                    width: 3
-                }),
-                points: 4,
-                radius: 10,
-                angle: Math.PI / 4,
-            })
-        }),
+        modifySnapPointStyle: CpsiMapview.util.Style.yellowSquare,
 
         /**
          * The style of the line to draw (without start and endpoint)
          */
-        drawStyleLine: new ol.style.Style({
-            stroke: new ol.style.Stroke({
-                color: 'orange',
-                width: 2
-            })
-        }),
+        drawStyleLine: CpsiMapview.util.Style.orangeLine,
 
         /**
          * The style of the point when snapped to the referenced
          * node layer.
          */
-        snappedNodeStyle: new ol.style.Style({
-            // cross
-            image: new ol.style.RegularShape({
-                fill: new ol.style.Fill({
-                    color: 'black'
-                }),
-                stroke: new ol.style.Stroke({
-                    color: 'black',
-                    width: 3
-                }),
-                points: 4,
-                radius: 10,
-                radius2: 0,
-                angle: 0,
-            })
-        }),
+        snappedNodeStyle: CpsiMapview.util.Style.blackCross,
 
         /**
          * The style of the point when snapped to the referenced
          * edge layer.
          */
-        snappedEdgeStyle: new ol.style.Style({
-            // cross (45° rotation)
-            image: new ol.style.RegularShape({
-                fill: new ol.style.Fill({
-                    color: 'black'
-                }),
-                stroke: new ol.style.Stroke({
-                    color: 'black',
-                    width: 3
-                }),
-                points: 4,
-                radius: 10,
-                radius2: 0,
-                angle: Math.PI / 4
-            })
-        }),
+        snappedEdgeStyle: CpsiMapview.util.Style.blackRotatedCross,
 
         /**
          * The style of the snapped edge's vertices.
          */
-        snappedEdgeVertexStyle: new ol.style.Style({
-            image: new ol.style.Circle({
-                radius: 3,
-                fill: new ol.style.Fill({
-                    color: 'white',
-                }),
-                stroke: new ol.style.Stroke({
-                    color: 'black',
-                    width: 1
-                }),
-            })
-        })
+        snappedEdgeVertexStyle: CpsiMapview.util.Style.whiteCircle
     },
 
     /**

--- a/app/view/button/DrawingButton.js
+++ b/app/view/button/DrawingButton.js
@@ -78,6 +78,7 @@ Ext.define('CpsiMapview.view.tool.DrawingButton', {
          * Style of the first point of the drawn line.
          */
         drawStyleStartPoint: new ol.style.Style({
+            // triangle
             image: new ol.style.RegularShape({
                 fill: new ol.style.Fill({
                     color: 'green'
@@ -97,6 +98,7 @@ Ext.define('CpsiMapview.view.tool.DrawingButton', {
          * Style of the last point of the currently drawn line.
          */
         drawStyleEndPoint: new ol.style.Style({
+            // square
             image: new ol.style.RegularShape({
                 fill: new ol.style.Fill({
                     color: 'red'
@@ -115,6 +117,7 @@ Ext.define('CpsiMapview.view.tool.DrawingButton', {
          * The style of the point to modify.
          */
         modifySnapPointStyle: new ol.style.Style({
+            // square
             image: new ol.style.RegularShape({
                 fill: new ol.style.Fill({
                     color: 'yellow'
@@ -144,6 +147,7 @@ Ext.define('CpsiMapview.view.tool.DrawingButton', {
          * node layer.
          */
         snappedNodeStyle: new ol.style.Style({
+            // cross
             image: new ol.style.RegularShape({
                 fill: new ol.style.Fill({
                     color: 'black'
@@ -164,6 +168,7 @@ Ext.define('CpsiMapview.view.tool.DrawingButton', {
          * edge layer.
          */
         snappedEdgeStyle: new ol.style.Style({
+            // cross (45° rotation)
             image: new ol.style.RegularShape({
                 fill: new ol.style.Fill({
                     color: 'black'

--- a/app/view/button/DrawingButton.js
+++ b/app/view/button/DrawingButton.js
@@ -190,7 +190,7 @@ Ext.define('CpsiMapview.view.tool.DrawingButton', {
         }),
 
         /**
-         * The style snapped edge's vertices.
+         * The style of the snapped edge's vertices.
          */
         snappedEdgeVertexStyle: new ol.style.Style({
             image: new ol.style.Circle({

--- a/app/view/button/DrawingButton.js
+++ b/app/view/button/DrawingButton.js
@@ -70,44 +70,44 @@ Ext.define('CpsiMapview.view.tool.DrawingButton', {
         /**
          * Style of the editing cursor, before first point is set.
          */
-        drawBeforeEditingPoint: CpsiMapview.util.Style.blackCircle,
+        drawBeforeEditingPoint: CpsiMapview.util.Style.createBlackCircle(),
 
         /**
          * Style of the first point of the drawn line.
          */
-        drawStyleStartPoint: CpsiMapview.util.Style.greenTriangle,
+        drawStyleStartPoint: CpsiMapview.util.Style.createGreenTriangle(),
 
         /**
          * Style of the last point of the currently drawn line.
          */
-        drawStyleEndPoint: CpsiMapview.util.Style.redSquare,
+        drawStyleEndPoint: CpsiMapview.util.Style.createRedSquare(),
 
         /**
          * The style of the point to modify.
          */
-        modifySnapPointStyle: CpsiMapview.util.Style.yellowSquare,
+        modifySnapPointStyle: CpsiMapview.util.Style.createYellowSquare(),
 
         /**
          * The style of the line to draw (without start and endpoint)
          */
-        drawStyleLine: CpsiMapview.util.Style.orangeLine,
+        drawStyleLine: CpsiMapview.util.Style.createOrangeLine(),
 
         /**
          * The style of the point when snapped to the referenced
          * node layer.
          */
-        snappedNodeStyle: CpsiMapview.util.Style.blackCross,
+        snappedNodeStyle: CpsiMapview.util.Style.createBlackCross(),
 
         /**
          * The style of the point when snapped to the referenced
          * edge layer.
          */
-        snappedEdgeStyle: CpsiMapview.util.Style.blackRotatedCross,
+        snappedEdgeStyle: CpsiMapview.util.Style.createBlackRotatedCross(),
 
         /**
          * The style of the snapped edge's vertices.
          */
-        snappedEdgeVertexStyle: CpsiMapview.util.Style.whiteCircle
+        snappedEdgeVertexStyle: CpsiMapview.util.Style.createWhiteCircle()
     },
 
     /**

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -199,7 +199,7 @@
     {
       "layerType": "switchlayer",
       "layerKey": "WATERBODY_SWITCH_LAYER",
-      "visibility": true,
+      "visibility": false,
       "layers": [
         {
           "layerType": "wms",
@@ -252,7 +252,7 @@
     {
       "layerType": "switchlayer",
       "layerKey": "BOREHOLE_SWITCH_LAYER",
-      "visibility": true,
+      "visibility": false,
       "layers": [
         {
           "layerType": "wms",
@@ -384,7 +384,7 @@
       "noCluster": true,
       "idProperty": "NodeId",
       "openLayers": {
-        "visibility": false,
+        "visibility": true,
         "maxScale": 800000
       }
     },
@@ -411,7 +411,7 @@
       "sldUrl": "resources/data/styling/ruins.xml",
       "idProperty": "osm_id",
       "openLayers": {
-        "visibility": true,
+        "visibility": false,
         "maxScale": 800000
       },
       "tooltipsConfig": [
@@ -459,7 +459,7 @@
       },
       "openLayers": {
         "opacity": 0.7,
-        "visibility": true
+        "visibility": false
       }
     }
   ]

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -362,7 +362,7 @@
       "noCluster": true,
       "idProperty": "EdgeId",
       "openLayers": {
-        "visibility": false,
+        "visibility": true,
         "maxScale": 800000
       }
     },


### PR DESCRIPTION
- references #564 
- snapped node or edges are highlighted
- provides various configurable styles for editing
- todo: 
  - [x] handle polygons

## snapping

![Peek 2022-07-27 18-55](https://user-images.githubusercontent.com/15704517/181305357-0eb63d86-0945-4506-ab9d-2696c13bd548.gif)

## highlight vertices of snapped line

![Peek 2022-07-28 10-25](https://user-images.githubusercontent.com/15704517/181458542-c5320424-2dee-4b52-9767-0f8a3779bcb9.gif)


