### PR TITLE
Allow defining extraPropertyNames in cmv_grid

### DIFF
--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -529,15 +529,17 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
      * the WFS propertyName so only data to
      * be displayed is returned. The idProperty will
      * always be returned even if the column is hidden.
+     * Merge in an extraPropertyNames defined in the viewModel
      */
     getVisibleColumns: function () {
 
         var me = this;
+        var viewModel = me.getViewModel();
         var grid = me.getView();
         var store = grid.getStore();
+        var extraPropertyNames = viewModel.get('extraPropertyNames');
 
         var visibleColumnNames, idProperty;
-
         if (!store.isEmptyStore) {
             visibleColumnNames = Ext.Array.pluck(grid.getVisibleColumns(), 'dataIndex');
             idProperty = store.model.prototype.idField.name;
@@ -550,7 +552,7 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
             // remove any null columns which may have been created by
             // selection checkboxes for example
             visibleColumnNames = Ext.Array.clean(visibleColumnNames);
-            store.propertyName = visibleColumnNames.join(',');
+            store.propertyName = Ext.Array.merge(visibleColumnNames, extraPropertyNames).join(',');
         }
     },
 

--- a/app/model/grid/Grid.js
+++ b/app/model/grid/Grid.js
@@ -25,7 +25,8 @@ Ext.define('CpsiMapview.model.grid.Grid', {
         usePresetFilters: false,
         clearFiltersVisible: true,
         exportExcelVisible: true,
-        exportShapefileVisible: true
+        exportShapefileVisible: true,
+        extraPropertyNames: []
     },
 
     formulas: {

--- a/test/spec/controller/grid/Grid.spec.js
+++ b/test/spec/controller/grid/Grid.spec.js
@@ -33,9 +33,10 @@ describe('CpsiMapview.controller.grid.Grid', function () {
                 var menuItems = menu.down('[itemId=columnItem]').menu.items.items;
                 var orderedTitles = menuItems.map(function (item) {
                     return item.text;
-                })
+                });
 
-                // deep array comparison - original order without sorting would be [ 'Test1', 'Test3', 'Test2' ]
+                // deep array comparison - original order without sorting
+                // would be [ 'Test1', 'Test3', 'Test2' ]
                 expect(orderedTitles).to.eql(['Test1', 'Test2', 'Test3']);
             });
 
@@ -50,6 +51,36 @@ describe('CpsiMapview.controller.grid.Grid', function () {
 
             // trigger the headermenucreate event by clicking a column header dropdown icon
             view.getEl().down('.x-column-header-trigger').dom.click();
+        });
+
+        it('Gets visible columns, adds Id prop and any extra propertyNames', function() {
+            var store = view.getStore();
+            var vm = ctrl.getViewModel();
+
+            vm.set('extraPropertyNames', ['Extra']);
+
+            // emulate a populated store
+            store.isEmptyStore = false;
+
+            // set fixture columns
+            view.setColumns([{
+                text: 'Test1',
+                dataIndex: 'Test1',
+            }, {
+                text: 'Test2',
+                dataIndex: 'Test2',
+                hidden: true,
+            }, {
+                text: 'Test3',
+                dataIndex: 'Test3',
+            }]);
+
+            ctrl.getVisibleColumns();
+
+            // revert back to true to prevent errors in other tests
+            store.isEmptyStore = true;
+
+            expect(store.propertyName).to.be('id,Test1,Test3,Extra');
         });
 
     });


### PR DESCRIPTION
This PR allows setting of extraPropertyNames in the `cmv_grid` viewModel, which is an array of propertyNames which will be added the currently visible grid columns when the WFS is requested.

Useful for when you need a column/property to be present for background processing but there's no guarantee it will be a visible column