### PR TITLE
Add Github action to publish to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: Publish to NPM
+on:
+  release:
+    types: [created]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Publish package on NPM
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR adds an action to publish to NPM on each Github release.

A secret with name NPM_TOKEN needs to be added under Settings > Secrets & Variables > Actions > New repository secret
The value of NPM_TOKEN is stored in LastPass, PMS shared folder (or a new token can be created under your account on npm)

Just before a release is created, the version number in package.json needs to be incremented.



