### PR TITLE
Add polygon example layer to snapping tool example

### DIFF
--- a/app/view/snappingExample/EdgeButton.js
+++ b/app/view/snappingExample/EdgeButton.js
@@ -40,6 +40,18 @@ Ext.define('CpsiMapview.view.snappingExample.EdgeModel', {
             defaultValue: null
         },
         {
+            name: 'startPolygonId',
+            type: 'int',
+            allowNull: true,
+            defaultValue: null
+        },
+        {
+            name: 'endPolygonId',
+            type: 'int',
+            allowNull: true,
+            defaultValue: null
+        },
+        {
             name: 'startCoord',
             type: 'auto',
             allowNull: true,

--- a/app/view/snappingExample/EdgeWindow.js
+++ b/app/view/snappingExample/EdgeWindow.js
@@ -132,37 +132,37 @@ Ext.define('CpsiMapview.view.snappingExample.EdgeWindow', {
                                     value: '{currentRecord.endEdgeId}'
                                 }
                             }
-                            },
-                            {
-                                xtype: 'cmv_rightinfofield',
-                                colspan: 1,
-                                width: 300,
-                                field: {
-                                    xtype: 'displayfield',
-                                    labelWidth: 100,
-                                    width: 200,
-                                    fieldLabel: 'Start Polygon ID',
-                                    infoIconTooltip: 'Database Identifier',
-                                    bind: {
-                                        value: '{currentRecord.startPolygonId}'
-                                    }
+                        },
+                        {
+                            xtype: 'cmv_rightinfofield',
+                            colspan: 1,
+                            width: 300,
+                            field: {
+                                xtype: 'displayfield',
+                                labelWidth: 100,
+                                width: 200,
+                                fieldLabel: 'Start Polygon ID',
+                                infoIconTooltip: 'Database Identifier',
+                                bind: {
+                                    value: '{currentRecord.startPolygonId}'
                                 }
-                            },
-                            {
-                                xtype: 'cmv_rightinfofield',
-                                colspan: 1,
-                                width: 300,
-                                field: {
-                                    xtype: 'displayfield',
-                                    labelWidth: 100,
-                                    width: 200,
-                                    fieldLabel: 'End Polygon ID',
-                                    infoIconTooltip: 'Database Identifier',
-                                    bind: {
-                                        value: '{currentRecord.endPolygonId}'
-                                    }
+                            }
+                        },
+                        {
+                            xtype: 'cmv_rightinfofield',
+                            colspan: 1,
+                            width: 300,
+                            field: {
+                                xtype: 'displayfield',
+                                labelWidth: 100,
+                                width: 200,
+                                fieldLabel: 'End Polygon ID',
+                                infoIconTooltip: 'Database Identifier',
+                                bind: {
+                                    value: '{currentRecord.endPolygonId}'
                                 }
-                            },
+                            }
+                        },
                         {
                             xtype: 'displayfield',
                             colspan: 2,

--- a/app/view/snappingExample/EdgeWindow.js
+++ b/app/view/snappingExample/EdgeWindow.js
@@ -1,4 +1,4 @@
-﻿Ext.define('CpsiMapview.view.snappingExample.EdgeWindow', {
+Ext.define('CpsiMapview.view.snappingExample.EdgeWindow', {
     extend: 'CpsiMapview.view.window.MinimizableWindow',
     xtype: ['cmv_edgewindow'],
     requires: [
@@ -42,9 +42,10 @@
                 bind: {
                     drawLayer: '{resultLayer}' // bind the draw layer to the model's featurestore / layer
                 },
-                snappingLayerKeys: ['EDGES_WFS', 'NODES_WFS'],
+                snappingLayerKeys: ['EDGES_WFS', 'NODES_WFS', 'POLYGONS_WFS'],
                 nodeLayerKey: 'NODES_WFS',
-                edgeLayerKey: 'EDGES_WFS'
+                edgeLayerKey: 'EDGES_WFS',
+                polygonLayerKey: 'POLYGONS_WFS'
             }
         }
     ],
@@ -131,7 +132,37 @@
                                     value: '{currentRecord.endEdgeId}'
                                 }
                             }
-                        },
+                            },
+                            {
+                                xtype: 'cmv_rightinfofield',
+                                colspan: 1,
+                                width: 300,
+                                field: {
+                                    xtype: 'displayfield',
+                                    labelWidth: 100,
+                                    width: 200,
+                                    fieldLabel: 'Start Polygon ID',
+                                    infoIconTooltip: 'Database Identifier',
+                                    bind: {
+                                        value: '{currentRecord.startPolygonId}'
+                                    }
+                                }
+                            },
+                            {
+                                xtype: 'cmv_rightinfofield',
+                                colspan: 1,
+                                width: 300,
+                                field: {
+                                    xtype: 'displayfield',
+                                    labelWidth: 100,
+                                    width: 200,
+                                    fieldLabel: 'End Polygon ID',
+                                    infoIconTooltip: 'Database Identifier',
+                                    bind: {
+                                        value: '{currentRecord.endPolygonId}'
+                                    }
+                                }
+                            },
                         {
                             xtype: 'displayfield',
                             colspan: 2,

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -357,6 +357,17 @@
     },
     {
       "layerType": "wfs",
+      "layerKey": "POLYGONS_WFS",
+      "featureType": "polygons",
+      "noCluster": true,
+      "idProperty": "PolygonId",
+      "openLayers": {
+        "visibility": true,
+        "maxScale": 800000
+      }
+    },
+    {
+      "layerType": "wfs",
       "layerKey": "EDGES_WFS",
       "featureType": "edges",
       "noCluster": true,

--- a/resources/data/layers/tree.json
+++ b/resources/data/layers/tree.json
@@ -35,6 +35,12 @@
             "qtip": "Used in the snapping tool example"
           },
           {
+            "id": "POLYGONS_WFS",
+            "leaf": true,
+            "text": "Polygons",
+            "qtip": "Used in the snapping tool example"
+          },
+          {
             "id": "BOREHOLE_WMS",
             "leaf": true,
             "text": "Borehole WMS"


### PR DESCRIPTION
Relies on the test dataset in https://github.com/compassinformatics/mapview-demo/pull/6

Adds a new polygon layer for snapping and retrieving IDs.

![image](https://user-images.githubusercontent.com/490840/181713678-3ce891ef-115a-4127-9589-be8c102b02b3.png)

