### PR TITLE
Set qtip to fix issue where tooltip is not updated

### DIFF
--- a/app/plugin/TreeColumnInResolutionRange.js
+++ b/app/plugin/TreeColumnInResolutionRange.js
@@ -74,7 +74,7 @@ Ext.define('CpsiMapview.plugin.TreeColumnInResolutionRange', {
             var changed = description !== descriptionBefore;
             node.getOlLayer().set('description', description);
             if (changed) {
-                node.triggerUIUpdate();
+                node.set('qtip', description);
             }
         });
         // This triggers the rendering if any existing StyleSwitcherRadioGroups


### PR DESCRIPTION
Fixes #629 

Everything worked as expected up until `node.triggerUIUpdate()`. The UI/tooltips didn't update as they did before, maybe a change in ExtJS itself?

Setting the `qtip` instead updates the tooltip as expected.