### PR TITLE
Allow GetFeatureInfo requests on layers with combined WMS layers

### DIFF
--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -38,6 +38,9 @@ Ext.define('CpsiMapview.view.main.Map', {
             ptype: 'cmv_feature_attribute_grouping',
             startGroupingEvent: 'click',
             endGroupingEvent: 'context'
+        },
+        {
+            ptype: 'cmv_feature_info_window'
         }
     ],
 
@@ -255,11 +258,6 @@ Ext.define('CpsiMapview.view.main.Map', {
                 stateful: true,
                 stateId: 'cmv_mapstate',
                 map: me.map,
-                plugins: [
-                    {
-                        ptype: 'cmv_feature_info_window'
-                    }
-                ],
                 listeners: {
                     afterrender: 'afterMapRender'
                 }

--- a/test/spec/plugin/FeatureInfoWindow.spec.js
+++ b/test/spec/plugin/FeatureInfoWindow.spec.js
@@ -1,0 +1,12 @@
+describe('CpsiMapview.plugin.FeatureInfoWindow', function () {
+
+    it('is defined', function () {
+        expect(CpsiMapview.plugin.FeatureInfoWindow).not.to.be(undefined);
+    });
+
+    it('can be instantiated', function () {
+        var inst = Ext.create('CpsiMapview.plugin.FeatureInfoWindow');
+        expect(inst).to.be.a(CpsiMapview.plugin.FeatureInfoWindow);
+    });
+
+});


### PR DESCRIPTION
A `ol.source.ImageWMS` can combine multiple WMS layers e.g. `params: { 'LAYERS': 'river,road'}`.
If the properties for the combined features don't match, then MapServer throws an error. This pull request splits each of the layers in `params.LAYERS` into a separate call to avoid this. 