### PR TITLE
Allow sending of extra params to login endpoint

### DIFF
--- a/app/controller/form/Login.js
+++ b/app/controller/form/Login.js
@@ -198,15 +198,14 @@ Ext.define('CpsiMapview.controller.form.Login', {
 
         var me = this;
         var view = me.getView();
-
+        var app = Ext.getApplication ? Ext.getApplication() : Ext.app.Application.instance;
         var formValues = view.down('form').getForm().getValues();
         Ext.util.Cookies.set('username', formValues.username);
 
-        var jsonData = Ext.JSON.encode(formValues);
+        var jsonData = Ext.JSON.encode(Ext.Object.merge({}, formValues, app.extraLoginParams));
 
         var serviceUrl = me.getViewModel().serviceUrl;
         me.callLoginService(jsonData, serviceUrl, true);
-
     }
 
 });

--- a/test/spec/view/form/Login.spec.js
+++ b/test/spec/view/form/Login.spec.js
@@ -28,5 +28,27 @@ describe('CpsiMapview.view.form.Login', function() {
 
             ctrlr.attemptLogin();
         });
+
+    });
+
+    describe('extraLoginParams', function() {
+        before(function () {
+            var app = Ext.getApplication ? Ext.getApplication() : Ext.app.Application.instance;
+            app.extraLoginParams = { test: true };
+        });
+
+        it('adds extraLoginParams to serviceUrl post', function () {
+            var inst = Ext.create('CpsiMapview.view.form.Login', {
+                viewModel: {
+                    serviceUrl: '/resources/data/forms/login.json'
+                }
+            });
+            var ctrlr = inst.getController();
+            var spy = sinon.spy(ctrlr, 'callLoginService');
+            ctrlr.attemptLogin();
+            expect(spy.calledOnce);
+            var jsonDataArg = spy.getCall(0).args[0];
+            expect(JSON.parse(jsonDataArg).test).to.be(true);
+        });
     });
 });


### PR DESCRIPTION
This PR allows sending extra params / data to the `authorization/authenticate` endpoint, e.g

`{ "username": "MyUserName", "password": "MyPassword", "loginSourceId": 1 }`

Extra params are defined in `Application.js`, e.g:

```javascript
Ext.define('Some.Application', {
    extend: 'Ext.app.Application',
    //...
    extraLoginParams: { loginSourceId: 1 },
    //...
});
```