### PR TITLE
Dynamically set the PROPERTYNAME param depending on style loaded and …

### DIFF
--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -557,6 +557,7 @@ Ext.define('CpsiMapview.factory.Layer', {
                     onError();
                 }
             };
+            vectorSource.set('xhr', xhr);
             xhr.send(queryParams);
         };
 
@@ -1040,7 +1041,18 @@ Ext.define('CpsiMapview.factory.Layer', {
 
                             if (hasStyleExtraPropertyNames) {
                                 var propertyNames = LayerFactory.buildRequiredPropertyNames(stylePropertyNames, mapLayer.get('toolTipConfig'));
+                                var xhr = source.get('xhr');
+
                                 source.set('propertyNames', propertyNames);
+
+                                // abort an existing xhr for this source if there is one and it is in progress
+                                // to prevent race conditions where the initial request for data would
+                                // finish after the subsequent request with extra fields, rendering features
+                                // without the required data, meaning styles would not apply in certain cases
+                                if (xhr && xhr.readyState !== 4) {
+                                    xhr.abort();
+                                }
+
                                 source.refresh();
                             }
                         });

--- a/test/resources/style/style1.xml
+++ b/test/resources/style/style1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StyledLayerDescriptor version="1.1.0" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <NamedLayer>
+        <se:Name>Footways</se:Name>
+        <UserStyle>
+            <se:Name>Default</se:Name>
+            <se:FeatureTypeStyle>
+                <se:Rule>
+                    <se:Name>Footways</se:Name>
+                    <se:LineSymbolizer>
+                        <se:Stroke>
+                            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+                            <se:SvgParameter name="stroke-width">5</se:SvgParameter>
+                        </se:Stroke>
+                    </se:LineSymbolizer>
+                    <se:TextSymbolizer>
+                      <se:Label>
+                        <ogc:PropertyName>EdgeId</ogc:PropertyName>, <PropertyName>FID</PropertyName>
+                      </se:Label>
+                      <se:Font />
+                      <se:Fill>
+                        <CssParameter name="fill">#000000</CssParameter>
+                      </se:Fill>
+                    </se:TextSymbolizer>
+                </se:Rule>
+            </se:FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+</StyledLayerDescriptor>

--- a/test/spec/factory/Layer.spec.js
+++ b/test/spec/factory/Layer.spec.js
@@ -1,0 +1,36 @@
+describe('CpsiMapview.factory.Layer', function () {
+    var layerFactory = CpsiMapview.factory.Layer;
+
+    describe('buildRequiredPropertyNames', function () {
+
+        it('should merge and clean property names in both arguments into a unique array', function () {
+            var currentPropertyNames = ['Prop1', 'Prop2', 'Prop3', ''];
+            var tooltipConfig = [{
+                alias: 'Name',
+                property: 'Prop1'
+            }, {
+                alias: 'Name',
+                property: 'Prop4'
+            }];
+            var propertyNames = layerFactory.buildRequiredPropertyNames(currentPropertyNames, tooltipConfig);
+            expect(propertyNames).to.eql(['Prop1', 'Prop2', 'Prop3', 'Prop4']);
+
+        });
+
+    });
+
+    describe('getPropertyNamesInSLD', function () {
+
+        it('should extract PropertName values from an SLD', function (done) {
+            Ext.Ajax.request({
+                url: '/resources/style/style1.xml',
+                success: function (response) {
+                    var propertyNames = layerFactory.getPropertyNamesInSLD(response.responseXML);
+                    expect(propertyNames).to.eql(['EdgeId', 'FID']);
+                    done();
+                }
+            });
+        });
+
+    });
+});


### PR DESCRIPTION
…tooltip config

resolves #628 

If `serverOptions.propertyname` has not been set in the config, the `PROPERTYNAME` is not set and all fields will be returned. Style switching and tooltip config doesn't change this because all properties are already available

On WFS layer creation, the values in `serverOptions.propertyname` and property names referenced in `tooltipConfig` are combined and sent in the `PROPERTYNAME` param. This means you can define only the properties used in the default style `serverOptions.propertyname` and let the `tooltipConfig` populate the rest

On WFS default style xml file load, or on switching styles, property names will be extracted from the SLD XML. If there are property names found in the SLD which have not already been requested, these property names will be added to the list and the source refreshed (a new WFS request with required fields for the current style and `tooltipConfig`)

The property names originally defined in `serverOptions.propertyname` config will always be sent along side the dynamically generated property names. This is to ensure that certain properties that might not be in a style or a `tooltipConfig` are always available so that functionality that this PR (https://github.com/compassinformatics/cpsi-mapview/pull/599) enables will continue to work

Generated and mergerd property names are cleaned and duplicates removed. The are treated as case sensitive.