### PR TITLE
Add filter to layer tree

### DIFF
--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -142,7 +142,10 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
             // create a new LayerStore from the grouped layers
             var groupedLayerTreeStore = Ext.create('GeoExt.data.store.LayersTree', {
                 model: 'CpsiMapview.data.model.LayerTreeNode',
-                layerGroup: rootLayerGroup
+                layerGroup: rootLayerGroup,
+                // filters are applied from bottom to top
+                // necessary for filtering empty layer groups
+                filterer: 'bottomup'
             });
             me.getView().setStore(groupedLayerTreeStore);
 

--- a/app/form/LayerTreeFilter.js
+++ b/app/form/LayerTreeFilter.js
@@ -37,25 +37,24 @@ Ext.define('CpsiMapview.controller.form.LayerTreeFilter', {
         var filter = Ext.util.Filter({
             id: view.FILTER_ID,
             filterFn: function(node) {
-                if (vm.get('searchText')) {
-                    var isMatch = LayerTreeFilterUtil.isSearchTextInLayerName(node, vm.get('searchText'), filterBaseLayers);
-                    if (!isMatch) {
-                        return false;
+                var isLeaf = !node.hasChildNodes();
+                if (isLeaf) {
+                    if (vm.get('hideInvisibleLayers')) {
+                        var isVisible = LayerTreeFilterUtil.isLayerVisible(node, filterBaseLayers);
+                        if (!isVisible) {
+                            return false;
+                        }
                     }
-                }
-                if (vm.get('hideInvisibleLayers')) {
-                    var isVisible = LayerTreeFilterUtil.isLayerVisible(node, filterBaseLayers);
-                    if (!isVisible) {
-                        return false;
+                    if (vm.get('searchText')) {
+                        var isMatch = LayerTreeFilterUtil.isSearchTextInLayerName(node, vm.get('searchText'), filterBaseLayers);
+                        if (!isMatch) {
+                            return false;
+                        }
                     }
+                    return true;
+                } else {
+                    return false;
                 }
-                if (view.hideGroupsWithNoVisibleLayer) {
-                    var keepGroup = LayerTreeFilterUtil.groupHasVisibleLayer(node);
-                    if (!keepGroup) {
-                        return false;
-                    }
-                }
-                return true;
             }
         });
         store.addFilter(filter);
@@ -76,9 +75,6 @@ Ext.define('CpsiMapview.controller.form.LayerTreeFilter', {
             return;
         }
         vm.set('searchText', searchText);
-        // Making sure we work on the latest state,
-        // when updating the filter.
-        vm.notify();
         ctrl.updateFilter();
     },
 
@@ -97,9 +93,6 @@ Ext.define('CpsiMapview.controller.form.LayerTreeFilter', {
             return;
         }
         vm.set('hideInvisibleLayers', checked);
-        // Making sure we work on the latest state,
-        // when updating the filter.
-        vm.notify();
         ctrl.updateFilter();
     }
 });

--- a/app/form/LayerTreeFilter.js
+++ b/app/form/LayerTreeFilter.js
@@ -1,0 +1,103 @@
+/**
+ * This is the controller for the {@link CpsiMapview.view.form.LayerTreeFilter} component
+ *
+ * @class CpsiMapview.controller.form.LayerTreeFilter
+ */
+Ext.define('CpsiMapview.controller.form.LayerTreeFilter', {
+    extend: 'Ext.app.ViewController',
+
+    alias: 'controller.cmv_layertreefilter',
+
+    /**
+     * Filters the tree by matching the layer's names with the input text.
+     *
+     * @param {Ext.form.field.Text} textField The textfield
+     * @param {String} newVal The new value
+     */
+    onSearch: function (textField, newVal) {
+        var me = this;
+        var view = me.getView();
+
+        // show/hide clear trigger button
+        if (textField.getValue()) {
+            textField.setHideTrigger(false);
+        } else {
+            textField.setHideTrigger(true);
+        }
+
+        var tree = Ext.ComponentQuery.query('cmv_layertree')[0];
+        if (!tree){
+            return;
+        }
+        var store = tree.getStore();
+        if(!store){
+            return;
+        }
+
+        // remove previous filter if exists
+        store.removeFilter(view.TEXT_FILTER_ID);
+
+        var textFilter = new Ext.util.Filter({
+            id: view.TEXT_FILTER_ID,
+            filterFn: function (node) {
+                // always show group layers
+                if (node.hasChildNodes()) {
+                    return true;
+                }
+                // check if baselayers should be filtered
+                if (!view.getDoFilterBaseLayers() && node.getOlLayerProp('isBaseLayer')){
+                    return true;
+                }
+                // prevent case sensitive matches
+                var name = node.getOlLayerProp('name');
+                if (!name) {
+                    return;
+                }
+                var text = name.toLowerCase();
+                var compare = newVal.toLowerCase();
+                return text.includes(compare);
+            }
+        });
+        store.addFilter(textFilter);
+    },
+
+    /**
+     * Filters the tree by checking the visibility of the layers.
+     *
+     * @param {Ext.form.field.Field} checkBox The checkbox
+     * @param {Boolean} showOnlyVisible If only visible layers should be shown in the tree
+     */
+    filterVisibleLayers: function (checkBox, showOnlyVisible) {
+        var me = this;
+        var view = me.getView();
+
+        var tree = Ext.ComponentQuery.query('cmv_layertree')[0];
+        if (!tree) {
+            return;
+        }
+        var store = tree.getStore();
+        if (!store) {
+            return;
+        }
+        if (showOnlyVisible) {
+            var visibleLayerFilter = new Ext.util.Filter({
+                id: view.VISIBLE_LAYER_FILTER_ID,
+                filterFn: function (node) {
+                    if (node.hasChildNodes()) {
+                        return true;
+                    }
+                    // check if baselayers should be filtered
+                    if (!view.getDoFilterBaseLayers() && node.getOlLayerProp('isBaseLayer')){
+                        return true;
+                    }
+                    var checked = node.get('checked');
+                    return checked;
+                }
+            });
+
+            store.addFilter(visibleLayerFilter);
+        } else {
+            store.removeFilter(view.VISIBLE_LAYER_FILTER_ID);
+        }
+    }
+});

--- a/app/form/LayerTreeFilter.js
+++ b/app/form/LayerTreeFilter.js
@@ -48,11 +48,11 @@ Ext.define('CpsiMapview.controller.form.LayerTreeFilter', {
                 if (!view.getDoFilterBaseLayers() && node.getOlLayerProp('isBaseLayer')){
                     return true;
                 }
-                // enforce case insensitive matches
-                var name = node.getOlLayerProp('name');
+                var name = node.get('text');
                 if (!name) {
                     return;
                 }
+                // enforce case insensitive matches
                 var text = name.toLowerCase();
                 var compare = newVal.toLowerCase();
                 return text.includes(compare);

--- a/app/form/LayerTreeFilter.js
+++ b/app/form/LayerTreeFilter.js
@@ -48,7 +48,7 @@ Ext.define('CpsiMapview.controller.form.LayerTreeFilter', {
                 if (!view.getDoFilterBaseLayers() && node.getOlLayerProp('isBaseLayer')){
                     return true;
                 }
-                // prevent case sensitive matches
+                // enforce case insensitive matches
                 var name = node.getOlLayerProp('name');
                 if (!name) {
                     return;

--- a/app/form/LayerTreeFilter.js
+++ b/app/form/LayerTreeFilter.js
@@ -76,6 +76,9 @@ Ext.define('CpsiMapview.controller.form.LayerTreeFilter', {
             return;
         }
         vm.set('searchText', searchText);
+        // Making sure we work on the latest state,
+        // when updating the filter.
+        vm.notify();
         ctrl.updateFilter();
     },
 
@@ -94,6 +97,9 @@ Ext.define('CpsiMapview.controller.form.LayerTreeFilter', {
             return;
         }
         vm.set('hideInvisibleLayers', checked);
+        // Making sure we work on the latest state,
+        // when updating the filter.
+        vm.notify();
         ctrl.updateFilter();
     }
 });

--- a/app/form/LayerTreeFilter.js
+++ b/app/form/LayerTreeFilter.js
@@ -9,6 +9,30 @@ Ext.define('CpsiMapview.controller.form.LayerTreeFilter', {
     alias: 'controller.cmv_layertreefilter',
 
     /**
+     * Clears the textfield for filtering the layer tree.
+     *
+     * @param {Ext.form.field.Text } textField
+     */
+    clearText: function (textField) {
+        var me = this;
+        var view = me.getView();
+
+        textField.setValue('');
+
+        var tree = Ext.ComponentQuery.query('cmv_layertree')[0];
+        if (!tree) {
+            return;
+        }
+        var store = tree.getStore();
+        if (!store) {
+            return;
+        }
+
+        // remove previous filter if exists
+        store.removeFilter(view.TEXT_FILTER_ID);
+    },
+
+    /**
      * Filters the tree by matching the layer's names with the input text.
      *
      * @param {Ext.form.field.Text} textField The textfield
@@ -26,15 +50,14 @@ Ext.define('CpsiMapview.controller.form.LayerTreeFilter', {
         }
 
         var tree = Ext.ComponentQuery.query('cmv_layertree')[0];
-        if (!tree){
+        if (!tree) {
             return;
         }
         var store = tree.getStore();
-        if(!store){
+        if (!store) {
             return;
         }
 
-        // remove previous filter if exists
         store.removeFilter(view.TEXT_FILTER_ID);
 
         var textFilter = new Ext.util.Filter({
@@ -45,7 +68,7 @@ Ext.define('CpsiMapview.controller.form.LayerTreeFilter', {
                     return true;
                 }
                 // check if baselayers should be filtered
-                if (!view.getDoFilterBaseLayers() && node.getOlLayerProp('isBaseLayer')){
+                if (!view.getDoFilterBaseLayers() && node.getOlLayerProp('isBaseLayer')) {
                     return true;
                 }
                 var name = node.get('text');
@@ -87,7 +110,7 @@ Ext.define('CpsiMapview.controller.form.LayerTreeFilter', {
                         return true;
                     }
                     // check if baselayers should be filtered
-                    if (!view.getDoFilterBaseLayers() && node.getOlLayerProp('isBaseLayer')){
+                    if (!view.getDoFilterBaseLayers() && node.getOlLayerProp('isBaseLayer')) {
                         return true;
                     }
                     var checked = node.get('checked');

--- a/app/form/LayerTreeFilter.js
+++ b/app/form/LayerTreeFilter.js
@@ -22,7 +22,6 @@ Ext.define('CpsiMapview.controller.form.LayerTreeFilter', {
         var view = me.getView();
         var vm = view.getViewModel();
         var LayerTreeFilterUtil = CpsiMapview.util.LayerTreeFilter;
-        var filterBaseLayers = view.getDoFilterBaseLayers();
 
         var tree = Ext.ComponentQuery.query('cmv_layertree')[0];
         if (!tree) {
@@ -34,29 +33,12 @@ Ext.define('CpsiMapview.controller.form.LayerTreeFilter', {
         }
 
         store.removeFilter(view.FILTER_ID);
-        var filter = Ext.util.Filter({
-            id: view.FILTER_ID,
-            filterFn: function(node) {
-                var isLeaf = !node.hasChildNodes();
-                if (isLeaf) {
-                    if (vm.get('hideInvisibleLayers')) {
-                        var isVisible = LayerTreeFilterUtil.isLayerVisible(node, filterBaseLayers);
-                        if (!isVisible) {
-                            return false;
-                        }
-                    }
-                    if (vm.get('searchText')) {
-                        var isMatch = LayerTreeFilterUtil.isSearchTextInLayerName(node, vm.get('searchText'), filterBaseLayers);
-                        if (!isMatch) {
-                            return false;
-                        }
-                    }
-                    return true;
-                } else {
-                    return false;
-                }
-            }
-        });
+        var filter = LayerTreeFilterUtil.createLayerTreeFilter(
+            view.FILTER_ID,
+            vm.get('hideInvisibleLayers'),
+            vm.get('searchText'),
+            view.getDoFilterBaseLayers()
+        );
         store.addFilter(filter);
     },
 

--- a/app/util/LayerTreeFilter.js
+++ b/app/util/LayerTreeFilter.js
@@ -7,26 +7,6 @@ Ext.define('CpsiMapview.util.LayerTreeFilter', {
     alternateClassName: 'LayerTreeFilterUtil',
 
     statics: {
-        /**
-         * Checks if a group has at least one visible layer.
-         *
-         * @param {GeoExt.data.model.LayerTreeNode} node The node to check.
-         * @return {boolean} True, if group has visible layer. False otherwise.
-         */
-        groupHasVisibleLayer: function(node) {
-            if (node.hasChildNodes()) {
-                var hasVisibleLayer = false;
-                node.cascade(function (cascadeNode) {
-                    // search for any descending node that is checked
-                    if (!cascadeNode.hasChildNodes() && cascadeNode.get('checked')) {
-                        hasVisibleLayer = true;
-                    }
-                });
-                return hasVisibleLayer;
-            } else {
-                return true;
-            }
-        },
 
         /**
          * Checks if layer is visible.

--- a/app/util/LayerTreeFilter.js
+++ b/app/util/LayerTreeFilter.js
@@ -6,6 +6,10 @@
 Ext.define('CpsiMapview.util.LayerTreeFilter', {
     alternateClassName: 'LayerTreeFilterUtil',
 
+    requires: [
+        'Ext.util.Filter'
+    ],
+
     statics: {
 
         /**
@@ -16,9 +20,6 @@ Ext.define('CpsiMapview.util.LayerTreeFilter', {
          * @return {boolean} True, if layer is visible. False otherwise.
          */
         isLayerVisible: function(node, filterBaseLayers) {
-            if (node.hasChildNodes()) {
-                return true;
-            }
             // check if baselayers should be filtered
             if (!filterBaseLayers && node.getOlLayerProp('isBaseLayer')) {
                 return true;
@@ -36,10 +37,6 @@ Ext.define('CpsiMapview.util.LayerTreeFilter', {
          * @return {boolean} True, if search text was found in layer name. False otherwise.
          */
         isSearchTextInLayerName: function(node, searchText, filterBaseLayers) {
-            // always show group layers
-            if (node.hasChildNodes()) {
-                return true;
-            }
             // check if baselayers should be filtered
             if (!filterBaseLayers && node.getOlLayerProp('isBaseLayer')) {
                 return true;
@@ -52,6 +49,44 @@ Ext.define('CpsiMapview.util.LayerTreeFilter', {
             var text = name.toLowerCase();
             var compare = searchText.toLowerCase();
             return text.includes(compare);
+        },
+
+        /**
+         * Creates a filter for the layer tree.
+         *
+         * @param {string} id The id for the filter.
+         * @param {boolean} hideInvisibleLayers True, if invisible layers should be hidden. False otherwise.
+         * @param {string} searchText The search text to filter by.
+         * @param {boolean} filterBaseLayers True, if base layers should be filtered. False otherwise.
+         * @return {Ext.util.Filter} The created filter.
+         */
+        createLayerTreeFilter: function(id, hideInvisibleLayers, searchText, filterBaseLayers) {
+            var staticMe = CpsiMapview.util.LayerTreeFilter;
+            var filter = Ext.util.Filter({
+                id: id,
+                filterFn: function(node) {
+                    var isLeaf = !node.hasChildNodes();
+                    if (isLeaf) {
+                        if (hideInvisibleLayers) {
+                            var isVisible = staticMe.isLayerVisible(node, filterBaseLayers);
+                            if (!isVisible) {
+                                return false;
+                            }
+                        }
+                        if (searchText) {
+                            var isMatch = staticMe.isSearchTextInLayerName(node, searchText, filterBaseLayers);
+                            if (!isMatch) {
+                                return false;
+                            }
+                        }
+                        return true;
+                    } else {
+                        return false;
+                    }
+                }
+            });
+
+            return filter;
         }
     }
 });

--- a/app/util/LayerTreeFilter.js
+++ b/app/util/LayerTreeFilter.js
@@ -1,0 +1,77 @@
+/**
+ * Util class for working with LayerTreeFilter
+ *
+ * @class CpsiMapview.util.LayerTreeFilter
+ */
+Ext.define('CpsiMapview.util.LayerTreeFilter', {
+    alternateClassName: 'LayerTreeFilterUtil',
+
+    statics: {
+        /**
+         * Checks if a group has at least one visible layer.
+         *
+         * @param {GeoExt.data.model.LayerTreeNode} node The node to check.
+         * @return {boolean} True, if group has visible layer. False otherwise.
+         */
+        groupHasVisibleLayer: function(node) {
+            if (node.hasChildNodes()) {
+                var hasVisibleLayer = false;
+                node.cascade(function (cascadeNode) {
+                    // search for any descending node that is checked
+                    if (!cascadeNode.hasChildNodes() && cascadeNode.get('checked')) {
+                        hasVisibleLayer = true;
+                    }
+                });
+                return hasVisibleLayer;
+            } else {
+                return true;
+            }
+        },
+
+        /**
+         * Checks if layer is visible.
+         *
+         * @param {GeoExt.data.model.LayerTreeNode} node The node to check.
+         * @param {boolean} filterBaseLayers True, if baselayers should be filtered. False otherwise.
+         * @return {boolean} True, if layer is visible. False otherwise.
+         */
+        isLayerVisible: function(node, filterBaseLayers) {
+            if (node.hasChildNodes()) {
+                return true;
+            }
+            // check if baselayers should be filtered
+            if (!filterBaseLayers && node.getOlLayerProp('isBaseLayer')) {
+                return true;
+            }
+            var checked = node.get('checked');
+            return checked;
+        },
+
+        /**
+         * Checks if a search text can be found in the layer name.
+         *
+         * @param {GeoExt.data.model.LayerTreeNode} node The node to check.
+         * @param {string} searchText The search text.
+         * @param {boolean} filterBaseLayers True, if baselayers should be filtered. False otherwise.
+         * @return {boolean} True, if search text was found in layer name. False otherwise.
+         */
+        isSearchTextInLayerName: function(node, searchText, filterBaseLayers) {
+            // always show group layers
+            if (node.hasChildNodes()) {
+                return true;
+            }
+            // check if baselayers should be filtered
+            if (!filterBaseLayers && node.getOlLayerProp('isBaseLayer')) {
+                return true;
+            }
+            var name = node.get('text');
+            if (!name) {
+                return;
+            }
+            // enforce case insensitive matches
+            var text = name.toLowerCase();
+            var compare = searchText.toLowerCase();
+            return text.includes(compare);
+        }
+    }
+});

--- a/app/view/form/LayerTreeFilter.js
+++ b/app/view/form/LayerTreeFilter.js
@@ -84,7 +84,7 @@ Ext.define('CpsiMapview.view.form.LayerTreeFilter', {
         });
 
         // we have to add this filter after the store of the layer tree is created.
-        // this needs two steps:
+        // this needs following steps:
         // 1. wait for the event that layers are added to the map
         // 2. get the the layer tree component
         // 3. wait for the event once the layer tree has been initialized

--- a/app/view/form/LayerTreeFilter.js
+++ b/app/view/form/LayerTreeFilter.js
@@ -38,7 +38,7 @@ Ext.define('CpsiMapview.view.form.LayerTreeFilter', {
         anchor: '100%',
         maxWidth: 250,
         triggers: {
-            clearText: {
+            clearTreeFilterText: {
                 cls: 'x-form-clear-trigger',
                 handler: function () {
                     this.setValue('');

--- a/app/view/form/LayerTreeFilter.js
+++ b/app/view/form/LayerTreeFilter.js
@@ -1,0 +1,59 @@
+/**
+ * Panel with filtering tools for the layer tree.
+ *
+ * @class CpsiMapview.view.from.LayerTreeFilter
+ */
+Ext.define('CpsiMapview.view.form.LayerTreeFilter', {
+    extend: 'Ext.form.FieldSet',
+
+    xtype: 'cmv_layertreefilter',
+
+    requires: [
+        'CpsiMapview.controller.form.LayerTreeFilter'
+    ],
+
+    controller: 'cmv_layertreefilter',
+
+    config: {
+        /**
+         * If baselayes shall be filtered by text filter.
+         */
+        doFilterBaseLayers: true
+    },
+
+    /**
+     * The ID of the filter created by the text field.
+     */
+    TEXT_FILTER_ID: 'cpsi-tree-layer-text-filter',
+
+    /**
+     * The ID of the filter created by the checkbox.
+     */
+    VISIBLE_LAYER_FILTER_ID: 'cpsi-tree-visible-layer',
+
+    items: [{
+        xtype: 'textfield',
+        emptyText: 'Search for layers',
+        hideTrigger: true,
+        anchor: '100%',
+        maxWidth: 250,
+        triggers: {
+            clearText: {
+                cls: 'x-form-clear-trigger',
+                handler: function () {
+                    this.setValue('');
+                }
+            }
+        },
+        listeners: {
+            change: 'onSearch'
+        }
+    },
+    {
+        xtype: 'checkboxfield',
+        boxLabel: 'Show Visible',
+        listeners: {
+            change: 'filterVisibleLayers'
+        }
+    }]
+});

--- a/app/view/form/LayerTreeFilter.js
+++ b/app/view/form/LayerTreeFilter.js
@@ -16,7 +16,7 @@ Ext.define('CpsiMapview.view.form.LayerTreeFilter', {
 
     config: {
         /**
-         * If baselayes shall be filtered by text filter.
+         * If baselayers shall be filtered by text filter.
          */
         doFilterBaseLayers: true
     },
@@ -31,6 +31,11 @@ Ext.define('CpsiMapview.view.form.LayerTreeFilter', {
      */
     VISIBLE_LAYER_FILTER_ID: 'cpsi-tree-visible-layer-filter',
 
+    /**
+     * The ID of the filter to hide empty groups.
+     */
+    HIDE_EMPTY_GROUPS_FILTER_ID: 'cpsi-tree-hide-empty-groups',
+
     items: [{
         xtype: 'textfield',
         emptyText: 'Search for layers',
@@ -40,9 +45,7 @@ Ext.define('CpsiMapview.view.form.LayerTreeFilter', {
         triggers: {
             clearTreeFilterText: {
                 cls: 'x-form-clear-trigger',
-                handler: function () {
-                    this.setValue('');
-                }
+                handler: 'clearText'
             }
         },
         listeners: {
@@ -55,5 +58,45 @@ Ext.define('CpsiMapview.view.form.LayerTreeFilter', {
         listeners: {
             change: 'filterVisibleLayers'
         }
-    }]
+    }],
+
+    initComponent: function() {
+        var me = this;
+        me.callParent(arguments);
+
+        var mapPanel = CpsiMapview.view.main.Map.guess();
+
+        mapPanel.on('cmv-init-layersadded', function () {
+            var tree = Ext.ComponentQuery.query('cmv_layertree')[0];
+            if (!tree) {
+                return;
+            }
+
+            tree.on('cmv-init-layertree', function() {
+                var store = tree.getStore();
+                if (!store) {
+                    return;
+                }
+                var emptyGroupFilter = Ext.util.Filter({
+                    id: me.HIDE_EMPTY_GROUPS_FILTER_ID,
+                    filterFn: function (node) {
+                        if (node.hasChildNodes()) {
+                            var keep = false;
+                            node.cascade(function (cascadeNode) {
+                                // search for any descending node that is checked
+                                if (!cascadeNode.hasChildNodes() && cascadeNode.get('checked')) {
+                                    keep = true;
+                                }
+                            });
+                            return keep;
+                        } else {
+                            return true;
+                        }
+                    }
+                });
+
+                store.addFilter(emptyGroupFilter);
+            });
+        });
+    }
 });

--- a/app/view/form/LayerTreeFilter.js
+++ b/app/view/form/LayerTreeFilter.js
@@ -29,7 +29,7 @@ Ext.define('CpsiMapview.view.form.LayerTreeFilter', {
     /**
      * The ID of the filter created by the checkbox.
      */
-    VISIBLE_LAYER_FILTER_ID: 'cpsi-tree-visible-layer',
+    VISIBLE_LAYER_FILTER_ID: 'cpsi-tree-visible-layer-filter',
 
     items: [{
         xtype: 'textfield',

--- a/app/view/main/Main.js
+++ b/app/view/main/Main.js
@@ -17,7 +17,8 @@ Ext.define('CpsiMapview.view.main.Main', {
         'CpsiMapview.view.header.Panel',
         'CpsiMapview.view.LayerTree',
         'CpsiMapview.view.grid.ExampleGrid',
-        'CpsiMapview.view.grid.GridFiltersExample'
+        'CpsiMapview.view.grid.GridFiltersExample',
+        'CpsiMapview.view.form.LayerTreeFilter'
     ],
 
     layout: 'border',
@@ -35,10 +36,15 @@ Ext.define('CpsiMapview.view.main.Main', {
             type: 'vbox',
             align: 'stretch'
         },
-        items: {
-            xtype: 'cmv_layertree',
-            structureMode: 'BASELAYER_OVERLAY'
-        }
+        items: [
+            {
+                xtype: 'cmv_layertreefilter'
+            },
+            {
+                xtype: 'cmv_layertree',
+                structureMode: 'BASELAYER_OVERLAY'
+            }
+        ]
     }, {
         xtype: 'cmv_header'
     }]

--- a/test/spec/util/LayerTreeFilter.spec.js
+++ b/test/spec/util/LayerTreeFilter.spec.js
@@ -1,0 +1,309 @@
+Ext.Loader.syncRequire([
+    'Ext.util.Filter',
+    'Ext.data.TreeStore',
+    'GeoExt.data.store.LayersTree',
+    'CpsiMapview.data.model.LayerTreeNode'
+]);
+
+var createNode = function(opts) {
+    var layerNode = Ext.create(
+        'CpsiMapview.data.model.LayerTreeNode',
+        new ol.layer.Vector({
+            source: new ol.source.Vector(),
+            visible: opts.visible,
+            isBaseLayer: opts.isBaseLayer,
+            name: opts.name
+        })
+    );
+    return layerNode;
+};
+
+describe('CpsiMapview.util.LayerTreeFilter', function() {
+    var layerTreeFilterUtil = CpsiMapview.util.LayerTreeFilter;
+
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(layerTreeFilterUtil).not.to.be(undefined);
+        });
+    });
+
+    describe('#isLayerVisible', function() {
+
+        describe('layer', function() {
+
+            it('returns true, if layer is visible', function() {
+                var layerNode = createNode({visible: true});
+                var isVisible = layerTreeFilterUtil.isLayerVisible(layerNode, true);
+                expect(isVisible).to.be(true);
+            });
+
+            it('returns false, if layer is not visible', function() {
+                var layerNode = createNode({visible: false});
+                var isVisible = layerTreeFilterUtil.isLayerVisible(layerNode, true);
+                expect(isVisible).to.be(false);
+            });
+
+        });
+
+        describe('baseLayer', function() {
+
+            it('always returns true, if baseLayers should not be filtered', function() {
+                var visibleBaseLayer = createNode({visible: true, isBaseLayer: true});
+                var visibleBaseLayerIsVisible = layerTreeFilterUtil.isLayerVisible(
+                    visibleBaseLayer, false);
+                expect(visibleBaseLayerIsVisible).to.be(true);
+
+                var invisibleBaseLayer = createNode({visible: false, isBaseLayer: true});
+                var invisibleBaseLayerIsVisible = layerTreeFilterUtil.isLayerVisible(
+                    invisibleBaseLayer, false);
+                expect(invisibleBaseLayerIsVisible).to.be(true);
+            });
+        });
+    });
+
+    describe('#isSearchTextInLayerName', function() {
+
+        describe('layers', function() {
+
+            it('returns true, if text was found', function() {
+                var searchText = 'foo';
+                var layerName = searchText;
+
+                var layerNode = createNode({name: layerName});
+
+                var result = layerTreeFilterUtil.isSearchTextInLayerName(
+                    layerNode,
+                    searchText,
+                    true
+                );
+
+                expect(result).to.be(true);
+            });
+
+            it('returns true, if layer name contains search text', function() {
+                var searchText = 'foo';
+                var layerName = 'barfoobar';
+
+                var layerNode = createNode({name: layerName});
+
+                var result = layerTreeFilterUtil.isSearchTextInLayerName(
+                    layerNode,
+                    searchText,
+                    true
+                );
+
+                expect(result).to.be(true);
+            });
+
+            it('returns false, if text was not found', function() {
+                var searchText = 'foo';
+                var layerName = 'bar';
+
+                var layerNode = createNode({name: layerName});
+
+                var result = layerTreeFilterUtil.isSearchTextInLayerName(
+                    layerNode,
+                    searchText,
+                    true
+                );
+
+                expect(result).to.be(false);
+            });
+        });
+
+        describe('baseLayers', function() {
+
+            it('always returns true if baseLayers should not be filtered', function() {
+                var searchText = 'foo';
+                var layerName = 'bar';
+
+                var matchingNode = createNode({name: searchText, isBaseLayer: true});
+                var notMatchingNode = createNode({name: layerName, isBaseLayer: true});
+
+                var matchingResult = layerTreeFilterUtil.isSearchTextInLayerName(
+                    matchingNode,
+                    searchText,
+                    false
+                );
+                expect(matchingResult).to.be(true);
+
+                var notMatchingResult = layerTreeFilterUtil.isSearchTextInLayerName(
+                    notMatchingNode,
+                    searchText,
+                    false
+                );
+
+                expect(notMatchingResult).to.be(true);
+            });
+        });
+
+    });
+
+    describe('#createLayerTreeFilter', function() {
+
+        var source;
+        var visibleLayer;
+        var invisibleLayer;
+        var layerGroup;
+        var olMap;
+        var div;
+        var store;
+        var filterId = 'test';
+
+        var findVisibleLayer = function() {
+            var rec = store.findBy(function(rec) {
+                return rec.get('text') === visibleLayer.get('name');
+            });
+            return rec !== -1;
+        };
+
+        var findInvisibleLayer = function() {
+            var rec = store.findBy(function(rec) {
+                return rec.get('text') === invisibleLayer.get('name');
+            });
+            return rec !== -1;
+        };
+
+        var findLayerGroup = function() {
+            var rec = store.findBy(function(rec) {
+                return rec.get('text') === layerGroup.get('name');
+            });
+            return rec !== -1;
+        };
+
+        beforeEach(function() {
+            source = new ol.source.Vector();
+            visibleLayer = new ol.layer.Vector({
+                source: source,
+                visible: true,
+                name: 'foo'
+            });
+            invisibleLayer = new ol.layer.Vector({
+                source: source,
+                visible: false,
+                name: 'bar'
+            });
+            layerGroup = new ol.layer.Group({
+                layers: [],
+                name: 'mygroup'
+            });
+            div = document.createElement('div');
+            div.style.position = 'absolute';
+            div.style.top = '0';
+            div.style.left = '-1000px';
+            div.style.width = '512px';
+            div.style.height = '256px';
+            document.body.appendChild(div);
+
+            olMap = new ol.Map({
+                target: div,
+                layers: [layerGroup],
+                view: new ol.View({
+                    center: [0, 0],
+                    zoom: 2
+                })
+            });
+
+            store = Ext.create('GeoExt.data.store.LayersTree', {
+                layerGroup: olMap.getLayerGroup()
+            });
+            olMap.getLayerGroup().getLayers().insertAt(0, invisibleLayer);
+            olMap.getLayerGroup().getLayers().insertAt(0, visibleLayer);
+
+        });
+
+        afterEach(function() {
+            store.removeFilter(filterId);
+            store.removeAll();
+        });
+
+        it('finds visibleLayer', function() {
+            var foundVisibleLayer = findVisibleLayer();
+            expect(foundVisibleLayer).to.be(true);
+        });
+
+        it('finds invisibleLayer', function() {
+            var foundInvisibleLayer = findInvisibleLayer();
+            expect(foundInvisibleLayer).to.be(true);
+
+        });
+
+        it('finds layerGroup', function() {
+            var foundLayerGroup = findLayerGroup();
+            expect(foundLayerGroup).to.be(true);
+        });
+
+        it('filters by name', function() {
+            var searchText = visibleLayer.get('name');
+
+            var filter = layerTreeFilterUtil.createLayerTreeFilter(
+                filterId,
+                false,
+                searchText,
+                false
+            );
+            store.addFilter(filter);
+
+            var foundVisibleLayer = findVisibleLayer();
+            var foundInvisibleLayer = findInvisibleLayer();
+
+            expect(foundVisibleLayer).to.be(true);
+            expect(foundInvisibleLayer).to.be(false);
+        });
+
+        it('filters by visibility', function() {
+            var hideInvisibleLayers = true;
+
+            var filter = layerTreeFilterUtil.createLayerTreeFilter(
+                filterId,
+                hideInvisibleLayers,
+                '',
+                false
+            );
+            store.addFilter(filter);
+
+            var foundVisibleLayer = findVisibleLayer();
+            var foundInvisibleLayer = findInvisibleLayer();
+
+            expect(foundVisibleLayer).to.be(true);
+            expect(foundInvisibleLayer).to.be(false);
+        });
+
+        it('filters by visibility and name', function() {
+            var hideInvisibleLayers = true;
+            var searchText = invisibleLayer.get('name');
+
+            var filter = layerTreeFilterUtil.createLayerTreeFilter(
+                filterId,
+                hideInvisibleLayers,
+                searchText,
+                false
+            );
+            store.addFilter(filter);
+
+            var foundVisibleLayer = findVisibleLayer();
+            var foundInvisibleLayer = findInvisibleLayer();
+
+            expect(foundVisibleLayer).to.be(false);
+            expect(foundInvisibleLayer).to.be(false);
+        });
+
+        it('removes empty folders', function() {
+            var hideInvisibleLayers = true;
+            var searchText = invisibleLayer.get('name');
+
+            var filter = layerTreeFilterUtil.createLayerTreeFilter(
+                filterId,
+                hideInvisibleLayers,
+                searchText,
+                false
+            );
+            store.addFilter(filter);
+
+            var foundLayerGroup = findLayerGroup();
+            expect(foundLayerGroup).to.be(false);
+        });
+
+    });
+
+});


### PR DESCRIPTION
- fixes #484
- adds textfield for filtering by layer name
- adds checkbox to filter by visible layers
- adds a config if baselayers should be filtered or not (defaults to `true`)

![Peek 2022-07-29 14-28](https://user-images.githubusercontent.com/15704517/181758394-3b186316-03d4-44df-b829-d57803c92752.gif)
 