### PR TITLE
Npm prep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ package-lock.json
 .vscode
 /.vs/*
 
+lib/*/
 lib/turf.js

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "lib/geoext3"]
-	path = lib/geoext3
-	url = https://github.com/geoext/geoext3.git
-[submodule "lib/BasiGX"]
-	path = lib/BasiGX
-	url = https://github.com/terrestris/BasiGX.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "lib/geoext3"]
+	path = lib/geoext3
+	url = https://github.com/geoext/geoext3.git
+[submodule "lib/BasiGX"]
+	path = lib/BasiGX
+	url = https://github.com/terrestris/BasiGX.git

--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ sencha app watch
 
 Open http://localhost:1841 in your browser.
 
+## Override dependencies
+
+To debug against the main branches (or a specific commit) of dependencies, update the `classpath` property in `app.json` to use the `lib` folder instead of `node_modues`, and run the following command to clone git submodules:
+```
+git submodule update --init --recursive
+```
+
 ## Docker install
 
 If a simple local server is needed to omit CORS problems, you can use the one configured in `docker-compose.yml`.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Clone this repository
 ```
 git clone https://github.com/compassinformatics/cpsi-mapview.git
 cd cpsi-mapview
-git submodule update --init --recursive
 ```
 
 Ensure that Sencha Cmd is available on the command line. Examples for Windows:
@@ -47,14 +46,12 @@ mklink /D ext D:\Tools\Sencha\ext-6.2.0
 new-item -itemtype symboliclink -path . -name ext -value D:\Tools\Sencha\ext-6.2.0
 ```
 
-Build required turf library:
+Install dependencies:
 
 ```
 npm i
-npm run build:turf
 ```
 
-This will create the required library turf.js (only the needed subset of functions) and put it in `lib/`.
 
 Start dev-server
 

--- a/app.json
+++ b/app.json
@@ -33,9 +33,9 @@
      */
     "classpath": [
         "app",
-        "./lib/geoext3/src",
-        "./lib/geoext3/classic",
-        "./lib/BasiGX/src"
+        "./node_modules/@geoext/geoext/src",
+        "./node_modules/@geoext/geoext/classic",
+        "./node_modules/@terrestris/basigx/src"
     ],
 
     /**

--- a/app.json
+++ b/app.json
@@ -33,6 +33,9 @@
      */
     "classpath": [
         "app",
+        // "./lib/geoext3/src",
+        // "./lib/geoext3/classic",
+        // "./lib/BasiGX/src",
         "./node_modules/@geoext/geoext/src",
         "./node_modules/@geoext/geoext/classic",
         "./node_modules/@terrestris/basigx/src"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "lib": "lib"
   },
   "scripts": {
+    "start": "sencha app watch",
     "lint": "eslint app",
     "jsonlint": "jsonlint -q resources/data/layers/default.json && jsonlint -q resources/data/layers/tree.json",
     "test": "npm run lint && npm run jsonlint && karma start --single-run",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "cpsi-mapview",
-  "version": "1.0.0",
+  "name": "@compassinformatics/cpsi-mapview",
+  "version": "1.0.1",
   "description": "An application using GeoExt and BasiGX",
   "directories": {
     "lib": "lib"
@@ -12,6 +12,7 @@
     "test:watch": "karma start karma-watch.conf.js",
     "test:coverage": "karma start karma.conf.js --single-run --reporters coverage",
     "generate:docs": "jsduck --config=jsduck.json --output=docs-ext --title=\"MapView Documentation\" && cp -r docs-ext build/production/CpsiMapview/docs-ext",
+    "postinstall": "npm run build:turf",
     "build:turf": "browserify turf-builder.js -s turf > lib/turf.js"
   },
   "repository": {
@@ -25,8 +26,10 @@
   },
   "homepage": "https://github.com/compassinformatics/cpsi-mapview#readme",
   "dependencies": {
+    "@geoext/geoext": "4.1",
     "@geoext/openlayers-legacy": "6.5.4",
     "@ogc-schemas/ogc-schemas": "^3.0.0",
+    "@terrestris/basigx": "3.6",
     "@turf/line-offset": "^6.5.0",
     "eslint": "^7.29.0",
     "font-gis": "^1.0.4",
@@ -50,5 +53,17 @@
     "karma-sinon": "1.0.5",
     "mocha": "^9.1.3",
     "sinon": "^12.0.1"
+  },
+  "files": [
+    "./app/",
+    "./resources/",
+    "./sass/",
+    "./lib/.gitkeep",
+    "./turf-builder.js"
+  ],
+  "overrides": {
+    "@terrestris/basigx": {
+      "@geoext/openlayers-legacy": "6.5.4"
+    }
   }
 }


### PR DESCRIPTION
This PR configures `package.json` ready to publish to @compassinformatics npm.

It also removes the need for git submodules, replacing them with `@geoext/geoext` and `@terrestris/basigx` from npm. 
Build config updated to pull in `@geoext/geoext` and `@terrestris/basigx` from `node_modules`
Turf is build postinstall and is included in the npm package so a project like PMS doesn't have to have it's own turf build step.

