### PR TITLE
Refresh layer tree ui on expand

### DIFF
--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -12,7 +12,8 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
         'BasiGX.util.Map',
         'BasiGX.util.Layer',
         'CpsiMapview.data.model.LayerTreeNode',
-        'CpsiMapview.view.main.Map'
+        'CpsiMapview.view.main.Map',
+        'CpsiMapview.util.Layer'
     ],
 
     statics: {
@@ -465,5 +466,18 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
             this.addArcGISRestWindow.destroy();
             this.addArcGISRestWindow = null;
         }
+    },
+
+    /**
+    * Updates the UI of childNodes of an expanded item
+    * @param {CpsiMapview.data.model.LayerTreeNode} LayerTreeNode
+    */
+    updateExpandedItemChildNodesUI: function (layerTreeNode) {
+        Ext.each(layerTreeNode.childNodes, function (node) {
+            var layer =  node.getOlLayer(); ;
+            if (layer.get('isWms') || layer.get('isWfs') || layer.get('isVt')) {
+                CpsiMapview.util.Layer.updateLayerNodeUI(layer, false);
+            }
+        });
     }
 });

--- a/app/util/Layer.js
+++ b/app/util/Layer.js
@@ -75,8 +75,13 @@ Ext.define('CpsiMapview.util.Layer', {
     /**
     * Update any associated layer tree node to indicate that the layer is filtered or unfiltered
     * @param {any} layer
+    * @param {boolean} triggerUIUpdate
     */
-    updateLayerNodeUI: function (layer) {
+    updateLayerNodeUI: function (layer, triggerUIUpdate) {
+        // default the triggerUIUpdate param to true if not set
+        if (typeof triggerUIUpdate === 'undefined') {
+            triggerUIUpdate = true;
+        }
 
         // Get a reference to the layer trees
         // we will only ever have one layer tree for an application
@@ -112,17 +117,26 @@ Ext.define('CpsiMapview.util.Layer', {
             Ext.log.warn('Layer type not recognized (updateLayerNodeUI)');
         }
 
+        var originalGlyph = layer.get('_origTreeConf') ? layer.get('_origTreeConf').glyph : null;
+        var expandedGlyph = 'f0b0@FontAwesome';
         if (hasFilters) {
-            node.set('glyph', 'f0b0@FontAwesome');
-            node.addCls('cpsi-tree-node-filtered');
+            // only set the glyph and class if needed - better for performance
+            if (node.get('glyph') !== expandedGlyph) {
+                node.set('glyph', 'f0b0@FontAwesome');
+                node.addCls('cpsi-tree-node-filtered');
+            }
         } else {
-            // revert to the original glyph if set on the layer
-            var glyph = layer.get('_origTreeConf') ? layer.get('_origTreeConf').glyph : null;
-            node.set('glyph', glyph);
-            node.removeCls('cpsi-tree-node-filtered');
+            // only set the glyph and class if needed - better for performance
+            if (node.get('glyph') !== originalGlyph) {
+                // revert to the original glyph if set on the layer
+                node.set('glyph', originalGlyph);
+                node.removeCls('cpsi-tree-node-filtered');
+            }
         }
 
-        node.triggerUIUpdate();
+        if (triggerUIUpdate) {
+            node.triggerUIUpdate();
+        }
     },
 
     /**

--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -30,7 +30,8 @@ Ext.define('CpsiMapview.view.LayerTree', {
     },
 
     listeners: {
-        'cmv-init-layertree': 'filterLayersByRole'
+        'cmv-init-layertree': 'filterLayersByRole',
+        'afteritemexpand': 'updateExpandedItemChildNodesUI',
     },
 
     // So that instantiation works without errors, might be changed during


### PR DESCRIPTION
This PR fixes an issue where a layer has an initial filter configured but the node in the layer tree doesn't show the "filtered" icon when that node is in a folder which is not expanded by default.

See item 34402 in DevOps.