### PR TITLE
Add null guard when checking for opened windows

### DIFF
--- a/app/controller/MapController.js
+++ b/app/controller/MapController.js
@@ -128,6 +128,14 @@ Ext.define('CpsiMapview.controller.MapController', {
                         var vm = win.getViewModel();
                         vm.set('currentRecord', rec);
                         win.show();
+                    },
+                    failure: function (rec) {
+                        Ext.toast({
+                            html: 'Cannot load the record with id ' + recId,
+                            title: 'Record Loading Failed',
+                            width: 200,
+                            align: 'br'
+                        });
                     }
                 });
             } else {

--- a/app/controller/MapController.js
+++ b/app/controller/MapController.js
@@ -129,7 +129,7 @@ Ext.define('CpsiMapview.controller.MapController', {
                         vm.set('currentRecord', rec);
                         win.show();
                     },
-                    failure: function (rec) {
+                    failure: function () {
                         Ext.toast({
                             html: 'Cannot load the record with id ' + recId,
                             title: 'Record Loading Failed',

--- a/app/util/EditWindowOpenerMixin.js
+++ b/app/util/EditWindowOpenerMixin.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * A mixin for any menu controller or window controller which
  * needs to check if a model is already opened in a window.
  *
@@ -20,7 +20,9 @@ Ext.define('CpsiMapview.util.EditWindowOpenerMixin', {
 
         Ext.each(existingWindows, function (w) {
             rec = w.getViewModel().get('currentRecord');
-            if (rec.getId() == recId) {
+            // if the window has been opened but the model failed to load
+            // then rec can be null
+            if (rec && rec.getId() == recId) {
                 recordWindow = w;
                 return false;
             }


### PR DESCRIPTION
Add a toast pop-up informing a user if a record fails to load when clicking on a map. Also fix a bug where if the record fails to load then the form no longer opens for valid records are `rec` is null which then causes a `TypeError: Cannot read properties of null (reading 'getId')` error. 