### PR TITLE
Add Group Edit Mixin

### DIFF
--- a/app/controller/grid/GroupEditMixin.js
+++ b/app/controller/grid/GroupEditMixin.js
@@ -1,0 +1,209 @@
+Ext.define('CpsiMapview.controller.grid.GroupEditMixin', {
+    extend: 'Ext.Mixin',
+    requires: ['Ext.menu.Menu'],
+    mixinConfig: {
+        on: {
+            init: function () {
+                var me = this;
+                var view = this.getView();
+
+                view.on('beforerender', function (grid) {
+                    var dropdownMenu = grid.headerCt.getMenu();
+                    dropdownMenu.on({
+                        beforeshow: me.onHeaderMenuBeforeShow,
+                        scope: me
+                    });
+
+                    // Add custom menu items to the default grid menu
+                    dropdownMenu.insert(dropdownMenu.items.length - 2, [{
+                        itemId: 'groupEditorMenuItem',
+                        text: 'Group Edit',
+                        tooltip: 'Group Edit mode must be enabled to use this menu. If you do not see the Group Edit button, you may not have sufficient permissions for grid editing.',
+                        bind: {
+                            disabled: '{!isGroupEditingEnabled}'
+                        }
+                    }]);
+                });
+
+                // Hide the checkbox selection column on initial load
+                view.on('render', function (grid) {
+                    var c = grid.columnManager.getFirst();
+                    if (c) c.hide();
+                });
+
+                view.on('staterestore', function (grid, state) {
+                    grid.getViewModel().set('isGroupEditingEnabled', state.isGroupEditingEnabled);
+                });
+            }
+        }
+    },
+
+    /**
+     * When the Group Edit is clicked then show the record checkbox
+     * column, remove any selections, and disable paging so all
+     * records are displayed
+     * @param {any} btn
+     * @param {any} state
+     */
+    onGroupEditToggle: function (btn, state) {
+        var grid = this.getView();
+        grid.getViewModel().set('isGroupEditingEnabled', state);
+        if (state) {
+            grid.columnManager.getFirst().show();
+        } else {
+            grid.columnManager.getFirst().hide();
+        }
+        grid.selModel.deselectAll();
+    },
+
+    onHeaderMenuBeforeShow: function (menu) {
+        var me = this;
+        var menuItem = menu.down('#groupEditorMenuItem');
+
+        // check if it is a column that can be bulk edited
+        if (!menu.activeHeader.groupEditable) {
+            menuItem.hide(); // simply hide the menu if it is not editable
+        } else {
+            var newMenu = menuItem.menu;
+
+            if (newMenu) {
+                newMenu.removeAll();
+            } else {
+                newMenu = menuItem.menu = Ext.create('Ext.menu.Menu');
+            }
+
+            var newMenuItems = me.createGroupEditMenuItems(menu);
+            newMenu.add(newMenuItems);
+            menuItem.show();
+        }
+    },
+
+    createGroupEditMenuItems: function (menu) {
+        var me = this;
+        var grid = me.getView();
+        var newMenuItem;
+        var newMenuItems = [];
+        var activeHeader = menu.activeHeader;
+        var filterType = activeHeader.filter.type || '';
+        switch (filterType.toLowerCase()) {
+            case 'list':
+                var ff = menu.down('#filters');
+                // create menu options based on the filter options
+                Ext.each(ff.menu.items.items, function (item) {
+
+                    if (item.value === -1) {
+                        // don not create a "No Data" option
+                        // but continue creating the other items
+                        return true;
+                    }
+
+                    newMenuItem = {
+                        text: item.text,
+                        value: item.value,
+                        handler: function (item, event) {
+                            event.stopPropagation();
+
+                            // get the list of Ids that will be updated
+                            var list = grid.selModel.getSelection().map(function (x) {
+                                return x.id;
+                            });
+
+                            me.onGroupUpdate(activeHeader, list, item.value);
+                        }
+                    };
+
+                    newMenuItems.push(newMenuItem);
+                });
+                break;
+            case 'boolean':
+                // create menu options for true and false
+                var trueText = activeHeader.trueText || 'true';
+                var falseText = activeHeader.falseText || 'false';
+                var items = [{ text: trueText, value: true }, { text: falseText, value: false }];
+
+                Ext.each(items, function (item) {
+                    newMenuItem = {
+                        text: item.text,
+                        value: item.value,
+                        handler: function (item, event) {
+                            event.stopPropagation();
+
+                            // get the list of Ids that will be updated
+                            var list = grid.selModel.getSelection().map(function (x) {
+                                return x.id;
+                            });
+
+                            me.onGroupUpdate(activeHeader, list, item.value);
+                        }
+                    };
+
+                    newMenuItems.push(newMenuItem);
+                });
+                break;
+            default:
+                Ext.log.error('Filter type "' + filterType.toLowerCase() + '" not supported');
+                break;
+        }
+
+        return newMenuItems;
+    },
+
+    onGroupUpdate: function (activeHeader, selectedIDs, newValue) {
+
+        var me = this;
+
+        Ext.Msg.show({
+            title: 'Group editing',
+            message: 'You are about to update ' + selectedIDs.length + ' selected items, do you want to proceed?',
+            buttons: Ext.Msg.YESNO,
+            scope: me,
+            fn: function (buttonId) {
+
+                if (buttonId == 'yes') {
+
+                    var data = {};
+                    var idProperty = me.getViewModel().get('idProperty');
+                    var serviceUrl = me.getViewModel().get('serviceUrl') + activeHeader.groupEditService;
+
+                    // first char to lower case to match backend naming
+                    idProperty = idProperty[0].toLowerCase() + idProperty.slice(1);
+                    data[idProperty] = selectedIDs;
+                    data[activeHeader.groupEditDataProp] = newValue;
+
+                    Ext.Ajax.request({
+                        url: serviceUrl,
+                        method: 'POST',
+                        jsonData: data,
+                        success: function (response) {
+                            var resp = Ext.decode(response.responseText);
+                            if (resp.success === true) {
+                                // trigger a refresh of all related layers and stores, including the grid itself
+                                // as defined by syncLayerKeys and syncStoreIds in the model
+                                var clearPaging = false;
+                                me.refreshStore(clearPaging);
+                                var force = true;
+                                me.updateAssociatedLayers(force);
+                            } else {
+                                Ext.Msg.show({
+                                    title: 'Error',
+                                    message: 'Error updating the selected records: ' + resp.message,
+                                    buttons: Ext.Msg.OK,
+                                    icon: Ext.window.MessageBox.ERROR
+                                });
+                            }
+                        },
+                        failure: function () {
+                            Ext.Msg.show({
+                                title: 'Error',
+                                message: 'Error connecting to the update service ' + serviceUrl,
+                                buttons: Ext.Msg.OK,
+                                icon: Ext.window.MessageBox.ERROR
+                            });
+                        }
+                    });
+                }
+            }
+        });
+    }
+
+});

