### PR TITLE
Allow customising role prefixes

### DIFF
--- a/app/controller/button/LoginButtonController.js
+++ b/app/controller/button/LoginButtonController.js
@@ -14,7 +14,7 @@ Ext.define('CpsiMapview.controller.button.LoginButtonController', {
     * The prefix used in the cookie for any browser-based
     * user roles
     * */
-    browserRolePrefix: 'Browser_',
+    displayRolePrefixes: ['Browser_'],
 
     /**
      * Logout, clear the login cookie, and show
@@ -55,20 +55,24 @@ Ext.define('CpsiMapview.controller.button.LoginButtonController', {
     getLoginDetails: function () {
 
         var me = this;
+        var app = Ext.getApplication ? Ext.getApplication() : Ext.app.Application.instance;
         var userName = Ext.util.Cookies.get('username');
         var roles = Ext.util.Cookies.get('roles');
-
+        var displayRolePrefixes = (app && app.displayRolePrefixes) || me.displayRolePrefixes;
         if (roles) {
             roles = roles.split(',');
-            var browserRoles = [];
+            var displayRoles = [];
 
             Ext.Array.each(roles, function (r) {
-                if (r.startsWith(me.browserRolePrefix)) {
-                    browserRoles.push(r.replace(me.browserRolePrefix, ''));
-                }
+                Ext.Array.each(displayRolePrefixes, function (prefix) {
+                    if (r.startsWith(prefix)) {
+                        displayRoles.push(r.replace(prefix, ''));
+                    }
+                });
             });
 
-            roles = browserRoles.join('<br />');
+            displayRoles.sort();
+            roles = displayRoles.join('<br />');
         }
         return Ext.String.format('Username: <b>{0}</b><br />User Roles: <br /><br />{1}', userName, roles);
     },

--- a/test/spec/controller/button/LoginButtonController.spec.js
+++ b/test/spec/controller/button/LoginButtonController.spec.js
@@ -19,6 +19,18 @@ describe('CpsiMapview.controller.button.LoginButtonController', function() {
             expect(text).to.be('Username: <b>test</b><br />User Roles: <br /><br />Role1<br />Role2');
         });
 
+        it('can get roles with different prefixes', function () {
+            var app = Ext.getApplication ? Ext.getApplication() : Ext.app.Application.instance;
+            app.displayRolePrefixes = ['Browser_', 'External_'];
+            var ctrl = new CpsiMapview.controller.button.LoginButtonController();
+
+            Ext.util.Cookies.set('username', 'test');
+            Ext.util.Cookies.set('roles', 'Browser_Role1,External_Role2');
+
+            var text = ctrl.getLoginDetails();
+            expect(text).to.be('Username: <b>test</b><br />User Roles: <br /><br />Role1<br />Role2');
+        });
+
         it('can call onClick which clears login cookie', function () {
             var ctrl = new CpsiMapview.controller.button.LoginButtonController();
 


### PR DESCRIPTION
This PR allows roles other than Browser_ prefixed roles to display in the user details tooltip of the login button.

Prefixes can be customised with the `displayRolePrefixes` property in application.js, e.g.

```
displayRolePrefixes: ['Browser_', 'External_']
```