### PR TITLE
Move padlock hidden binding to a formula so it can be overridden

### DIFF
--- a/app/form/ViewMixin.js
+++ b/app/form/ViewMixin.js
@@ -35,7 +35,7 @@ Ext.define('CpsiMapview.form.ViewMixin', {
                 xtype: 'tool',
                 callback: 'onPadlockClick',
                 bind: {
-                    hidden: '{currentRecord.phantom}',
+                    hidden: '{!isPadlockVisible}',
                     disabled: '{!canUnlock}',
                     glyph: '{padlockIcon}',
                     tooltip: '{padlockToolText}'

--- a/app/form/ViewModelMixin.js
+++ b/app/form/ViewModelMixin.js
@@ -165,6 +165,19 @@ Ext.define('CpsiMapview.form.ViewModelMixin', {
                     }
                     return !data.currentRecord.isPhantom();
                 }
+            },
+
+            isPadlockVisible: {
+                bind: {
+                    currentRecord: '{currentRecord}',
+                    phantom: '{currentRecord.phantom}'
+                },
+                get: function (data) {
+                    if (!data.currentRecord || !data.currentRecord.isPhantom) {
+                        return false;
+                    }
+                    return !data.currentRecord.isPhantom();
+                }
             }
         }
     }


### PR DESCRIPTION
This PR allows individual form windows hide the padlock icon even if `Application.enableIsLocked` is true. 

To hide the padlock icon for a particular window, set create formula `isPadlockVisible` and return false