--- a/test/spec/controller/grid/GroupEdit.spec.js
+++ b/test/spec/controller/grid/GroupEdit.spec.js
@@ -1,0 +1,61 @@
+Ext.define('CpsiMapview.controller.TestGroupEditController', {
+    extend: 'CpsiMapview.controller.grid.Grid',
+    alias: 'controller.test_groupeditgrid',
+    mixins: ['CpsiMapview.controller.grid.GroupEditMixin']
+});
+
+Ext.define('CpsiMapview.view.TestGroupEditGrid', {
+    extend: 'CpsiMapview.view.grid.Grid',
+    requires: [
+        'CpsiMapview.controller.TestGroupEditController'
+    ],
+    controller: 'test_groupeditgrid',
+    // Added for Group Edit
+    selModel: {
+        selType: 'featurecheckboxmodel',
+        checkOnly: false,
+        selectStyle: new ol.style.Style({
+            stroke: new ol.style.Stroke({
+                width: 10,
+                color: '#0ff'
+            })
+        })
+    }, columns: {
+        items: [
+            {
+                text: '<i class="x-fa fa-pencil"></i> Editable?',
+                dataIndex: 'Editable',
+                flex: 0.3,
+                hidden: false,
+                xtype: 'booleancolumn',
+                trueText: 'Yes',
+                falseText: 'No',
+                groupEditable: true,
+                groupEditService: 'myGroupEditService',
+                groupEditDataProp: 'myEditableProperty',
+                filter: {
+                    type: 'boolean',
+                },
+            }
+        ]
+    }
+});
+
+
+describe('CpsiMapview.controller.grid.GroupEditMixin', function () {
+    describe('Basics', function () {
+        it('is defined', function () {
+            expect(CpsiMapview.controller.grid.GroupEditMixin).not.to.be(undefined);
+        });
+
+        it('can be created', function () {
+            var mixin = new CpsiMapview.controller.grid.GroupEditMixin();
+            expect(mixin).to.not.be(undefined);
+        });
+
+        it('example can be created', function () {
+            var grid = new CpsiMapview.view.TestGroupEditGrid();
+            expect(grid).not.to.be(undefined);
+        });
+    });
+});


### PR DESCRIPTION
This pull request allows a new drop-down menu to be added to grid columns to allow them to be "group edited":

![image](https://user-images.githubusercontent.com/490840/223092869-ae61b38f-1aff-49ae-9bb4-3677a5000ade.png)

![image](https://user-images.githubusercontent.com/490840/223092509-97d6b93f-4117-4fab-bbf0-072edff07612.png)

When the "Group Edit" mode is selected, a checkbox column appears on the left of the grid. A user can then select records, and update multiple records by selecting a value from the dropdown list of the column:

![image](https://user-images.githubusercontent.com/490840/223092764-7ba8b81e-9eae-4782-9ea1-7d784a4bc892.png)

![image](https://user-images.githubusercontent.com/490840/223092974-a765dd6a-659d-43cd-8a8d-1cab0f9d35b6.png)

![image](https://user-images.githubusercontent.com/490840/223093249-ac3a12b7-3efd-4c70-8080-c2ffa4a905c8.png)

An example column configuration is shown below:

            {
                text: '<i class="x-fa fa-pencil"></i> Editable Example',
                dataIndex: 'exampleField',
                flex: 0.3,
                hidden: false,
                xtype: 'booleancolumn',
                trueText: 'Yes',
                falseText: 'No',
                groupEditable: true,
                groupEditService: 'exampleServiceUrl',
                groupEditDataProp: 'myExampleField',
                filter: {
                    type: 'boolean',
                },
            },

A service call is made using the following format, `idFieldName` is the `idProperty` used for the grid. 

`{idFieldName: [260891, 522021, 522020, 521148], myExampleField: 1}`

