### PR TITLE
Add showGridWindow titleOverride option

### DIFF
--- a/app/util/MenuMixin.js
+++ b/app/util/MenuMixin.js
@@ -7,7 +7,7 @@
 
     mixins: ['CpsiMapview.util.EditWindowOpenerMixin'],
 
-    showGridWindow: function (layerKey) {
+    showGridWindow: function (layerKey, titleOverride) {
 
         // get a layer by layer key - if this is a switch layer only one may have been loaded to the map
         // search for both and take the first layer found
@@ -17,7 +17,7 @@
         // reuse the logic from the menuitem to find any existing grid window, or create
         // a new one
 
-        var menuItem = Ext.create('CpsiMapview.view.menuitem.LayerGrid', { layer: layer });
+        var menuItem = Ext.create('CpsiMapview.view.menuitem.LayerGrid', { layer: layer, titleOverride: titleOverride });
         menuItem.handlerFunc();
         menuItem.destroy();
     },

--- a/app/view/menuitem/LayerGrid.js
+++ b/app/view/menuitem/LayerGrid.js
@@ -18,6 +18,13 @@ Ext.define('CpsiMapview.view.menuitem.LayerGrid', {
     layer: null,
 
     /**
+     * If set, the gridWindow title will be set to this value
+     *
+     * @cfg {String}
+     */
+    titleOverride: null,
+
+    /**
      * Text shown in this MenuItem
      * @cfg {String}
      */
@@ -53,6 +60,10 @@ Ext.define('CpsiMapview.view.menuitem.LayerGrid', {
     handlerFunc: function () {
         var me = this;
         var gridWindow = CpsiMapview.util.Grid.getGridWindow(me.layer);
+
+        if (me.titleOverride) {
+            gridWindow.setTitle(me.titleOverride);
+        }
 
         var grid = gridWindow.down('grid');
         grid.fireEvent('applypresetfilters');


### PR DESCRIPTION
This PR allows a grid window title to be set to a custom value in the scenario where the layer doesn't exist in tree.json (currently where the window title is retrieved from)

Usage:
```
this.showGridWindow(layerKey, 'My Custom Title')
```