### PR TITLE
Apply preset filters when loading layer tree

### DIFF
--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -159,6 +159,17 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
                 if (node.getOlLayer()) {
                     var origTreeNodeConf = node.getOlLayer().get('_origTreeConf') || {};
                     me.applyTreeConfigsToNode(node, origTreeNodeConf);
+
+                    // We are creating the gridWindow here already, to ensure that
+                    // any preset filter will be applied directly, without having to
+                    // open the gridWindow first.
+                    var gridWindow = CpsiMapview.util.Grid.getGridWindow(node.getOlLayer());
+                    if (gridWindow) {
+                        var grid = gridWindow.down('grid');
+                        if (grid) {
+                            grid.fireEvent('applypresetfilters');
+                        }
+                    }
                 }
             });
 


### PR DESCRIPTION
This applies the preset filters when loading the layer tree. Before this, the filters were only applied when the layer grid was opened.

Solves https://github.com/compassinformatics/cpsi-mapview/issues/573

![compass-preset-filters](https://user-images.githubusercontent.com/12186477/183904908-d073aecf-4dbf-4ce8-841b-68254ee654bf.gif)

