### PR TITLE
Update karma testing approach 

### DIFF
--- a/app/view/LayerTree.js
+++ b/app/view/LayerTree.js
@@ -17,10 +17,11 @@ Ext.define('CpsiMapview.view.LayerTree', {
         'CpsiMapview.view.menuitem.LayerMetadata',
         'CpsiMapview.view.menuitem.LayerFilterReset',
         'CpsiMapview.plugin.TreeColumnStyleSwitcher',
+        'CpsiMapview.plugin.TreeColumnInResolutionRange',
         'CpsiMapview.controller.LayerTreeController',
         'CpsiMapview.view.window.MinimizableWindow',
         'CpsiMapview.view.addWms.AddWmsForm',
-        'CpsiMapview.view.addArcGISRest.AddArcGISRestForm'
+        'CpsiMapview.view.addArcGISRest.AddArcGISRestForm',
     ],
 
     controller: 'cmv_layertree',

--- a/app/view/form/LayerTreeFilter.js
+++ b/app/view/form/LayerTreeFilter.js
@@ -9,6 +9,7 @@ Ext.define('CpsiMapview.view.form.LayerTreeFilter', {
     xtype: 'cmv_layertreefilter',
 
     requires: [
+        'CpsiMapview.view.main.Map',
         'CpsiMapview.controller.form.LayerTreeFilter'
     ],
 

--- a/karma-conf.common.js
+++ b/karma-conf.common.js
@@ -25,16 +25,31 @@ module.exports = function(config) {
         'https://cdn.jsdelivr.net/gh/highsource/ogc-schemas@2.6.1/scripts/lib/WPS_1_0_0.js',
         'https://cdn.jsdelivr.net/gh/highsource/w3c-schemas@1.4.0/scripts/lib/XLink_1_0.js',
         'https://cdn.jsdelivr.net/npm/proj4@2.5.0/dist/proj4-src.min.js',
-        'https://maps.googleapis.com/maps/api/js?v=3.42&key=AIzaSyAj6xrC0L3G0YquO1q6Qsma1ZEfYgGQotU',
-        'node_modules/@terrestris/basigx/src/**/*.js',
+        'https://maps.googleapis.com/maps/api/js?v=3.42&key=AIzaSyAj6xrC0L3G0YquO1q6Qsma1ZEfYgGQotU&callback=Function.prototype',
         'lib/turf.js',
         {
+            pattern: 'node_modules/@terrestris/basigx/src/**/*.js',
+            served: true,
+            included: false // or get Duplicate entity name errors
+        },
+        'app/util/Style.js', // ensure this is included first as it is used when defining CpsiMapview.view.toolbar.MapFooter
+        {
             pattern: 'app/**/*.js',
+            watched: true,
+            served: true,
+            included: false
+        },
+        {
+            pattern: 'test/**/*.js',
+            watched: true,
+            served: true,
             included: true
         },
-        'test/test-helper-functions.js',
-        'test/**/*.js',
-        {pattern: 'test/resources/**/*', watched: false, included: false, served: true}
+        {
+            pattern: 'test/resources/**/*',
+            included: false,
+            served: true
+        }
     ];
 
     config.set({

--- a/test/load-tests.js
+++ b/test/load-tests.js
@@ -1,21 +1,39 @@
 // This file is taken from GeoExt3
-(function() {
-    Ext.Loader.setConfig({
-        enabled: true,
-        paths: {
-            'BasiGX': '/BasiGX',
-            'CpsiMapview': '/CpsiMapview'
-        }
+(function () {
+
+    // see https://stackoverflow.com/a/27390799/179520
+
+    // Karma normally starts the tests right after all files specified in 'karma-conf.common.js' have been loaded
+    // We only want the tests to start after Sencha Touch/ExtJS has bootstrapped the application
+    // 1. We temporary override the '__karma__.loaded' function
+    // 2. When Ext is ready we call the '__karma__.loaded' function manually
+
+    var karmaLoadedFunction = window.__karma__.loaded;
+    window.__karma__.loaded = function () { };
+
+
+    Ext.onReady(function () {
+        Ext.Loader.setConfig({
+            enabled: true,
+            disableCaching: false,
+            paths: {
+                'BasiGX': '/BasiGX',
+                'CpsiMapview': '/CpsiMapview'
+            }
+        });
+
+        // create a simple object to mock the application for testing
+        Ext.app.Application.instance = {
+            enableIsLocked: true // enable the padlock icon
+        };
+
+        // mock the getMap function to return a map
+        BasiGX.util.Map.getMapComponent = function () {
+            return Ext.create('GeoExt.component.Map');
+        };
+
+        window.__karma__.loaded = karmaLoadedFunction;
+        window.__karma__.loaded();
     });
-
-    // create a simple object to mock the application for testing
-    Ext.app.Application.instance = {
-        enableIsLocked: true // enable the padlock icon
-    };
-
-    // mock the getMap function to return a map
-    BasiGX.util.Map.getMapComponent = function () {
-        return Ext.create('GeoExt.component.Map');
-    };
 
 }(document, this));

--- a/test/spec/controller/MapController.spec.js
+++ b/test/spec/controller/MapController.spec.js
@@ -1,4 +1,7 @@
-describe('CpsiMapview.controller.MapController', function() {
+describe('CpsiMapview.controller.MapController', function () {
+
+    Ext.Loader.syncRequire(['CpsiMapview.controller.MapController']);
+
     describe('Basics', function() {
         it('is defined', function() {
             expect(CpsiMapview.controller.MapController).not.to.be(undefined);

--- a/test/spec/controller/button/DigitizeButtonController.spec.js
+++ b/test/spec/controller/button/DigitizeButtonController.spec.js
@@ -1,4 +1,7 @@
 describe('CpsiMapview.controller.button.DigitizeButtonController', function () {
+
+    Ext.Loader.syncRequire(['CpsiMapview.controller.button.DigitizeButtonController']);
+
     describe('Basics', function () {
         it('is defined', function () {
             expect(CpsiMapview.controller.button.DigitizeButtonController).not.to.be(undefined);

--- a/test/spec/controller/button/HelpButtonController.spec.js
+++ b/test/spec/controller/button/HelpButtonController.spec.js
@@ -1,4 +1,7 @@
-describe('CpsiMapview.controller.button.HelpButtonController', function() {
+describe('CpsiMapview.controller.button.HelpButtonController', function () {
+
+    Ext.Loader.syncRequire(['CpsiMapview.controller.button.HelpButtonController']);
+
     describe('Basics', function() {
         it('is defined', function() {
             expect(CpsiMapview.controller.button.HelpButtonController).not.to.be(undefined);

--- a/test/spec/controller/button/LoginButtonController.spec.js
+++ b/test/spec/controller/button/LoginButtonController.spec.js
@@ -1,4 +1,7 @@
-describe('CpsiMapview.controller.button.LoginButtonController', function() {
+describe('CpsiMapview.controller.button.LoginButtonController', function () {
+
+    Ext.Loader.syncRequire(['CpsiMapview.controller.button.LoginButtonController']);
+
     describe('Basics', function() {
         it('is defined', function() {
             expect(CpsiMapview.controller.button.LoginButtonController).not.to.be(undefined);

--- a/test/spec/controller/button/SplitByClickButtonController.spec.js
+++ b/test/spec/controller/button/SplitByClickButtonController.spec.js
@@ -1,4 +1,7 @@
-describe('CpsiMapview.controller.button.SplitByClickButtonController', function() {
+describe('CpsiMapview.controller.button.SplitByClickButtonController', function () {
+
+    Ext.Loader.syncRequire(['CpsiMapview.controller.button.SplitByClickButtonController']);
+
     describe('Basics', function() {
         it('is defined', function() {
             expect(CpsiMapview.controller.button.SplitByClickButtonController).not.to.be(undefined);

--- a/test/spec/controller/button/TracingMixin.spec.js
+++ b/test/spec/controller/button/TracingMixin.spec.js
@@ -1,5 +1,7 @@
 describe('CpsiMapview.controller.button.TracingMixin', function () {
 
+    Ext.Loader.syncRequire(['CpsiMapview.controller.button.TracingMixin']);
+
     it('is defined', function () {
         expect(CpsiMapview.controller.button.TracingMixin).not.to.be(undefined);
     });

--- a/test/spec/controller/grid/Grid.spec.js
+++ b/test/spec/controller/grid/Grid.spec.js
@@ -1,4 +1,7 @@
-describe('CpsiMapview.controller.grid.Grid', function() {
+describe('CpsiMapview.controller.grid.Grid', function () {
+
+    Ext.Loader.syncRequire(['CpsiMapview.controller.grid.Grid']);
+
     describe('Basics', function() {
         it('is defined', function() {
             expect(CpsiMapview.controller.grid.Grid).not.to.be(undefined);

--- a/test/spec/controller/grid/GroupEdit.spec.js
+++ b/test/spec/controller/grid/GroupEdit.spec.js
@@ -43,6 +43,9 @@ Ext.define('CpsiMapview.view.TestGroupEditGrid', {
 
 
 describe('CpsiMapview.controller.grid.GroupEditMixin', function () {
+
+    Ext.Loader.syncRequire(['CpsiMapview.controller.grid.GroupEditMixin']);
+
     describe('Basics', function () {
         it('is defined', function () {
             expect(CpsiMapview.controller.grid.GroupEditMixin).not.to.be(undefined);

--- a/test/spec/controller/toolbar/MapTools.spec.js
+++ b/test/spec/controller/toolbar/MapTools.spec.js
@@ -1,5 +1,5 @@
 Ext.Loader.syncRequire(['GeoExt.form.field.GeocoderComboBox',
-    'BasiGX.view.button.Measure', 'CpsiMapview.model.button.MeasureButton']);
+    'BasiGX.view.button.Measure', 'CpsiMapview.controller.toolbar']);
 
 describe('CpsiMapview.controller.toolbar.MapTools', function () {
 

--- a/test/spec/factory/Layer.spec.js
+++ b/test/spec/factory/Layer.spec.js
@@ -1,4 +1,7 @@
 describe('CpsiMapview.factory.Layer', function () {
+    
+    Ext.Loader.syncRequire(['CpsiMapview.factory.Layer']);
+
     var layerFactory = CpsiMapview.factory.Layer;
 
     describe('buildRequiredPropertyNames', function () {

--- a/test/spec/form/ControllerMixin.spec.js
+++ b/test/spec/form/ControllerMixin.spec.js
@@ -11,6 +11,8 @@ Ext.define('CpsiMapview.form.TestController', {
 
 describe('CpsiMapview.form.ControllerMixin', function () {
 
+    Ext.Loader.syncRequire(['CpsiMapview.form.ControllerMixin']);
+
     it('is defined', function () {
         expect(CpsiMapview.form.ControllerMixin).not.to.be(undefined);
     });

--- a/test/spec/form/HelpMixin.spec.js
+++ b/test/spec/form/HelpMixin.spec.js
@@ -6,6 +6,8 @@ Ext.define('CpsiMapview.form.TestHelpController', {
 
 describe('CpsiMapview.form.HelpMixin', function () {
 
+    Ext.Loader.syncRequire(['CpsiMapview.form.HelpMixin']);
+
     it('is defined', function () {
         expect(CpsiMapview.form.HelpMixin).not.to.be(undefined);
     });

--- a/test/spec/form/RightInfoField.spec.js
+++ b/test/spec/form/RightInfoField.spec.js
@@ -1,5 +1,7 @@
 describe('CpsiMapview.form.RightInfoField', function () {
 
+    Ext.Loader.syncRequire(['CpsiMapview.form.RightInfoField']);
+
     it('is defined', function () {
         expect(CpsiMapview.form.RightInfoField).not.to.be(undefined);
     });

--- a/test/spec/form/ViewMixin.spec.js
+++ b/test/spec/form/ViewMixin.spec.js
@@ -19,6 +19,8 @@ Ext.define('CpsiMapview.form.TestWindow', {
 
 describe('CpsiMapview.form.ViewMixin', function () {
 
+    Ext.Loader.syncRequire(['CpsiMapview.form.ViewMixin']);
+
     it('is defined', function () {
         expect(CpsiMapview.form.ViewMixin).not.to.be(undefined);
     });

--- a/test/spec/form/ViewModelMixin.spec.js
+++ b/test/spec/form/ViewModelMixin.spec.js
@@ -10,6 +10,8 @@ Ext.define('CpsiMapview.form.TestViewModel', {
 
 describe('CpsiMapview.form.ViewModelMixin', function () {
 
+    Ext.Loader.syncRequire(['CpsiMapview.form.ViewModelMixin']);
+
     it('is defined', function () {
         expect(CpsiMapview.form.ViewModelMixin).not.to.be(undefined);
     });

--- a/test/spec/form/field/Combo.spec..js
+++ b/test/spec/form/field/Combo.spec..js
@@ -1,5 +1,7 @@
 describe('CpsiMapview.form.field.Combo', function () {
 
+    Ext.Loader.syncRequire(['CpsiMapview.form.field.Combo']);
+
     it('is defined', function () {
         expect(CpsiMapview.form.field.Combo).not.to.be(undefined);
     });

--- a/test/spec/form/field/ComboLegacy.spec.js
+++ b/test/spec/form/field/ComboLegacy.spec.js
@@ -1,5 +1,7 @@
 describe('CpsiMapview.form.field.ComboLegacy', function () {
 
+    Ext.Loader.syncRequire(['CpsiMapview.form.field.ComboLegacy']);
+
     it('is defined', function () {
         expect(CpsiMapview.form.field.ComboLegacy).not.to.be(undefined);
     });

--- a/test/spec/model/FeatureEventsMixin.spec.js
+++ b/test/spec/model/FeatureEventsMixin.spec.js
@@ -1,5 +1,7 @@
 describe('CpsiMapview.model.FeatureEventsMixin', function () {
 
+    Ext.Loader.syncRequire(['BasiGX.util.Layer', 'CpsiMapview.model.FeatureEventsMixin']);
+
     var map;
     var layer1;
     var layer2;

--- a/test/spec/plugin/FeatureInfoWindow.spec.js
+++ b/test/spec/plugin/FeatureInfoWindow.spec.js
@@ -1,5 +1,7 @@
 describe('CpsiMapview.plugin.FeatureInfoWindow', function () {
 
+    Ext.Loader.syncRequire(['CpsiMapview.plugin.FeatureInfoWindow']);
+
     it('is defined', function () {
         expect(CpsiMapview.plugin.FeatureInfoWindow).not.to.be(undefined);
     });

--- a/test/spec/util/Grid.spec.js
+++ b/test/spec/util/Grid.spec.js
@@ -1,4 +1,7 @@
-describe('CpsiMapview.util.Grid', function() {
+describe('CpsiMapview.util.Grid', function () {
+
+    Ext.Loader.syncRequire(['CpsiMapview.util.Grid']);
+
     var cmp = CpsiMapview.util.Grid;
 
     describe('Basics', function() {

--- a/test/spec/util/Layer.spec.js
+++ b/test/spec/util/Layer.spec.js
@@ -1,4 +1,7 @@
 describe('CpsiMapview.util.Layer', function () {
+
+    Ext.Loader.syncRequire(['CpsiMapview.util.Layer']);
+
     var layerUtil = CpsiMapview.util.Layer;
 
     describe('Basics', function () {

--- a/test/spec/util/LayerTreeFilter.spec.js
+++ b/test/spec/util/LayerTreeFilter.spec.js
@@ -18,7 +18,10 @@ var createNode = function(opts) {
     return layerNode;
 };
 
-describe('CpsiMapview.util.LayerTreeFilter', function() {
+describe('CpsiMapview.util.LayerTreeFilter', function () {
+
+    Ext.Loader.syncRequire(['CpsiMapview.util.LayerTreeFilter']);
+
     var layerTreeFilterUtil = CpsiMapview.util.LayerTreeFilter;
 
     describe('Basics', function() {

--- a/test/spec/util/RoleManager.spec.js
+++ b/test/spec/util/RoleManager.spec.js
@@ -1,4 +1,7 @@
 describe('CpsiMapview.util.RoleManager', function () {
+
+    Ext.Loader.syncRequire(['CpsiMapview.util.RoleManager']);
+
     var cmp = CpsiMapview.util.RoleManager;
 
     describe('Basics', function () {

--- a/test/spec/util/Style.spec.js
+++ b/test/spec/util/Style.spec.js
@@ -1,4 +1,5 @@
-describe('CpsiMapview.util.Style', function() {
+describe('CpsiMapview.util.Style', function () {
+    Ext.Loader.syncRequire(['CpsiMapview.util.Style']);
     var styleUtil = CpsiMapview.util.Style;
 
     describe('Basics', function() {

--- a/test/spec/util/Tracing.spec.js
+++ b/test/spec/util/Tracing.spec.js
@@ -1,4 +1,7 @@
 describe('CpsiMapview.util.Tracing', function () {
+
+    Ext.Loader.syncRequire(['CpsiMapview.util.Tracing']);
+
     var util = CpsiMapview.util.Tracing;
 
     describe('Basics', function () {

--- a/test/spec/util/ZoomerMixin.js
+++ b/test/spec/util/ZoomerMixin.js
@@ -1,4 +1,7 @@
-describe('CpsiMapview.util.ZoomerMixin', function() {
+describe('CpsiMapview.util.ZoomerMixin', function () {
+
+    Ext.Loader.syncRequire(['CpsiMapview.util.ZoomerMixin']);
+
     var cmp = CpsiMapview.util.ZoomerMixin;
 
     describe('Basics', function() {

--- a/test/spec/view/LayerTree.spec.js
+++ b/test/spec/view/LayerTree.spec.js
@@ -1,4 +1,7 @@
-describe('CpsiMapview.view.LayerTree', function() {
+describe('CpsiMapview.view.LayerTree', function () {
+
+    Ext.Loader.syncRequire(['CpsiMapview.view.LayerTree']);
+
     describe('Basics', function() {
         it('is defined', function() {
             expect(CpsiMapview.view.LayerTree).not.to.be(undefined);

--- a/test/spec/view/button/HelpButton.spec.js
+++ b/test/spec/view/button/HelpButton.spec.js
@@ -1,4 +1,6 @@
-describe('CpsiMapview.view.button.HelpButton', function() {
+describe('CpsiMapview.view.button.HelpButton', function () {
+    Ext.Loader.syncRequire(['CpsiMapview.view.button.HelpButton']);
+
     describe('Basics', function() {
         it('is defined', function() {
             expect(CpsiMapview.view.button.HelpButton).not.to.be(undefined);


### PR DESCRIPTION
Use `Ext.Loader.syncRequire` to load required classes in tests and wait for `Ext.onReady` to run tests. 

Any test that uses a variable such as `CpsiMapview.controller.grid.Grid` will need to ensure it is loaded for the test by adding:

`Ext.Loader.syncRequire(['CpsiMapview.controller.grid.Grid']);`

Alternatively using `Ext.create("CpsiMapview.controller.grid.Grid")` can be used to dynamically load the test. 

This is an attempt to avoid flaky tests when merging code - see failures at https://github.com/compassinformatics/cpsi-mapview/commits/master
These are mainly due to the test map component being ready causing errors such as `TypeError: Cannot read properties of undefined (reading 'map')`. Overriding the karma loading process, similar to the approach described at https://stackoverflow.com/a/27390799/179520, only runs the tests once the ExtJS framework is ready. 

It also avoids warnings that ExtJS classes have been loaded twice, such as `WARN: '[W] [Ext.define] Duplicate class name 'BasiGX.view.form.CoordinateTransform' specified, must be a non-empty string'`. 

The move to using `syncRequire` highlighted some discrepancies in class names and missing requires which have been addressed in other pull requests. 