### PR TITLE
Make a bbox filter optional if required for WFS layers

### DIFF
--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -432,6 +432,12 @@ Ext.define('CpsiMapview.factory.Layer', {
         }
 
         var featureType = layerConf.featureType;
+        var useBbox = true;
+
+        if (Ext.isEmpty(layerConf.useBbox) === false) {
+            useBbox = layerConf.useBbox;
+        }
+
         var geomFieldName = layerConf.geomFieldName ? layerConf.geomFieldName : 'geometry';
         var serverOptions = layerConf.serverOptions || {};
 
@@ -492,17 +498,22 @@ Ext.define('CpsiMapview.factory.Layer', {
 
             var allFilters = CpsiMapview.util.Layer.filterVectorSource(layerSource);
 
-            var bboxFilter = Ext.String.format(
-                GeoExt.util.OGCFilter.spatialFilterBBoxTpl,
-                geomFieldName,
-                params.SRSNAME,
-                extent[0],
-                extent[1],
-                extent[2],
-                extent[3]
-            );
+            // we can skip applying the bbox for a layer if required
+            // by default all layers will use a spatial filter
+            if (useBbox) {
 
-            allFilters.push(bboxFilter);
+                var bboxFilter = Ext.String.format(
+                    GeoExt.util.OGCFilter.spatialFilterBBoxTpl,
+                    geomFieldName,
+                    params.SRSNAME,
+                    extent[0],
+                    extent[1],
+                    extent[2],
+                    extent[3]
+                );
+
+                allFilters.push(bboxFilter);
+            }
 
             // merge all filters to OGC compliant AND filter
             var filter = GeoExt.util.OGCFilter.combineFilters(allFilters, 'And', false, params.VERSION);

--- a/resources/data/layers/default.json
+++ b/resources/data/layers/default.json
@@ -336,6 +336,7 @@
       "layerType": "wfs",
       "layerKey": "NODES_WFS",
       "featureType": "nodes",
+      "useBbox":  false,
       "noCluster": true,
       "idProperty": "NodeId",
       "openLayers": {


### PR DESCRIPTION
Some layers with only a few features are much faster when simply downloading the full layer without applying a bbox filter on the server. This change allows a layer config to ignore bboxes when creating filters. 