### PR TITLE
Add ability to override default.json and tree.json paths

### DIFF
--- a/app/controller/LayerTreeController.js
+++ b/app/controller/LayerTreeController.js
@@ -207,17 +207,20 @@ Ext.define('CpsiMapview.controller.LayerTreeController', {
      * @return {Ext.Promise} Promise resolving once the JSON is loaded
      */
     loadTreeStructure: function () {
-        return new Ext.Promise(function (resolve, reject) {
-            Ext.Ajax.request({
-                url: 'resources/data/layers/tree.json',
-                method: 'GET',
-                success: function (response) {
-                    var respJson = Ext.decode(response.responseText);
-                    resolve(respJson);
-                },
-                failure: function (response) {
-                    reject(response.status);
-                }
+        var app = Ext.getApplication ? Ext.getApplication() : Ext.app.Application.instance;
+        return app.resourcePathsDeferred.then(function (resourcePaths) {
+            return new Ext.Promise(function (resolve, reject) {
+                Ext.Ajax.request({
+                    url: resourcePaths.treeConfig,
+                    method: 'GET',
+                    success: function (response) {
+                        var respJson = Ext.decode(response.responseText);
+                        resolve(respJson);
+                    },
+                    failure: function (response) {
+                        reject(response.status);
+                    }
+                });
             });
         });
     },

--- a/app/util/ApplicationMixin.js
+++ b/app/util/ApplicationMixin.js
@@ -100,6 +100,12 @@ Ext.define('CpsiMapview.util.ApplicationMixin', {
      */
     tokenValidationUrl: '/WebServices/authorization/validateToken',
 
+    /**
+     * Used to store resource Paths (default.json, tree.json) and can be
+     * overridden by a consumer project
+     */
+    resourcePathsDeferred: null,
+
     errorCode: {
         None: 0,
         AccountLockedOut: 1,
@@ -212,9 +218,18 @@ Ext.define('CpsiMapview.util.ApplicationMixin', {
     },
 
     onApplicationCreated: function () {
-
         var me = this;
         me.setupRequestHooks();
+
+        // No resourcePathsDeferred defined, set default paths
+        if (!me.resourcePathsDeferred) {
+            me.resourcePathsDeferred = new Ext.Deferred();
+            me.resourcePathsDeferred.resolve({
+                layerConfig: 'resources/data/layers/default.json',
+                treeConfig: 'resources/data/layers/tree.json'
+            });
+        }
+
         if (me.requireLogin) {
             me.doLogin();
         } else {

--- a/test/spec/util/ApplicationMixin.spec.js
+++ b/test/spec/util/ApplicationMixin.spec.js
@@ -118,5 +118,35 @@ describe('CpsiMapview.util.ApplicationMixin', function () {
             expect(success).to.be(true);
         });
 
+        it('#onApplicationCreated sets default paths if resourcePathsDeferred is null', function () {
+            expect(mixin.resourcePathsDeferred).to.be.null;
+            mixin.onApplicationCreated();
+            expect(mixin.resourcePathsDeferred).to.exist;
+
+            return mixin.resourcePathsDeferred.then(function (data) {
+                expect(data).to.eql({
+                    layerConfig: 'resources/data/layers/default.json',
+                    treeConfig: 'resources/data/layers/tree.json'
+                });
+            });
+        });
+
+        it('#onApplicationCreated doesn\'t set resourcePathsDeferred if it already exists', function () {
+            mixin.resourcePathsDeferred = new Ext.Deferred();
+            mixin.resourcePathsDeferred.resolve({
+                layerConfig: 'custom/default.json',
+                treeConfig: 'custom/tree.json'
+            });
+
+            mixin.onApplicationCreated();
+
+            return mixin.resourcePathsDeferred.then(function (data) {
+                expect(data).to.eql({
+                    layerConfig: 'custom/default.json',
+                    treeConfig: 'custom/tree.json'
+                });
+            });
+        });
     });
+
 });

--- a/test/spec/view/main/Map.spec.js
+++ b/test/spec/view/main/Map.spec.js
@@ -1,4 +1,15 @@
 describe('CpsiMapview.view.main.Map', function() {
+
+    before(function () {
+        var app = Ext.getApplication ? Ext.getApplication() : Ext.app.Application.instance;
+        app.resourcePathsDeferred = new Ext.Deferred();
+        app.resourcePathsDeferred.resolve({
+            layerConfig: 'resources/data/layers/default.json',
+            treeConfig: 'resources/data/layers/tree.json'
+        });
+    });
+
+
     describe('Basics', function() {
         it('is defined', function() {
             expect(CpsiMapview.view.main.Map).not.to.be(undefined);


### PR DESCRIPTION
This PR allows projects using `cpsi-mapview` to override the location of default.json and tree.json (layerConfig and treeConfig).
By default, current behaviour is maintained. i.e. mapview will load `resources/data/layers/default.json` and `resources/data/layers/tree.json`  unless the project overrides `resourcePathsDeferred`, in which case it can resolve/set any values it needs to.

`Ext.Deferred` is used so that the project can resolve custom paths at some point in future, e.g. after the login event which is fired after the map is initialised.
