### PR TITLE
Add option to only snap to visible layers/features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 build/*
 coverage/*
-ext/
+ext
 node_modules/
 
 bootstrap.css

--- a/app/controller/button/DrawingButtonController.js
+++ b/app/controller/button/DrawingButtonController.js
@@ -731,7 +731,8 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
     },
 
     /**
-     * Remove the interaction when this component gets destroyed
+     * Remove event listeners by key, for each key in the listenerKeys array
+     *
      */
     unBindLayerListeners: function () {
         Ext.Array.each(this.listenerKeys, function(key) {

--- a/app/view/button/DrawingButton.js
+++ b/app/view/button/DrawingButton.js
@@ -129,9 +129,9 @@ Ext.define('CpsiMapview.view.tool.DrawingButton', {
         /**
          * Allows consumer of component choice of snapping to only visible layer features
          * defined in snappingLayerKeys, or snapping to layer features even if they
-         * are invisible. Defaults to true for backward compatibility.
+         * are invisible.
          */
-        allowSnapToHiddenFeatures: true
+        allowSnapToHiddenFeatures: false
     },
 
     /**

--- a/app/view/button/DrawingButton.js
+++ b/app/view/button/DrawingButton.js
@@ -124,7 +124,14 @@ Ext.define('CpsiMapview.view.tool.DrawingButton', {
         /**
          * Pixel distance for snapping to the drawing finish (default 12)
          */
-        drawInteractionSnapTolerance: 2
+        drawInteractionSnapTolerance: 2,
+
+        /**
+         * Allows consumer of component choice of snapping to only visible layer features
+         * defined in snappingLayerKeys, or snapping to layer features even if they
+         * are invisible. Defaults to true for backward compatibility.
+         */
+        allowSnapToHiddenFeatures: true
     },
 
     /**


### PR DESCRIPTION
Currently when snapping is set up in `cmv_drawing_button` and one of the configured snapping Layers is turned off, the snap interaction will still snap to the features of the invisible layer.

This PR adds option `allowSnapToHiddenFeatures` which defaults to `true` (current behavior)

If set to `false`, the snapCollection collection will be updated accordingly depending on layer visibility.