### PR TITLE
Add parentRecord property to Drawing Tool for advanced snapping logic

### DIFF
--- a/app/controller/button/DrawingButtonController.js
+++ b/app/controller/button/DrawingButtonController.js
@@ -399,7 +399,24 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
         });
 
         if (features.length > 0) {
-            return features[0];
+            var selectedFeat = null;
+            var parentRec = me.getView().getParentRecord();
+            if (parentRec) {
+                features.forEach(function (feat) {
+                    if (feat.getId() !== parentRec.getId()) {
+                        // the found feature does not share the same Id as the associated record
+                        // this allows us to avoid snapping a feature to itself
+                        selectedFeat = feat;
+                        return false;
+                    }
+                });
+            }
+
+            if (!selectedFeat) {
+                selectedFeat = features[0]; // by default return the first feature
+            }
+
+            return selectedFeat;
         } else {
             return null;
         }
@@ -722,26 +739,26 @@ Ext.define('CpsiMapview.controller.button.DrawingButtonController', {
             }
         }
 
-        me.prepareDrawingStyles();
+        if (!me.defaultDrawStyle) {
+            me.prepareDrawingStyles();
+            // set initial style for drawing features
+            me.defaultDrawStyle = [
+                view.getDrawBeforeEditingPoint(),
+                view.getDrawStyleStartPoint(),
+                view.getDrawStyleLine(),
+                view.getDrawStyleEndPoint(),
+            ];
+            me.drawLayer.setStyle(me.defaultDrawStyle);
 
-        // set initial style for drawing features
-        me.defaultDrawStyle = [
-            view.getDrawBeforeEditingPoint(),
-            view.getDrawStyleStartPoint(),
-            view.getDrawStyleLine(),
-            view.getDrawStyleEndPoint(),
-        ];
-        me.drawLayer.setStyle(me.defaultDrawStyle);
-
-        me.setDrawInteraction(me.drawLayer);
-        me.setModifyInteraction(me.drawLayer);
-        me.setSnapInteraction(me.drawLayer);
+            me.setDrawInteraction(me.drawLayer);
+            me.setModifyInteraction(me.drawLayer);
+            me.setSnapInteraction(me.drawLayer);
+        }
 
         var viewPort = me.map.getViewport();
 
-        var tracingLayerKeys = view.getTracingLayerKeys();
-
         if (pressed) {
+            var tracingLayerKeys = view.getTracingLayerKeys();
 
             me.initTracing(
                 tracingLayerKeys,

--- a/app/view/button/DrawingButton.js
+++ b/app/view/button/DrawingButton.js
@@ -141,7 +141,12 @@ Ext.define('CpsiMapview.view.button.DrawingButton', {
          * defined in snappingLayerKeys, or snapping to layer features even if they
          * are invisible.
          */
-        allowSnapToHiddenFeatures: false
+        allowSnapToHiddenFeatures: false,
+
+        /**
+        * The ExtJS record associated with the tool (if any), that can be used to apply snapping logic
+        */
+        parentRecord: null,
     },
 
     /**

--- a/test/spec/controller/button/DrawingButtonController.spec.js
+++ b/test/spec/controller/button/DrawingButtonController.spec.js
@@ -21,6 +21,7 @@ describe('CpsiMapview.controller.button.DrawingButtonController', function () {
         var drawLayer;
         var layer1;
         var layer2;
+        var layer3;
         var getLayersByStub;
         // change in future if test layers get more features
         var expectedUniqueFeaturesCount = 3;
@@ -71,6 +72,32 @@ describe('CpsiMapview.controller.button.DrawingButtonController', function () {
                             geometry: new ol.geom.LineString([[0, 0], [1, 1]])
                         }),
                         sharedFeature
+                    ]
+                })
+            });
+
+            var feat3 = new ol.Feature({
+                geometry: new ol.geom.LineString([[0, 0], [1, 1]]),
+                nodeIdFrom: 1,
+                nodeIdTo: 2
+            });
+
+            feat3.setId(3);
+
+            var feat4 = new ol.Feature({
+                geometry: new ol.geom.LineString([[1, 1], [2, 2]]),
+                nodeIdFrom: 2,
+                nodeIdTo: 3
+            });
+
+            feat4.setId(4);
+
+            layer3 = new ol.layer.Vector({
+                isWfs: true,
+                source: new ol.source.Vector({
+                    features: [
+                        feat3,
+                        feat4
                     ]
                 })
             });
@@ -271,6 +298,29 @@ describe('CpsiMapview.controller.button.DrawingButtonController', function () {
             });
 
             ctrl.calculateLineIntersections(inputFeature);
+        });
+
+        it('snap to self at an intersection', function () {
+
+            var coord = [1, 1];
+            ctrl.map.getView().setResolution(1);
+            var selectedFeat = ctrl.getSnappedEdge(coord, layer3);
+            expect(selectedFeat.getId()).to.be(3);
+        });
+        it('avoid snapping an edge to itself at an intersection by setting an associated record', function () {
+
+            var coord = [1, 1];
+
+            // associate a record with the controller
+            // mock a record with a getId function
+            var rec = {
+                getId: function () { return 3 } // 1 matches the Id of feat1
+            };
+            ctrl.getView().setParentRecord(rec);
+            ctrl.map.getView().setResolution(1);
+
+            var selectedFeat = ctrl.getSnappedEdge(coord, layer3);
+            expect(selectedFeat.getId()).to.be(4);
         });
     });
 });


### PR DESCRIPTION
Allow a record to be associated with the drawing tool to avoid snapping features to themselves by checking if the current Id is the same as the snapped-to Id. 

A new `parentRecord` property is added to the button view. A record can then be bound to this property.

```js
            button: {
                xtype: 'cmv_drawing_button',
                bind: {
                    disabled: '{!canDraw}',
                    parentRecord: '{currentRecord}',
                    drawLayer: '{resultLayer}' // bind the draw layer to the model's featurestore / layer
                },
...
```

In the controller logic if multiple edges are found when snapping to an edge, edges with a different Id to the currently edited feature are selected. If only one edge is found then this is returned.

The use case is to allow errors in `nodeIdTo` and `nodeIdFrom` to be fixed for an edge being modified. Currently if a user modifies an edge and resnaps to the same start or end point the edge currently being modified is always returned first, and the node Id never changes. This pull request selects a different edge and gets the nodeIds from the alternate edge. 
