### PR TITLE
Add grep option to karma testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,15 @@ To open in a browser and leave the browser open (to review UI components, debug,
 
 ```
 karma start --browsers Chrome --single-run=False --debug --auto-watch
-
 ```
 
 See also https://glebbahmutov.com/blog/debugging-karma-unit-tests/
+
+To run for single test file you can use the `grep` option:
+
+```
+karma start --single-run --grep 'CpsiMapview.factory.Layer'
+```
 
 ## Production Builds
 

--- a/karma-conf.common.js
+++ b/karma-conf.common.js
@@ -47,6 +47,15 @@ module.exports = function(config) {
             '/CpsiMapview': '/base/app'
         },
 
+        // the following works to limit the tests run
+        // see https://github.com/karma-runner/karma-mocha/issues/192
+        // also https://stackoverflow.com/questions/38876237/karma-start-passing-parameters
+        client: {
+            mocha: {
+                grep: config.grep
+            }
+        },
+
         // frameworks to use
         // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
         frameworks: ['mocha', 'expect', 'sinon'],


### PR DESCRIPTION
Allows running of a single test e.g. `karma start --single-run --grep 'CpsiMapview.factory.Layer'`