### PR TITLE
Re-enable test coverage

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -39,11 +39,10 @@ jobs:
     - name: Testing 🔎
       run: npm test
 
-    # disable until errors can become warnings
-    #- name: Generate coverage 🧪
-    #  run: npm run test:coverage
+    - name: Generate coverage 🧪
+      run: npm run test:coverage
 
-    #- name: Publish to coveralls ⭐
-    #  uses: coverallsapp/github-action@master
-    #  with:
-    #    github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Publish to coveralls ⭐
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-push-master.yml
+++ b/.github/workflows/on-push-master.yml
@@ -77,14 +77,13 @@ jobs:
     - name: Testing 🔎
       run: npm test
 
-    # disabled until coverage decrease can be marked as a warning rather than a failure
-    #- name: Generate coverage 🧪
-    #  run: npm run test:coverage
+    - name: Generate coverage 🧪
+      run: npm run test:coverage
 
-    #- name: Publish to coveralls ⭐
-    #  uses: coverallsapp/github-action@master
-    #  with:
-    #    github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Publish to coveralls ⭐
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build sencha app
       run: |

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -37,6 +37,9 @@ module.exports = function(config) {
             dir: 'coverage/',
             check: {
                 emitWarning: true // don't fail the tests
+                global: {
+                    statements: 15 // minimum coverage of 15%
+                }
             },
             reporters: [
                 { type: 'html', subdir: '.' },

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -36,7 +36,7 @@ module.exports = function(config) {
         coverageReporter: {
             dir: 'coverage/',
             check: {
-                emitWarning: true // don't fail the tests
+                emitWarning: true, // don't fail the tests
                 global: {
                     statements: 15 // minimum coverage of 15%
                 }


### PR DESCRIPTION
Hopefully setting `statements` means CI will not produce errors unless it falls below the 15% threshold. 