### PR TITLE
Allow merging to both start and end of existing line

### DIFF
--- a/app/controller/button/DrawingButtonController.js
+++ b/app/controller/button/DrawingButtonController.js
@@ -430,15 +430,24 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
      * @param {any} newGeom
      */
     mergeLineStrings: function (origGeom, newGeom) {
+        var newGeomFirstCoord = newGeom.getFirstCoordinate();
+        var matchesFirstCoord = Ext.Array.equals(origGeom.getFirstCoordinate(), newGeomFirstCoord);
+        var matchesLastCoord = Ext.Array.equals(origGeom.getLastCoordinate(), newGeomFirstCoord);
 
-        if (Ext.Array.equals(origGeom.getLastCoordinate(), newGeom.getFirstCoordinate()) === true) {
+        if (matchesFirstCoord || matchesLastCoord) {
             var origCoords = origGeom.getCoordinates();
+            // if drawing in continued from the start point of the original,
+            // the original needs to be reversed to we end up with correct
+            // start and end points
+            if (matchesFirstCoord) {
+                origCoords.reverse();
+            }
             var newCoords = newGeom.getCoordinates();
             newGeom.setCoordinates(origCoords.concat(newCoords));
         } else {
-            Ext.log('End coordinates differ');
-            Ext.log('End coord: ', origGeom.getLastCoordinate());
-            Ext.log('Start coord: ', newGeom.getFirstCoordinate());
+            Ext.log('Start / End coordinates differ');
+            Ext.log('origGeom start/end coords: ', origGeom.getFirstCoordinate(), origGeom.getLastCoordinate());
+            Ext.log('newGeom start coord: ', newGeom.getFirstCoordinate());
         }
 
         return newGeom;


### PR DESCRIPTION
Currently with the `cmv_drawing_button`, you can only append to the last point of a previously drawn line. If you try to append to the start point, it will create a new line:

https://user-images.githubusercontent.com/1889044/200355790-b08c6c50-6bf0-4795-a378-19a59338078e.mp4

With this PR, you can append to either start or end of the previous line. If appending to the start, the coords of the previous line are reversed so the we end up with a single line with one start and one end point.

https://user-images.githubusercontent.com/1889044/200356769-14567c54-d1ea-41f7-a4e2-6e14624e1ca7.mp4

