### PR TITLE
Match only exact grid xtypes and not Inherited xtypes

### DIFF
--- a/app/util/Grid.js
+++ b/app/util/Grid.js
@@ -22,7 +22,7 @@ Ext.define('CpsiMapview.util.Grid', {
             // we can't keep a reference to the window in this class
             // as a new Ext.menu.Item is created each time the menu is
             // opened - use Ext.ComponentQuery instead
-            var existingGrids = Ext.ComponentQuery.query(gridXType);
+            var existingGrids = Ext.ComponentQuery.query(gridXType + '(true)');
 
             var gridWindowExists =
                 existingGrids.length > 0 &&


### PR DESCRIPTION
See https://docs.sencha.com/extjs/7.7.0/classic/Ext.ComponentQuery.html:

To match only the exact type, pass the "shallow" flag by adding (true) to xtype (See Component's [isXType](https://docs.sencha.com/extjs/7.7.0/classic/Ext.Component.html#method-isXType) method):

`prevTextField = myField.previousNode('textfield(true)');`

This allows us to subclass grids and allow them to be associated with a layer - otherwise only one grid will be shown for both layers. 