### PR TITLE
Clean up error log output in FeatureEventsMixin

### DIFF
--- a/app/model/FeatureEventsMixin.js
+++ b/app/model/FeatureEventsMixin.js
@@ -50,7 +50,18 @@ Ext.define('CpsiMapview.model.FeatureEventsMixin', {
                 layerUtil.layerRefresh(layer);
             } else {
                 //<debug>
-                Ext.log.error('layerKey "' + k + '" in syncLayerKeys invalid for ' + me.$className);
+                // if a switch layer is used then it may not yet have been created
+                // so we check for its twin layer
+                var switchLayerFound = false;
+                var type = k.endsWith('_WMS') ? '_WMS' : '_WFS';
+                var altType = k.endsWith('_WMS') ? '_WFS' : '_WMS';
+                var altLayerKey = k.replace(type, altType);
+
+                switchLayerFound = !Ext.isEmpty(BasiGX.util.Layer.getLayersBy('layerKey', altLayerKey));
+
+                if (switchLayerFound === false) {
+                    Ext.log.error('layerKey "' + k + '" in syncLayerKeys invalid for ' + me.$className);
+                }
                 //</debug>
             }
         });

--- a/test/spec/model/FeatureEventsMixin.spec.js
+++ b/test/spec/model/FeatureEventsMixin.spec.js
@@ -1,0 +1,57 @@
+describe('CpsiMapview.model.FeatureEventsMixin', function () {
+
+    var map;
+    var layer1;
+    var layer2;
+    var layer3;
+    var getLayersByStub;
+
+    beforeEach(function () {
+
+        map = new ol.Map();
+
+        layer1 = new ol.layer.Vector({
+            layerKey: 'MYKEY'
+        });
+
+        layer2 = new ol.layer.Vector({
+            layerKey: 'MYKEY_WFS'
+        });
+
+        layer3 = new ol.layer.Vector({
+            layerKey: 'MYKEY_WMS'
+        });
+
+        // stub BasiGX.util.Layer.getLayersBy to return test data during these tests
+        getLayersByStub = sinon.stub(BasiGX.util.Layer, 'getLayersBy').callsFake(function (prop, key) {
+            switch (key) {
+                case 'MYKEY':
+                    return [layer1]
+                case 'MYKEY_WFS':
+                    return [layer2]
+                case 'MYKEY_WMS':
+                    // test for when a switch layer is used and the WMS layer has not yet been loaded
+                    return []
+            }
+        });
+    });
+
+    afterEach(function () {
+        getLayersByStub.restore();
+    });
+
+    it('is defined', function () {
+        expect(CpsiMapview.model.FeatureEventsMixin).not.to.be(undefined);
+    });
+
+    it('run model saved', function () {
+
+        var mixin = CpsiMapview.model.FeatureEventsMixin;
+        mixin.syncLayerKeys = ['MYKEY', 'MYKEY_WFS', 'MYKEY_WMS'];
+        mixin.onModelSaved();
+
+        // the above function has no return value for testing
+        expect(mixin).not.to.be(undefined);
+    });
+
+});

--- a/test/spec/model/FeatureEventsMixin.spec.js
+++ b/test/spec/model/FeatureEventsMixin.spec.js
@@ -46,8 +46,13 @@ describe('CpsiMapview.model.FeatureEventsMixin', function () {
 
     it('run model saved', function () {
 
-        var mixin = CpsiMapview.model.FeatureEventsMixin;
-        mixin.syncLayerKeys = ['MYKEY', 'MYKEY_WFS', 'MYKEY_WMS'];
+        var mixin = Ext.create('CpsiMapview.model.FeatureEventsMixin', {
+            syncLayerKeys: ['MYKEY', 'MYKEY_WFS', 'MYKEY_WMS']
+        });
+
+        // avoid throwing an error as fireEvent needs to be triggered when the mixin is part of a class
+        mixin.hasListeners = {};
+
         mixin.onModelSaved();
 
         // the above function has no return value for testing


### PR DESCRIPTION
Switch layers are always logging error output when either the WMS or WFS aren't loaded. Ensure only valid errors are logged.
Also run a basic test so this code is run. 