### PR TITLE
Force number for NumericField with allowBlank false

### DIFF
--- a/app/form/field/NumericField.js
+++ b/app/form/field/NumericField.js
@@ -79,6 +79,19 @@ Ext.define('CpsiMapview.form.field.NumericField',
                 this.setRawValue(this.rawToValue(this.getRawValue()));
             }
             this.callParent(arguments);
+        },
+
+        /**
+         * Using the keyboard to clear leaves a blank input
+         * even if allowBlank is false or a minValue is defined
+         * This check always forces a number to be present
+         */
+        onChange: function () {
+            var me = this;
+            if (!me.allowBlank && me.getValue() === '') {
+                me.setValue(me.minValue || 0);
+            }
+            this.callParent(arguments);
         }
     }
 );


### PR DESCRIPTION
This PR forces `CpsiMapview.form.field.NumericField` to have a numeric value if `allowBlank === false`.

Currently if you use keyboard backspace or delete to clear the field, the field will be cleared regardless of `allowBlank` or `minValue` settings, and the underlaying model value will be 0, not null as might be expected.