### PR TITLE
Ensure new models are only created if they are not already open

### DIFF
--- a/app/controller/MapController.js
+++ b/app/controller/MapController.js
@@ -57,7 +57,7 @@ Ext.define('CpsiMapview.controller.MapController', {
         // Prevent triggering other map events, if we click on the coordinate marker
         var coordinateMousePanel = Ext.ComponentQuery.query('basigx-panel-coordinatemouseposition')[0];
         if (coordinateMousePanel) {
-            var coordinateMarker = Ext.Array.findBy(clickedFeatures, function(clickedFeature) {
+            var coordinateMarker = Ext.Array.findBy(clickedFeatures, function (clickedFeature) {
                 return coordinateMousePanel.fireEvent('isMapMarker', clickedFeature.feature);
             });
             if (coordinateMarker) {
@@ -117,16 +117,26 @@ Ext.define('CpsiMapview.controller.MapController', {
 
             var modelPrototype = Ext.ClassManager.get(modelClass);
 
-            // now load the full record in the appropriate form
-            modelPrototype.load(recId, {
-                success: function (rec) {
-                    // check if the window is already open
-                    var win = me.getEditingFormWindow(rec, editWindowClass);
-                    var vm = win.getViewModel();
-                    vm.set('currentRecord', rec);
+            // check if the window is already open
+            var win = me.getExistingEditingFormWindow(recId, editWindowClass);
+
+            // if the record is not already opened, create a new window and load the record
+            if (win === null) {
+                win = Ext.create(editWindowClass);
+                modelPrototype.load(recId, {
+                    success: function (rec) {
+                        var vm = win.getViewModel();
+                        vm.set('currentRecord', rec);
+                        win.show();
+                    }
+                });
+            } else {
+                // if the window is minimised make sure it is restored
+                if (win.isMinimized) {
                     win.show();
                 }
-            });
+                Ext.WindowManager.bringToFront(win);
+            }
 
             return false; // stop other map handlers
         }

--- a/test/spec/util/EditWindowOpenerMixin.spec.js
+++ b/test/spec/util/EditWindowOpenerMixin.spec.js
@@ -1,0 +1,31 @@
+describe('CpsiMapview.util.EditWindowOpenerMixin', function () {
+
+    Ext.Loader.syncRequire(['CpsiMapview.view.window.MinimizableWindow', 'CpsiMapview.util.EditWindowOpenerMixin']);
+
+    describe('Basics', function () {
+        it('is defined', function () {
+            expect(CpsiMapview.util.EditWindowOpenerMixin).not.to.be(undefined);
+        });
+    });
+
+    describe('Functions', function () {
+        it('getEditingFormWindow', function () {
+
+            var wt = 'CpsiMapview.view.window.MinimizableWindow';
+            var recId = 99;
+            var rec = {
+                getId: function () { return recId }
+            };
+            var win = Ext.create(wt, {
+                viewModel: {
+                    data: {
+                        currentRecord: rec
+                    }
+                }
+            });
+            var mixin = Ext.create('CpsiMapview.util.EditWindowOpenerMixin');
+            var returnedWin = mixin.getEditingFormWindow(rec, wt);
+            expect(returnedWin.id).to.be(win.id);
+        });
+    });
+});


### PR DESCRIPTION
This fixes a bug where if a user clicks twice on the same vector feature, and then closes the window a feature remains on the map.

This is because a model is created on each click, and applied to the open form, but the previous model is not destroyed and so the feature is "orphaned".
