### PR TITLE
Allow suffixes to be added to gazetteer field names

### DIFF
--- a/app/view/combo/Gazetteer.js
+++ b/app/view/combo/Gazetteer.js
@@ -27,6 +27,14 @@ Ext.define('CpsiMapview.view.combo.Gazetteer', {
      */
     srs: 'EPSG:3857',
 
+    /**
+     * String to append to the field names
+     * from example if set to '3857' extent field names
+     * will be expected to be in the format minX3857
+     * @cfg {String}
+     */
+    fieldNameSuffix: '3857',
+
     onFocus: Ext.emptyFn,
 
     /**
@@ -87,17 +95,21 @@ Ext.define('CpsiMapview.view.combo.Gazetteer', {
 
     /**
      * Function to convert the data delivered by the Gazetteer service to an
-     * ol.Extent ([minx, miny, maxx, maxy]).
+     * ol.Extent ([minX, minY, maxX, maxY]). If `fieldNameSuffix` is set then
+     * field names such as minX2857 can be supported
      *
      * @param  {Mixed}          v   The data value as read by the Reader
      * @param  {Ext.data.Model} rec The data record containing raw data
      * @return {ol.Extent}          The created ol.Extent
      */
     convertToExtent: function (v, rec) {
-        var minx = rec.get('minX3857');
-        var miny = rec.get('minY3857');
-        var maxx = rec.get('maxX3857');
-        var maxy = rec.get('maxY3857');
+
+        var me = this;
+
+        var minx = rec.get('minX' + me.fieldNameSuffix);
+        var miny = rec.get('minY' + me.fieldNameSuffix);
+        var maxx = rec.get('maxX' + me.fieldNameSuffix);
+        var maxy = rec.get('maxY' + me.fieldNameSuffix);
 
         return [minx, miny, maxx, maxy];
     }

--- a/app/view/combo/Gazetteer.js
+++ b/app/view/combo/Gazetteer.js
@@ -59,6 +59,10 @@ Ext.define('CpsiMapview.view.combo.Gazetteer', {
             })
         });
 
+        // ensure that the scope of convertToExtent is set to this class
+        // so we can get the fieldNameSuffix
+        me.convertToExtent = me.convertToExtent.bind(me);
+
         me.callParent();
 
         me.on({

--- a/test/spec/view/combo/Gazetteer.spec.js
+++ b/test/spec/view/combo/Gazetteer.spec.js
@@ -1,12 +1,54 @@
-describe('CpsiMapview.view.combo.Gazetteer', function() {
-    describe('Basics', function() {
-        it('is defined', function() {
+describe('CpsiMapview.view.combo.Gazetteer', function () {
+
+    Ext.define('TestGazetteerModel', {
+        extend: 'Ext.data.Model',
+
+        fields: [
+            { name: 'minX3857', type: 'float' },
+            { name: 'minY3857', type: 'float' },
+            { name: 'maxX3857', type: 'float' },
+            { name: 'maxY3857', type: 'float' }
+        ],
+
+        // Other configurations for your model can go here
+    });
+
+    describe('Basics', function () {
+        it('is defined', function () {
             expect(CpsiMapview.view.combo.Gazetteer).not.to.be(undefined);
         });
 
-        it('can be instantiated', function() {
+        it('can be instantiated', function () {
             var inst = Ext.create('CpsiMapview.view.combo.Gazetteer', {});
             expect(inst).to.be.a(CpsiMapview.view.combo.Gazetteer);
+        });
+
+        it('can get an extent record', function () {
+            var inst = Ext.create('CpsiMapview.view.combo.Gazetteer', {});
+
+            var rec = Ext.create('TestGazetteerModel', {
+                minX3857: 0,
+                minY3857: 0,
+                maxX3857: 100,
+                maxY3857: 100,
+            });
+
+            var extent = inst.convertToExtent(null, rec);
+            expect(extent.toString()).to.equal([0, 0, 100, 100].toString());
+        });
+
+        it('can get an extent record with alternate field names', function () {
+            var inst = Ext.create('CpsiMapview.view.combo.Gazetteer', { fieldNameSuffix: '2157' });
+
+            var rec = Ext.create('TestGazetteerModel', {
+                minX2157: 0,
+                minY2157: 0,
+                maxX2157: 100,
+                maxY2157: 100,
+            });
+
+            var extent = inst.convertToExtent(null, rec);
+            expect(extent.toString()).to.equal([0, 0, 100, 100].toString());
         });
     });
 });


### PR DESCRIPTION
By default field names are expected to be `minX3857` etc. 
This update allows different suffixes to be added so fields such as `minX2157 can be used, using a new `fieldNameSuffix` config setting on `CpsiMapview.view.combo.Gazetteer`:

Example:

```
{
    xtype: 'cmv_gazetteer_combo',
    url: '/gazetteer/',
    srs: 'EPSG:2157', // also set the project to use for the extents
    fieldNameSuffix: '2157',
    proxyRootProperty: 'data',
    displayValueMapping: 'name',
    emptyText: 'Townland...'
}
```

`Ext.create('CpsiMapview.view.combo.Gazetteer', { fieldNameSuffix: '2157' });`