### PR TITLE
Ensure the page is loaded before creating application

### DIFF
--- a/app/util/ApplicationMixin.js
+++ b/app/util/ApplicationMixin.js
@@ -227,7 +227,7 @@ Ext.define('CpsiMapview.util.ApplicationMixin', {
         if (me.requireLogin) {
             me.doLogin();
         } else {
-            me.loadApplication();
+            Ext.onReady(me.loadApplication, me);
         }
 
         // add a listener for whenever any button in the map toggleGroup is toggled


### PR DESCRIPTION
Related to #637 - if no login form is used then when attempting to get the application the following line returns null:

https://github.com/compassinformatics/cpsi-mapview/blob/b9d088cb4cf169e8262a54e4646a71b3f3b28108/app/view/main/Map.js#L222

There is then a JS error at:

https://github.com/compassinformatics/cpsi-mapview/blob/b9d088cb4cf169e8262a54e4646a71b3f3b28108/app/view/main/Map.js#L270

This fix delays the creation of the application and appears to resolve the issue.
When a login screen is used then `me.doLogin()` is called and the timing of the application creation seems fine. This is set in `ApplicationMixin.js` with `requireLogin: true`. 