### PR TITLE
Add 3 new edge vector layers and styles

### DIFF
--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -390,6 +390,54 @@
     },
     {
       "layerType": "wfs",
+      "layerKey": "FOOTWAYS_WFS",
+      "featureType": "footways",
+      "noCluster": true,
+      "idProperty": "EdgeId",
+      "styles": [
+        {
+          "name": "Footways.xml",
+          "title": "Default"
+        }
+      ],
+      "openLayers": {
+        "maxScale": 800000
+      }
+    },
+    {
+      "layerType": "wfs",
+      "layerKey": "SERVICES_WFS",
+      "featureType": "services",
+      "noCluster": true,
+      "idProperty": "EdgeId",
+      "styles": [
+        {
+          "name": "Services.xml",
+          "title": "Default"
+        }
+      ],
+      "openLayers": {
+        "maxScale": 800000
+      }
+    },
+    {
+      "layerType": "wfs",
+      "layerKey": "CYCLEWAYS_WFS",
+      "featureType": "cycleways",
+      "noCluster": true,
+      "idProperty": "EdgeId",
+      "styles": [
+        {
+          "name": "Cycleways.xml",
+          "title": "Default"
+        }
+      ],
+      "openLayers": {
+        "maxScale": 800000
+      }
+    },
+    {
+      "layerType": "wfs",
       "gridXType": "cmv_examplegrid",
       "gridFilters": [
         {

--- a/resources/data/layers/tree.json
+++ b/resources/data/layers/tree.json
@@ -23,22 +23,47 @@
             "qtip": "Right-click for a layer grid"
           },
           {
-            "id": "NODES_WFS",
-            "leaf": true,
-            "text": "Nodes",
-            "qtip": "Used in the snapping tool example"
-          },
-          {
-            "id": "EDGES_WFS",
-            "leaf": true,
-            "text": "Edges",
-            "qtip": "Used in the snapping tool example"
-          },
-          {
-            "id": "POLYGONS_WFS",
-            "leaf": true,
-            "text": "Polygons",
-            "qtip": "Used in the snapping tool example"
+            "id": "vector-editing",
+            "title": "Vector Editing",
+            "expanded": true,
+            "children": [
+              {
+                "id": "FOOTWAYS_WFS",
+                "leaf": true,
+                "text": "Footways",
+                "qtip": "Footways data from OSM"
+              },
+              {
+                "id": "SERVICES_WFS",
+                "leaf": true,
+                "text": "Services",
+                "qtip": "Services data from OSM"
+              },
+              {
+                "id": "CYCLEWAYS_WFS",
+                "leaf": true,
+                "text": "Cycleways",
+                "qtip": "Cycleways data from OSM"
+              },
+              {
+                "id": "NODES_WFS",
+                "leaf": true,
+                "text": "Nodes",
+                "qtip": "Used in the snapping tool example"
+              },
+              {
+                "id": "EDGES_WFS",
+                "leaf": true,
+                "text": "Edges",
+                "qtip": "Used in the snapping tool example"
+              },
+              {
+                "id": "POLYGONS_WFS",
+                "leaf": true,
+                "text": "Polygons",
+                "qtip": "Used in the snapping tool example"
+              }
+            ]
           },
           {
             "id": "BOREHOLE_WMS",

--- a/resources/data/styling/Cycleways.xml
+++ b/resources/data/styling/Cycleways.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StyledLayerDescriptor version="1.1.0" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <NamedLayer>
+        <se:Name>Cycleways</se:Name>
+        <UserStyle>
+            <se:Name>Default</se:Name>
+            <se:FeatureTypeStyle>
+                <se:Rule>
+                    <se:Name>Cycleways</se:Name>
+                    <se:LineSymbolizer>
+                        <se:Stroke>
+                            <se:SvgParameter name="stroke">#7393B3</se:SvgParameter>
+                            <se:SvgParameter name="stroke-width">1.2</se:SvgParameter>
+                        </se:Stroke>
+                    </se:LineSymbolizer>
+                </se:Rule>
+            </se:FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+</StyledLayerDescriptor>

--- a/resources/data/styling/Footways.xml
+++ b/resources/data/styling/Footways.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StyledLayerDescriptor version="1.1.0" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <NamedLayer>
+        <se:Name>Footways</se:Name>
+        <UserStyle>
+            <se:Name>Default</se:Name>
+            <se:FeatureTypeStyle>
+                <se:Rule>
+                    <se:Name>Footways</se:Name>
+                    <se:LineSymbolizer>
+                        <se:Stroke>
+                            <se:SvgParameter name="stroke">#808080</se:SvgParameter>
+                            <se:SvgParameter name="stroke-width">1.2</se:SvgParameter>
+                        </se:Stroke>
+                    </se:LineSymbolizer>
+                </se:Rule>
+            </se:FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+</StyledLayerDescriptor>

--- a/resources/data/styling/Services.xml
+++ b/resources/data/styling/Services.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StyledLayerDescriptor version="1.1.0" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <NamedLayer>
+        <se:Name>Services</se:Name>
+        <UserStyle>
+            <se:Name>Default</se:Name>
+            <se:FeatureTypeStyle>
+                <se:Rule>
+                    <se:Name>Services</se:Name>
+                    <se:LineSymbolizer>
+                        <se:Stroke>
+                            <se:SvgParameter name="stroke">#36454F</se:SvgParameter>
+                            <se:SvgParameter name="stroke-width">1.2</se:SvgParameter>
+                        </se:Stroke>
+                    </se:LineSymbolizer>
+                </se:Rule>
+            </se:FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
3 new line vector layers have been added to the demo MapServer (and deployed) via https://github.com/compassinformatics/mapview-demo/pull/7

@JakobMiksch - these layers are representative of some of the features we will be attempting to trace using #560. 

This pull request adds them to the layer tree, with basic SLD styles. It also moves all the vector testing layers to a subfolder. 

@JakobMiksch @jansule - let me know if it is ok to merge this, or if I should hold off while you are testing. 

