### PR TITLE
Add check to cleanupTracing to make sure tracing was previously initi…

### DIFF
--- a/app/controller/button/TracingMixin.js
+++ b/app/controller/button/TracingMixin.js
@@ -139,6 +139,12 @@ Ext.define('CpsiMapview.controller.button.TracingMixin', {
      */
     cleanupTracing: function () {
         var me = this;
+
+        // nothing to cleanup if tracing has not been initialised
+        if (!me.tracingDrawInteraction) {
+            return;
+        }
+
         me.map.removeLayer(me.previewVector);
         me.map.removeLayer(me.tracingVector);
         me.map.un('click', me.onTracingMapClick);


### PR DESCRIPTION
…alised

If a `DrawingButton` is added to view but not clicked, `initTracing` is never called and `tracingDrawInteraction` will be undefined. When the view is destroyed, the `DrawingButton` is destroyed which calls `cleanupTracing`` which attempts to unlisten to events on 'tracingDrawInteraction', which is undefined, throwing an error, and breaks the Map.

This PR protects against this, checking if `tracingDrawInteraction` is defined before trying to access it.