### PR TITLE
Show the hide trigger button by default

### DIFF
--- a/app/view/form/LayerTreeFilter.js
+++ b/app/view/form/LayerTreeFilter.js
@@ -42,7 +42,7 @@ Ext.define('CpsiMapview.view.form.LayerTreeFilter', {
 
     items: [{
         xtype: 'textfield',
-        hideTrigger: true,
+        hideTrigger: false,
         anchor: '100%',
         maxWidth: 250,
         bind: {


### PR DESCRIPTION
Now the clear function is back, make this the default - see #594