### PR TITLE
Remove setting of layer visibility from layer tree filter

### DIFF
--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -222,16 +222,6 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
             var requiredRoles = record.get('requiredRoles');
             if (requiredRoles && Ext.isArray(requiredRoles) && requiredRoles.length){
                 var showNode = CpsiMapview.util.RoleManager.hasAtLeastOneRequiredRole(requiredRoles);
-                // needed to ensure layer shown/hidden on both tree and map
-                // only show layer if it shall be visible initially
-                var olLayer = record.getOlLayer();
-                if (olLayer && olLayer.get('_origLayerConf') && olLayer.get('_origLayerConf').openLayers) {
-                    if (olLayer.get('_origLayerConf').openLayers.visibility) {
-                        olLayer.setVisible(true);
-                    } else {
-                        olLayer.setVisible(false);
-                    }
-                }
                 return showNode;
             }
             return true;


### PR DESCRIPTION
Quick fix for #581. This simply removes trying to handle setting layer visibility in the filter. 
The initial rationale was to handle the case where a user logs out and then logs back in after their user roles have been modified (without refreshing the browser). This use case may never happen, and even if it does, then changing which layers are visible in the application may be more confusing than helpful. 

Removing this logic keeps things simpler, and all that is lost is layers with visibility set to `true` by default have to be switched on manually in the case when logging in and out with different roles. 