### PR TITLE
Readd wrongly removed clearText handler

### DIFF
--- a/app/form/LayerTreeFilter.js
+++ b/app/form/LayerTreeFilter.js
@@ -13,6 +13,30 @@ Ext.define('CpsiMapview.controller.form.LayerTreeFilter', {
     ],
 
     /**
+     * Clears the textfield for filtering the layer tree.
+     *
+     * @param {Ext.form.field.Text } textField
+     */
+    clearText: function (textField) {
+        var me = this;
+        var view = me.getView();
+
+        textField.setValue('');
+
+        var tree = Ext.ComponentQuery.query('cmv_layertree')[0];
+        if (!tree) {
+            return;
+        }
+        var store = tree.getStore();
+        if (!store) {
+            return;
+        }
+
+        // remove previous filter if exists
+        store.removeFilter(view.TEXT_FILTER_ID);
+    },
+
+    /**
      * Updates the filter with the latest input values.
      *
      * @return {void}


### PR DESCRIPTION
This readds the logic for clearing a filter in the filter tree.

![compass-clear-filter-trigger](https://user-images.githubusercontent.com/12186477/205011240-ff65f540-6c2d-4478-abf2-d802157d9d84.gif)


solves https://github.com/compassinformatics/cpsi-mapview/issues/594