### PR TITLE
Fix issues with tracing drawEnd, make snapTolerance configurable

### DIFF
--- a/app/controller/button/DrawingButtonController.js
+++ b/app/controller/button/DrawingButtonController.js
@@ -98,6 +98,7 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
     setDrawInteraction: function (layer) {
 
         var me = this;
+        var view = me.getView();
 
         if (me.drawInteraction) {
             me.map.removeInteraction(me.drawInteraction);
@@ -115,7 +116,7 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
             features: collection,
             condition: drawCondition,
             style: me.getDrawStyleFunction(),
-            snapTolerance: 2 // Pixel distance for snapping to the drawing finish (default 12)
+            snapTolerance: view.getDrawInteractionSnapTolerance()
         };
 
         me.drawInteraction = new ol.interaction.Draw(drawInteractionConfig);

--- a/app/controller/button/TracingMixin.js
+++ b/app/controller/button/TracingMixin.js
@@ -132,6 +132,10 @@ Ext.define('CpsiMapview.controller.button.TracingMixin', {
     onTracingDrawEnd: function () {
         var me = this;
         me.tracingActive = false;
+        // Clear previous tracingFeature data
+        me.tracingFeature.getGeometry().setCoordinates([]);
+        me.tracingFeatureArray = [];
+        me.previewLine.getGeometry().setCoordinates([]);
     },
 
     /**
@@ -160,6 +164,11 @@ Ext.define('CpsiMapview.controller.button.TracingMixin', {
      */
     onTracingMapClick: function (event) {
         var me = this;
+
+        // Ignore the event if drawing is finished
+        if (!me.tracingActive) {
+            return;
+        }
 
         var hit = false;
         me.map.forEachFeatureAtPixel(
@@ -304,14 +313,17 @@ Ext.define('CpsiMapview.controller.button.TracingMixin', {
                 var geom = f.getGeometry();
                 var coords = geom.getCoordinates();
 
-                if (updatedCoords.length === 0) {
+                if (updatedCoords && updatedCoords.length === 0) {
                     updatedCoords = coords;
                 } else {
                     updatedCoords = me.tracingUtil.concatLineCoords(updatedCoords, coords);
                 }
             });
 
-            me.tracingFeature.getGeometry().setCoordinates(updatedCoords);
+            // concatLineCoords can return undefined if lines do not touch
+            if (updatedCoords) {
+                me.tracingFeature.getGeometry().setCoordinates(updatedCoords);
+            }
         }
     },
 

--- a/app/view/button/DrawingButton.js
+++ b/app/view/button/DrawingButton.js
@@ -119,7 +119,12 @@ Ext.define('CpsiMapview.view.tool.DrawingButton', {
         /**
          * The style of the snapped edge's vertices.
          */
-        snappedEdgeVertexStyle: CpsiMapview.util.Style.createWhiteCircle()
+        snappedEdgeVertexStyle: CpsiMapview.util.Style.createWhiteCircle(),
+
+        /**
+         * Pixel distance for snapping to the drawing finish (default 12)
+         */
+        drawInteractionSnapTolerance: 2
     },
 
     /**


### PR DESCRIPTION
Fixes #598 

- Makes snapTolerance configurable to allow easier drawEnd doubeclick
- Returns early from onTracingMapClick if drawing is finished to prevent conflicts
- Protects against undefined updatedCoords which cases console errors when tracing certain features


