### PR TITLE
Add option to only show FeatureInfoWindow if features are found

### DIFF
--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -249,6 +249,10 @@ Ext.define('CpsiMapview.view.main.Map', {
             });
         }
 
+        if (app) {
+            me.map.set('showFeatureInfoWindowOnlyIfContent', app.showFeatureInfoWindowOnlyIfContent);
+        }
+
         // create default items if not already been created in a derived class
         if (!me.items) {
             me.items = [{


### PR DESCRIPTION
This PR adds the ability to set option `showFeatureInfoWindowOnlyIfContent` which will change the behavior of the FeatureInfoWindow  popup. 

Instead of the window always opening, then possibly being empty if no features are found, the window will only open if features are found in one of the layers enabled when the user clicked the map.