### PR TITLE
introduces cmv_add_arcgisrest_form

### DIFF
--- a/app.json
+++ b/app.json
@@ -276,6 +276,9 @@
       "path": "node_modules/@ogc-schemas/ogc-schemas/lib/WCS_1_1.js"
     },
     {
+      "path": "node_modules/url-polyfill/url-polyfill.min.js"
+    },
+    {
       "path": "https://maps.googleapis.com/maps/api/js?v=quarterly&key=AIzaSyCmQRf1m6EISENeiijFjza18iIyrIQiArQ",
       "remote": true
     },

--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -428,12 +428,38 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
     },
 
     /**
+     * This reacts on toggling the add arcgisrest Button in the layertree. It shows a window with an AddArcGISRestForm.
+     * @param {Ext.button.Button} button
+     * @param {boolean} pressed
+     */
+    onAddArcGISRestToggle: function (button, pressed) {
+        var me = this;
+
+        if (pressed) {
+            if (!this.addArcGISRestWindow) {
+                this.addArcGISRestWindow = Ext.create(me.getView().addArcGISRestWindowConfig);
+                this.addArcGISRestWindow.on('close', function () {
+                    button.setPressed(false);
+                });
+            }
+            this.addArcGISRestWindow.show();
+
+        } else if (this.addArcGISRestWindow) {
+            this.addArcGISRestWindow.close();
+        }
+    },
+
+    /**
     * Destroy any associated windows when this component gets destroyed
     */
     onBeforeDestroy: function () {
         if (this.addWmsWindow) {
             this.addWmsWindow.destroy();
             this.addWmsWindow = null;
+        }
+        if (this.addArcGISRestWindow) {
+            this.addArcGISRestWindow.destroy();
+            this.addArcGISRestWindow = null;
         }
     }
 });

