### PR TITLE
Prevent user selection of isLegacy records

### DIFF
--- a/app/form/field/ComboLegacy.js
+++ b/app/form/field/ComboLegacy.js
@@ -12,17 +12,22 @@ Ext.define('CpsiMapview.form.field.ComboLegacy', {
     legacyPostfix: ' - Legacy',
 
     /**
-    * Attempt to prevent legacy values from being selected with the keyboard
-    * However using the select event stops the combobox being populated
-    * when a form is loaded
+    * Prevent selection of isLegacy, but only if it is
+    * a user initiated change
     **/
-    //listeners: {
-    //    select: function (combo, record) {
-    //        if (record.get('isLegacy')) {
-    //            combo.clearValue();
-    //        }
-    //    }
-    //},
+    listeners: {
+        focus: function (combo) {
+            combo.__isUserInteracting = true;
+        },
+        blur: function (combo) {
+            combo.__isUserInteracting = false;
+        },
+        select: function (combo, record) {
+            if (combo.__isUserInteracting && record.get('isLegacy')) {
+                combo.clearValue();
+            }
+        }
+    },
 
     /**
      * See https://docs.sencha.com/extjs/6.7.0/classic/Ext.XTemplate.html for docs on templates


### PR DESCRIPTION
This PR prevent users selecting  isLegacy records in cmv_combolegacy.

It only does so during user interacts (user is focused on the input)

Programmatic changes will be ignored (e.g. clicking the Refresh button, since the combo will have lost focus)