### PR TITLE
Hide the loading status bar when a request is aborted

### DIFF
--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -1050,6 +1050,8 @@ Ext.define('CpsiMapview.factory.Layer', {
                                 // finish after the subsequent request with extra fields, rendering features
                                 // without the required data, meaning styles would not apply in certain cases
                                 if (xhr && xhr.readyState !== 4) {
+                                    // ensure the loading bar is hidden
+                                    source.dispatchEvent('vectorloadend');
                                     xhr.abort();
                                 }
 


### PR DESCRIPTION
Fire the `vectorloadend` so the loading bar knows when to close, otherwise when zooming in on a switch layer the loading bar doesn't disappear. 