### PR TITLE
Allow custom parameters to be passed to a DELETE service

### DIFF
--- a/app/form/ControllerMixin.js
+++ b/app/form/ControllerMixin.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * A mixin for any edit window controller allowing for
  * validation, saving, deletion, exports etc.
  *
@@ -178,6 +178,15 @@ Ext.define('CpsiMapview.form.ControllerMixin', {
     },
 
     /**
+     * Override this function to return any additional parameters to send to
+     * the Delete URL as a querystring
+     * 
+     * @returns An object of key value pairs
+     */
+    getDeleteParameters: function () {
+        return {};
+    },
+    /**
      * Action for deletion
      * */
     onDelete: function () {
@@ -189,6 +198,7 @@ Ext.define('CpsiMapview.form.ControllerMixin', {
         rec.proxy.erase(Ext.create('Ext.data.operation.Destroy', {
             url: rec.proxy.getUrl(),
             records: [rec],
+            params: me.getDeleteParameters(),
             callback: function (records, operation, success) {
                 w.unmask();
                 // do something whether the delete succeeded or failed

--- a/app/form/ControllerMixin.js
+++ b/app/form/ControllerMixin.js
@@ -180,7 +180,7 @@ Ext.define('CpsiMapview.form.ControllerMixin', {
     /**
      * Override this function to return any additional parameters to send to
      * the Delete URL as a querystring
-     * 
+     *
      * @returns An object of key value pairs
      */
     getDeleteParameters: function () {


### PR DESCRIPTION
A new placeholder function has been added that can be overridden in a subclass to allow parameters to be passed to a DELETE service via the querystring.

For example, in a controller that inherits from `CpsiMapview.form.ControllerMixin` `getDeleteParameters` can be added to return an object of key value pairs:

```js
    getDeleteParameters: function () {
        var me = this;
        var myCustomParam= me.getViewModel().get('myCustomParam');
        return {
            myCustomParam: myCustomParam
        };
    }
```

The DELETE calls with then include a querystring e.g. `/object/12432?myCustomParam=abc`

This should have no effect on any existing code or classes. 