### PR TITLE
Remove no longer used magic numbers from digitising tool

### DIFF
--- a/app/controller/button/DrawingButtonController.js
+++ b/app/controller/button/DrawingButtonController.js
@@ -316,9 +316,9 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
         // Checks if a feature exists in layers other than the current layer
         var isFeatureInOtherLayers = function (allLayers, currentLayer, feature) {
             var found = false;
-            Ext.Array.each(allLayers, function(layer) {
-                if(layer !== currentLayer) {
-                    if(layer.getSource().hasFeature(feature)) {
+            Ext.Array.each(allLayers, function (layer) {
+                if (layer !== currentLayer) {
+                    if (layer.getSource().hasFeature(feature)) {
                         found = true;
                     }
                 }
@@ -673,13 +673,6 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
             startPolygonId: startPolygonId,
             endPolygonId: endPolygonId
         };
-
-        // set the node ids on the edge feature itself
-        // as these can be used by a polygon tool / grid
-        // the "magic" number -2 indicates a new node should be created
-        // for the line, rather than snapping to an existing node
-        feature.set('startNodeId', startNodeId ? startNodeId : -2);
-        feature.set('endNodeId', endNodeId ? endNodeId : -2);
 
         // fire an event when the drawing is complete
         var drawSource = me.drawLayer.getSource();

--- a/test/spec/controller/button/DrawingButtonController.spec.js
+++ b/test/spec/controller/button/DrawingButtonController.spec.js
@@ -29,7 +29,7 @@ describe('CpsiMapview.controller.button.DrawingButtonController', function () {
             return map.getInteractions().getArray().filter(function (v) {
                 return v instanceof ol.interaction.Snap;
             });
-        }
+        };
 
         beforeEach(function () {
             // Create the component, then get a reference to the
@@ -79,9 +79,9 @@ describe('CpsiMapview.controller.button.DrawingButtonController', function () {
             getLayersByStub = sinon.stub(BasiGX.util.Layer, 'getLayersBy').callsFake(function (prop, key) {
                 switch (key) {
                     case 'layer1':
-                        return [layer1]
+                        return [layer1];
                     case 'layer2':
-                        return [layer2]
+                        return [layer2];
                 }
             });
         });
@@ -152,7 +152,7 @@ describe('CpsiMapview.controller.button.DrawingButtonController', function () {
             ctrl.setSnapInteraction(drawLayer);
 
             // Clear features from layer1, leaving only layer2 features
-            layer1.getSource().clear()
+            layer1.getSource().clear();
 
             expect(ctrl.snapInteraction.getFeatures_().getLength()).to.be(expectedUniqueFeaturesCount - 1);
         });
@@ -218,7 +218,8 @@ describe('CpsiMapview.controller.button.DrawingButtonController', function () {
         it('can get NodeId from start of snapped edge', function () {
 
             var coord = [0, 0];
-            ctrl.map.getView().setResolution(1); // set a low resolution or the buffer covers both ends of the line
+            // set a low resolution or the buffer covers both ends of the line
+            ctrl.map.getView().setResolution(1);
             var edgesLayer = layer1;
             var edgeLayerConfig = {
                 startNodeProperty: 'nodeIdFrom',
@@ -243,7 +244,7 @@ describe('CpsiMapview.controller.button.DrawingButtonController', function () {
             expect(nodeId).to.be(2);
         });
 
-        it('can calculate line intersections', function () {
+        it('can calculate line intersections', function (done) {
 
             view.snappingLayerKeys = ['layer1', 'layer2'];
 
@@ -261,9 +262,15 @@ describe('CpsiMapview.controller.button.DrawingButtonController', function () {
                 geometry: new ol.geom.LineString([[1, 1], [10, 10]])
             });
 
+
+            drawLayer.getSource().on('localdrawend', function (evt) {
+                // console.log(evt.result);
+                expect(evt.result.startNodeId).to.be(2);
+                expect(evt.result.endNodeId).to.be(null);
+                done();
+            });
+
             ctrl.calculateLineIntersections(inputFeature);
-            expect(inputFeature.get('startNodeId')).to.be(2);
-            expect(inputFeature.get('endNodeId')).to.be(-2);  // indicates not snapped and a new node needs to be created
         });
     });
 });


### PR DESCRIPTION
These were used by a polygon creation tool that no longer requires "magic numbers" of -2 to indicate new nodes.
Other changes to the file are due to auto-formatting. 