--- a/app/controller/addArcGISRest/AddArcGISRestFormController.js
+++ b/app/controller/addArcGISRest/AddArcGISRestFormController.js
@@ -1,0 +1,43 @@
+Ext.define('CpsiMapview.controller.addArcGISRest.AddArcGISRestFormController', {
+    extend: 'Ext.app.ViewController',
+
+    requires: [
+        'BasiGX.util.Map'
+    ],
+
+    alias: 'controller.cmv_add_arcgisrest_form',
+
+    onArcGISRestAdd: function (olLayer) {
+        var me = this;
+        var map = BasiGX.util.Map.getMapComponent().getMap();
+
+        if (me.layerGroup === undefined) {
+
+            // create a new layer group to hold the external layers
+            me.layerGroup = new ol.layer.Group({
+                name: me.getView().layerGroupName,
+                collapsed: false
+            });
+
+            // add the external group layer to the layerTreeRoot
+            // so it appears in the layer tree
+            var layerTreeRoot = map.get('layerTreeRoot');
+            layerTreeRoot.getLayers().push(me.layerGroup);
+
+            setTimeout(function () {
+                var layerTrees = Ext.ComponentQuery.query('cmv_layertree');
+                layerTrees.forEach(function (layerTree) {
+                    var node = layerTree.getNodeForLayer(me.layerGroup);
+                    node.expand();
+                });
+            }, 0);
+        }
+
+        olLayer.set('refreshLayerOption', true);
+        olLayer.set('opacitySlider', true);
+
+        // now add the external layer to the external layers group
+        map.removeLayer(olLayer);
+        me.layerGroup.getLayers().push(olLayer);
+    }
+});

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -19,7 +19,8 @@ Ext.define('CpsiMapview.view.LayerTree', {
         'CpsiMapview.plugin.TreeColumnStyleSwitcher',
         'CpsiMapview.controller.LayerTreeController',
         'CpsiMapview.view.window.MinimizableWindow',
-        'CpsiMapview.view.addWms.AddWmsForm'
+        'CpsiMapview.view.addWms.AddWmsForm',
+        'CpsiMapview.view.addArcGISRest.AddArcGISRestForm'
     ],
 
     controller: 'cmv_layertree',
@@ -54,6 +55,19 @@ Ext.define('CpsiMapview.view.LayerTree', {
         },
 
         /**
+        * The window configuration used for the Add ArcGISRest button
+        * Any xtypes used should be added to the requires property
+        */
+        addArcGISRestWindowConfig: {
+            xtype: 'cmv_minimizable_window',
+            title: 'Add ArcGIS Rest Map Layer',
+            closeAction: 'hide',
+            items: [{
+                xtype: 'cmv_add_arcgisrest_form',
+            }]
+        },
+
+        /**
          * Steers if the style switcher radio groups are directly rendered under
          * the corresponding layer tree node (`true`) or if they are provided in
          * the context menu (`false`).
@@ -73,6 +87,13 @@ Ext.define('CpsiMapview.view.LayerTree', {
         enableToggle: true,
         listeners: {
             toggle: 'onAddWmsToggle'
+        }
+    }, {
+        xtype: 'button',
+        text: 'Add ArcGIS Rest Layer',
+        enableToggle: true,
+        listeners: {
+            toggle: 'onAddArcGISRestToggle'
         }
     }],
     columns: {

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -60,10 +60,11 @@ Ext.define('CpsiMapview.view.LayerTree', {
         */
         addArcGISRestWindowConfig: {
             xtype: 'cmv_minimizable_window',
-            title: 'Add ArcGIS Rest Map Layer',
+            title: 'Add ArcGIS REST Map Layer',
+            layout: 'anchor',
             closeAction: 'hide',
             items: [{
-                xtype: 'cmv_add_arcgisrest_form',
+                xtype: 'cmv_add_arcgisrest_form'
             }]
         },
 
@@ -90,7 +91,7 @@ Ext.define('CpsiMapview.view.LayerTree', {
         }
     }, {
         xtype: 'button',
-        text: 'Add ArcGIS Rest Layer',
+        text: 'Add ArcGIS REST Layer',
         enableToggle: true,
         listeners: {
             toggle: 'onAddArcGISRestToggle'

--- a/app/view/addArcGISRest/AddArcGISRestForm.js
+++ b/app/view/addArcGISRest/AddArcGISRestForm.js
@@ -39,5 +39,7 @@ Ext.define('CpsiMapview.view.addArcGISRest.AddArcGISRestForm', {
         arcgisrestadd: 'onArcGISRestAdd'
     },
 
+    bodyPadding: '5px',
+
     layerGroupName: 'External Layers'
 });

--- a/app/view/addArcGISRest/AddArcGISRestForm.js
+++ b/app/view/addArcGISRest/AddArcGISRestForm.js
@@ -1,0 +1,43 @@
+Ext.define('CpsiMapview.view.addArcGISRest.AddArcGISRestForm', {
+    extend: 'BasiGX.view.form.AddArcGISRest',
+
+    xtype: 'cmv_add_arcgisrest_form',
+
+    requires: ['CpsiMapview.controller.addArcGISRest.AddArcGISRestFormController'],
+
+    viewModel: {
+        data: {
+            queryParamsFieldSetTitle: 'Request parameters',
+            arcGISUrlTextFieldLabel: 'ArcGIS Service URL',
+            availableLayesFieldSetTitle: 'Available layers',
+            resetBtnText: 'Reset',
+            requestLayersBtnText: 'Request available layers',
+            checkAllLayersBtnText: 'Check all',
+            uncheckAllLayersBtnText: 'Uncheck all',
+            addCheckedLayersBtnText: 'Add chosen layers',
+            errorRequestFailed: 'The given URL could not be requested.',
+            msgRequestTimedOut: 'The request was not answered in time and was aborted.',
+            msgCorsMisconfiguration: 'HTTP access control (CORS) on the target server is probably not ' +
+                'configured correctly.',
+            msgUnauthorized: 'The client is not authenticated against the target server.',
+            msgForbidden: 'The client has no access to the requested resource.',
+            msgFileNotFound: 'The requested resource does not exist.',
+            msgTooManyRequests: 'The client sent to many requests.',
+            msgServiceUnavailable: 'The server is currently not available (too many or request or maintenance mode).',
+            msgGatewayTimeOut: 'The server acted as a gateway and the original target did not respond in time',
+            msgClientError: 'An unspecified client error has occurred.',
+            msgServerError: 'An unspecified server error has occurred.',
+            msgInvalidUrl: 'The provided URL is not a valid ArcGISRest URL',
+            documentation: '<h2>Add ArcGISRest layer</h2>• In this dialog you can add any desired map service to the map with the ' +
+                'help of an ArcGISRest URL.'
+        }
+    },
+
+    controller: 'cmv_add_arcgisrest_form',
+
+    listeners: {
+        arcgisrestadd: 'onArcGISRestAdd'
+    },
+
+    layerGroupName: 'External Layers'
+});

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "geostyler-sld-parser": "3.2.2",
     "jsonix": "^3.0.0",
     "jsonlint": "^1.6.3",
-    "proj4": "^2.7.4"
+    "proj4": "^2.7.4",
+    "url-polyfill": "^1.1.12"
   },
   "devDependencies": {
     "browserify": "^17.0.0",

--- a/test/spec/view/addArcGISRest/AddArcGISRestForm.spec.js
+++ b/test/spec/view/addArcGISRest/AddArcGISRestForm.spec.js
@@ -1,0 +1,13 @@
+describe('CpsiMapview.view.addArcGISRest.AddArcGISRestForm', function() {
+    describe('Basics', function() {
+        it('is defined', function() {
+            expect(CpsiMapview.view.addArcGISRest.AddArcGISRestForm).not.to.be(undefined);
+        });
+
+        it('can be instantiated', function() {
+            var inst = Ext.create('CpsiMapview.view.addArcGISRest.AddArcGISRestForm', {});
+            expect(inst).to.be.a(CpsiMapview.view.addArcGISRest.AddArcGISRestForm);
+        });
+
+    });
+});


### PR DESCRIPTION
This introduces the `cmv_add_arcgisrest_form`, which is an example implementation for importing layers via the ArcGIS Rest API.

This makes use of the not yet published `basgix-form-addarcgisrest` component (see https://github.com/terrestris/BasiGX/pull/691). So this PR will remain WIP until released. However, this PR can already be reviewed, as the application logic itself should not change anymore.

Multiple screencasts can be seen in https://github.com/terrestris/BasiGX/pull/691

This PR differs by adding English translations:

![image](https://user-images.githubusercontent.com/12186477/181786759-2fd90163-4949-4cd9-8302-7d9556769bce.png)

Note: I added the `url-polyfill` lib, since BasiGX now makes use of the `URL` interface, which is not supported by IE.

This (partially?) solves https://github.com/compassinformatics/cpsi-mapview/issues/561