### PR TITLE
Allow boolean filters in preset filters

### DIFF
--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -865,6 +865,14 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
 
                     column.filter.setValue(filterValue);
                     break;
+                case 'boolean':
+                    // only equal is supported for boolean
+                    if (operator !== '=') {
+                        Ext.log.warn('No valid operator provided.');
+                        return;
+                    }
+                    column.filter.setValue(value);
+                    break;
                 case 'list':
                     // we need to apply the initial config again,
                     // because otherwise the store with the list-choices
@@ -876,7 +884,7 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
                         return;
                     }
 
-                    // now we apply the oparator and the value
+                    // now we apply the operator and the value
                     newFilter.operator = operator;
                     newFilter.value = value;
 
@@ -884,6 +892,7 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
                     plugin.addFilter(newFilter);
                     break;
                 default:
+                    Ext.log.warn('Filters not implemented for columns of type ' + columnType);
                     break;
             }
         });


### PR DESCRIPTION
A follow-up to #410 - this allows preset filters to be added to a boolean column in a grid/layer.

A sample config is shown below. The value can be set to "1"/"0" or "true"/"false". The value can also be without quotes. 

```json
    {
      "layerType": "wms",
      "layerKey": "MY_WMS",
      "gridFilters": [
        {
          "property": "IsActive",
          "value": "1",
          "operator": "="
        }
      ],
```

One minor issue is that the filter UI does not populate correctly in the grids (the filter is set to "No" in the UI, but the value is "Yes" (1). This is the same whether quotes are used around the value or not. 

![image](https://github.com/compassinformatics/cpsi-mapview/assets/490840/0ca351ec-189a-4c26-bdbc-a5c2f041ced0)

