### PR TITLE
Ignore ext when it is a symbolic link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 build/*
 coverage/*
-ext/
+ext
 node_modules/
 
 bootstrap.css


### PR DESCRIPTION
Changing `ext/` to `ext` in gitignore will ignore ext if it is a folder or a symbolic link