### PR TITLE
Enable showing marker on centerToCoordinate click

### DIFF
--- a/app/view/toolbar/MapFooter.js
+++ b/app/view/toolbar/MapFooter.js
@@ -21,6 +21,16 @@ Ext.define('CpsiMapview.view.toolbar.MapFooter', {
             xtype: 'basigx-combo-scale'
         }, {
             xtype: 'basigx-panel-coordinatemouseposition',
+            showMarker: true,
+            markerStyle: new ol.style.Style({
+                text: new ol.style.Text({
+                    font: 'normal 2em "font-gis"',
+                    text: '\uea16',
+                    fill: new ol.style.Fill({
+                        color: 'red'
+                    })
+                })
+            }),
             epsgCodeArray: ['EPSG:4326', 'EPSG:29902', 'EPSG:2157'],
             activeEpsgCode: 'EPSG:29902',
             segmentedButtonLimit: 3


### PR DESCRIPTION
Title says it all...

Waits for https://github.com/terrestris/BasiGX/pull/699 to be merged and published. BasiGX submodule can then be updated.

Solves https://github.com/compassinformatics/cpsi-mapview/issues/487

![compass-marker-on-coordinate](https://user-images.githubusercontent.com/12186477/184156323-076a65ad-62fe-463f-81ff-138ca2d4e660.gif)

