### PR TITLE
Add support to filter a WFS in the config file

### DIFF
--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -427,7 +427,7 @@ Ext.define('CpsiMapview.factory.Layer', {
 
         var srid = 'EPSG:3857';
         var mapPanel = CpsiMapview.view.main.Map.guess();
-        if (mapPanel) {
+        if (mapPanel && mapPanel.olMap) {
             srid = mapPanel.olMap.getView().getProjection().getCode();
         }
 
@@ -482,6 +482,15 @@ Ext.define('CpsiMapview.factory.Layer', {
             // empty arrays ensure no PROPERTYNAME param is sent in the request below
             vectorSource.set('propertyNames', []);
             vectorSource.set('originalPropertyNames', []);
+        }
+
+        // add any configured filters for the WFS layer
+        if (layerConf.filters) {
+            var filters = [];
+            Ext.each(layerConf.filters, function (filter) {
+                filters.push(new Ext.util.Filter(filter));
+            });
+            vectorSource.set('additionalFilters', filters);
         }
 
         var loaderFn = function (extent) {

--- a/test/spec/factory/Layer.spec.js
+++ b/test/spec/factory/Layer.spec.js
@@ -65,6 +65,57 @@ describe('CpsiMapview.factory.Layer', function () {
 
         });
 
+
+        it('createWfsLayerWithFilters', function () {
+
+            var layerConf = {
+                "layerKey": "TEST_WFS",
+                "layerType": "wfs",
+                "idProperty": "ObjectId",
+                "noCluster": true,
+                "hasMetadata": true,
+                "featureType": "Test",
+                "styles": [
+                    {
+                        "name": "Test",
+                        "labelRule": "labels",
+                        "title": "Test Layer"
+                    }
+                ],
+                "openLayers": {
+                    "visibility": false,
+                    "opacity": 0.9,
+                    "projection": "EPSG:3857",
+                    "maxScale": 100000
+                },
+                "filters": [
+                    {
+                        "property": "IsActive",
+                        "value": "1",
+                        "operator": "="
+                    }
+                ],
+                "serverOptions": {
+                    "propertyname": "ObjectId"
+                },
+                "tooltipsConfig": [
+                    {
+                        "alias": "ObjectId",
+                        "property": "ObjectId"
+                    }
+                ]
+            };
+
+            var layer = layerFactory.createWfs(layerConf);
+            expect(layer).to.be.a(ol.layer.Vector);
+
+            var filters = layer.getSource().get('additionalFilters');
+            expect(filters.length).to.be(1);
+            expect(filters[0].getOperator()).to.be('=');
+            expect(filters[0].getProperty()).to.be('IsActive');
+            expect(filters[0].getValue()).to.be('1');
+        });
+
     });
 
     describe('buildStyleConfigs', function () {
@@ -292,7 +343,7 @@ describe('CpsiMapview.factory.Layer', function () {
         it('SLD applied to cluster layer', function (done) {
 
             var source = new ol.source.Cluster({
-                source:new ol.source.Vector()
+                source: new ol.source.Vector()
             });
 
             var layer = new ol.layer.Vector({


### PR DESCRIPTION
For WFS layers a new config setting can be added to have a permanent filter in a layer:

```
 "filters": [
      {
          "property": "IsActive",
          "value": "1",
          "operator": "="
      }
  ],
```

This is useful for standalone WFS layers without a grid, but where a filter is required. The filter is added to all requests - including when there are additional WFS filters added - for example the bbox filter. 