### PR TITLE
add the WFS typeName as the fileName

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ bootstrap.jsonp
 
 lib/*/
 lib/turf.js
+.sencha/ide/config.json
+.sencha/.gitignore

--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -503,6 +503,9 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
             params.filter = wfsGetFeatureFilter;
         }
 
+        // pass a filename to MapServer
+        params.fileName = params.typeName;
+
         params.outputFormat = outputFormat;
         // remove the count and startIndex parameters so that all records are exported
         delete params.count;


### PR DESCRIPTION
For export functionality, the fileName can be passed to the OUTPUTFORMAT parameter as a runtime substitution. The corresponding block in a MapFile can be configured as so:
```
    OUTPUTFORMAT
        NAME "xlsx"
        DRIVER "OGR/XLSX"
        MIMETYPE "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet; charset=utf-8"
        FORMATOPTION "FORM=zip"
        FORMATOPTION "STORAGE=memory"
        FORMATOPTION "FILENAME=%filename%.xlsx"
    END
```