### PR TITLE
Snap to ends of lines if node Id properties are present

### DIFF
--- a/app/controller/button/DrawingButtonController.js
+++ b/app/controller/button/DrawingButtonController.js
@@ -515,7 +515,6 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
      * @returns
      */
     getNodeIdFromSnappedEdge: function (edgesLayer, edgeLayerConfig, coord) {
-
         var me = this;
         var nodeId;
 
@@ -529,7 +528,7 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
 
         var startCoord = edge.getGeometry().getFirstCoordinate();
         var startExtent = me.getBufferedCoordExtent(startCoord);
-        var startDistance;
+        var startDistance = null;
 
         if (inputPoint.intersectsExtent(startExtent)) {
             nodeId = edge.get(edgeLayerConfig.startNodeProperty);
@@ -540,12 +539,15 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
         var endExtent = me.getBufferedCoordExtent(endCoord);
 
         if (inputPoint.intersectsExtent(endExtent)) {
-
-            if (startDistance) {
+            var endNodeId = edge.get(edgeLayerConfig.endNodeProperty);
+            if (startDistance !== null) {
+                // if an input coord snaps to both ends of the line, then take the closest end
                 var endDistance = new ol.geom.LineString([coord, endCoord]).getLength();
                 if (endDistance < startDistance) {
-                    nodeId = edge.get(edgeLayerConfig.endNodeProperty);
+                    nodeId = endNodeId;
                 }
+            } else {
+                nodeId = endNodeId;
             }
         }
 

--- a/app/view/button/DrawingButton.js
+++ b/app/view/button/DrawingButton.js
@@ -41,13 +41,13 @@ Ext.define('CpsiMapview.view.button.DrawingButton', {
 
         /**
          * The layerKey values for any vector layers the newly drawn lines should
-         * snap to e.g. ['NETWORKEDGES_WFS']
+         * snap to e.g. ['EDGES_WFS']
          */
         snappingLayerKeys: [],
 
         /**
          * The layerKey values for any vector layers the newly drawn lines should
-         * trace on e.g. ['CHANNELNETWORKVECTOR_WFS', 'NETWORKJUNCTIONS_WFS', 'NETWORKEDGES_WFS']
+         * trace on e.g. ['NODES_WFS', 'EDGES_WFS']
          */
         tracingLayerKeys: [],
 
@@ -62,6 +62,15 @@ Ext.define('CpsiMapview.view.button.DrawingButton', {
          * of newly drawn lines to, and return the edge ids
          */
         edgeLayerKey: null,
+
+        /**
+         * A config object for the vector edgeLayer that is used to
+         * store the property names of the start node and end node if available
+         * This allows snapping to ends of a line without requiring the nodeLayer to
+         * be switched on. the config object should have two properties:
+         * {startNodeProperty: 'nodeIdFrom', endNodeProperty: 'nodeIdTo'}
+         */
+        edgeLayerConfig: null,
 
         /**
          * The vector layer key of a polygon layer to snap the start and ends

--- a/app/view/snappingExample/EdgeWindow.js
+++ b/app/view/snappingExample/EdgeWindow.js
@@ -42,10 +42,14 @@ Ext.define('CpsiMapview.view.snappingExample.EdgeWindow', {
                 bind: {
                     drawLayer: '{resultLayer}' // bind the draw layer to the model's featurestore / layer
                 },
-                snappingLayerKeys: ['SERVICES_WFS', 'NODES_WFS', 'POLYGONS_WFS'],
-                tracingLayerKeys: ['SERVICES_WFS', 'POLYGONS_WFS'],
+                snappingLayerKeys: ['EDGES_WFS', 'NODES_WFS', 'POLYGONS_WFS'],
+                tracingLayerKeys: ['EDGES_WFS', 'POLYGONS_WFS'],
                 nodeLayerKey: 'NODES_WFS',
-                edgeLayerKey: 'SERVICES_WFS',
+                edgeLayerKey: 'EDGES_WFS',
+                edgeLayerConfig: {
+                    startNodeProperty: 'NodeIdFrom',
+                    endNodeProperty: 'NodeIdTo'
+                },
                 polygonLayerKey: 'POLYGONS_WFS'
             }
         }

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -339,7 +339,7 @@
       "noCluster": true,
       "idProperty": "NodeId",
       "openLayers": {
-        "visibility": true,
+        "visibility": false,
         "maxScale": 800000
       }
     },


### PR DESCRIPTION
Currently, if a user doesn't have a vector node layer switched on, and they snap to the end of a line, an edge Id is returned. 
This will require a line to be split if the drawn lines are required for routing - even though the new line snaps to a node. 

This pull request allows node Ids to be picked up from the line if a drawn line snaps to the end. 
A new config property has been added to the tool to set which properties of a line feature contain the node Ids:

```js
  edgeLayerConfig: {
      startNodeProperty: 'NodeIdFrom',
      endNodeProperty: 'NodeIdTo'
  },
```

If this is set then node Ids from the line will take priority over the line id. 

The node Ids will have to be added as properties to the line vector layer. This can be set in the `serverOptions` for a WFS layer in the JSON layer config file:

```js
  {
      "layerKey": "NETWORKEDGES_WFS",
      "layerType": "wfs",
      "idProperty": "ObjectId",
 ...
      ],
      "serverOptions": {
        "propertyname": "ObjectId,IsConnected,NodeIdFrom,NodeIdTo"
      },
```

https://github.com/compassinformatics/cpsi-mapview/assets/490840/56de118c-fa21-422c-937c-e2bf73c4206b


