### PR TITLE
Add support for EPSG:102100

### DIFF
--- a/app/view/main/Map.js
+++ b/app/view/main/Map.js
@@ -218,6 +218,10 @@ Ext.define('CpsiMapview.view.main.Map', {
         proj4.defs('EPSG:2157', '+proj=tmerc +lat_0=53.5 +lon_0=-8 +k=0.99982 +x_0=600000 +y_0=750000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
         proj4.defs('EPSG:29902', '+proj=tmerc +lat_0=53.5 +lon_0=-8 +k=1.000035 +x_0=200000 +y_0=250000 +ellps=mod_airy +towgs84=482.5,-130.6,564.6,-1.042,-0.214,-0.631,8.15 +units=m +no_defs');
 
+        // support deprecated ESRI code for EPSG3857
+        // see https://support.esri.com/en-us/knowledge-base/why-does-arcgis-online-use-a-deprecated-spatial-referen-000013950
+        proj4.defs('EPSG:102100', '+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs');
+
         ol.proj.proj4.register(proj4);
 
         // use app settings when available for zoom and center


### PR DESCRIPTION
Used by some ESRI services. See this article https://support.esri.com/en-us/knowledge-base/why-does-arcgis-online-use-a-deprecated-spatial-referen-000013950

> from the REST endpoint of a hosted service, the spatial reference being used may appear as 102100 (3857). This is an expected behavior