### PR TITLE
Generate JSON geometry param name from map SRS

### DIFF
--- a/app/controller/button/DigitizeButtonController.js
+++ b/app/controller/button/DigitizeButtonController.js
@@ -814,13 +814,14 @@ Ext.define('CpsiMapview.controller.button.DigitizeButtonController', {
      */
     getNetByPolygon: function (feat) {
         var me = this;
+        var srs = me.map.getView().getProjection().getCode();
         var format = new ol.format.GeoJSON({
-            dataProjection: me.map.getView().getProjection().getCode()
+            dataProjection: srs
         });
         var geoJson = format.writeFeature(feat);
-        var jsonParams = {
-            geometry3857: Ext.JSON.decode(geoJson).geometry
-        };
+        var jsonParams = {};
+        var geometryParamName = 'geometry' + srs.replace('EPSG:', '');
+        jsonParams[geometryParamName] = Ext.JSON.decode(geoJson).geometry;
         return me.doAjaxRequest(jsonParams)
             .then(me.parseNetsolverResponse.bind(me));
     },


### PR DESCRIPTION
This PR removes the hard coded geometry3857 JSON parameter name from DigitizeButton and dynamically generates it based on map projection code.

E.g. if map projection is:
EPSG:3857 - param name will be geometry3857
EPSG:2157 - param name will be geometry2157
etc