### PR TITLE
Allow a configurable hitTolerance

### DIFF
--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -47,7 +47,11 @@ Ext.define('CpsiMapview.view.main.Map', {
     mapViewConfig: {
         projection: 'EPSG:3857',
         zoom: 10,
-        center: [-890555.9263461886, 7076025.276180581] // ol.proj.fromLonLat([-8, 53.5])
+        center: [-890555.9263461886, 7076025.276180581], // ol.proj.fromLonLat([-8, 53.5])
+        // the number of pixels used for 'cmv-mapclick' tolerance
+        // 0 is the OpenLayers default
+        // see https://openlayers.org/en/latest/apidoc/module-ol_Map-Map.html#forEachFeatureAtPixel
+        hitTolerance: 0
     },
 
     /**
@@ -311,6 +315,9 @@ Ext.define('CpsiMapview.view.main.Map', {
                     function (feature, layer) {
                         // collect all clicked features and their layers
                         clickedFeatures.push({ feature: feature, layer: layer });
+                    },
+                    {
+                        hitTolerance: me.mapViewConfig.hitTolerance
                     }
                 );
 


### PR DESCRIPTION
This allows an application to increase the hit tolerance when selecting features. The default is set to the OpenLayers default of `0` so any existing applications will be unaffected. 

It can be applied in the ``Map.js`` file of an application which extends ``CpsiMapview.view.main.Map``

```js
    mapViewConfig: {
        projection: 'EPSG:2157',
        zoom: 11,
        center: [616038, 629971],
        hitTolerance: 3 // use 3 pixels when selecting features, as this makes it easier to select a line
    },
```

This makes it easier to select lines, rather than use the default of 1 pixel. 

Clickable features are set in classes extending from `CpsiMapview.controller.MapController` using the `clickableLayerConfigs`:

```js
    clickableLayerConfigs: {
        'NETWORKEDGES_WFS': {
            keyField: 'ObjectId',
            modelClass: 'Example.model.network.Edge',
            editWindowClass: 'Example.view.edge.EdgeWindow'
        },
```


