### PR TITLE
Add a new permalink button

### DIFF
--- a/app/controller/button/PermalinkButtonController.js
+++ b/app/controller/button/PermalinkButtonController.js
@@ -1,0 +1,44 @@
+/**
+ * This class is the controller for the {@link CpsiMapview.view.button.PermalinkButton} button.
+ */
+Ext.define('CpsiMapview.controller.button.PermalinkButtonController', {
+    extend: 'Ext.app.ViewController',
+
+    alias: 'controller.cmv_permalink_button',
+    /**
+    * Zoom to a permalink
+    **/
+    onPermalinkClick: function () {
+
+        const me = this;
+        const defaultValue = window.location.href;
+        const dialogWidth = me.getView().dialogWidth;
+        const cfg = {
+            prompt: true,
+            title: 'Zoom to Permalink',
+            minWidth: dialogWidth,
+            message: 'Please enter the permalink below:',
+            buttons: Ext.Msg.OKCANCEL,
+            callback: function (btn, text) {
+                if (btn == 'ok') {
+                    var map = me.getView().up('cmv_map');
+                    var parts = text.split('#map='); // only get the permalink from the URL
+                    var permalink = null;
+
+                    if (parts.length === 2) {
+                        permalink = parts[1];
+                        map.mapCmp.applyState(
+                            map.permalinkProvider.readPermalinkHash(permalink)
+                        );
+                    }
+                }
+            },
+            scope: me,
+            multiline: false,
+            value: defaultValue
+        };
+
+        Ext.Msg.prompt(cfg);
+    },
+
+});

--- a/app/view/button/PermalinkButton.js
+++ b/app/view/button/PermalinkButton.js
@@ -1,0 +1,46 @@
+/**
+ * This class is a button to open a prompt allowing
+ * permalinks to entered and zoomed to, without reloading the application
+ *
+ * @class CpsiMapview.view.button.PermalinkButton
+ */
+Ext.define('CpsiMapview.view.button.PermalinkButton', {
+    extend: 'Ext.button.Button',
+    xtype: 'cmv_permalink_button',
+
+    requires: [
+        'CpsiMapview.controller.button.PermalinkButtonController'
+    ],
+
+    tooltip: 'Zoom to a Permalink',
+
+    /**
+     * The icon the button should use
+     */
+    iconCls: 'x-fa fa-anchor',
+
+    /**
+     * The controller for this class
+     */
+    controller: 'cmv_permalink_button',
+
+    /**
+     * The name to be used e.g. in ComponentQueries
+     */
+    name: 'permalinkButton',
+
+    config: {
+
+        /**
+         * Width of the associated Ext.Msg.prompt dialog
+         */
+        dialogWidth: 400,
+    },
+    /**
+     * Register the listeners and redirect them
+     * to their corresponding controller methods
+     */
+    listeners: {
+        click: 'onPermalinkClick'
+    }
+});

--- a/app/view/toolbar/MapTools.js
+++ b/app/view/toolbar/MapTools.js
@@ -18,6 +18,7 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
         'CpsiMapview.controller.toolbar.MapTools',
         'CpsiMapview.model.toolbar.MapToolsModel',
         'CpsiMapview.view.combo.Gazetteer',
+        'CpsiMapview.view.button.PermalinkButton',
         'CpsiMapview.view.button.StreetViewTool',
         'CpsiMapview.view.panel.TimeSlider',
         'CpsiMapview.view.panel.NumericAttributeSlider',
@@ -152,6 +153,9 @@ Ext.define('CpsiMapview.view.toolbar.MapTools', {
                         this.getController().onResponseFeatures();
                     }
                 }
+            }, {
+                xtype: 'cmv_permalink_button',
+                dialogWidth: 500
             }, {
                 xtype: 'cmv_streetview_tool',
                 toggleGroup: 'map',

--- a/test/spec/view/button/PermalinkButton.spec.js
+++ b/test/spec/view/button/PermalinkButton.spec.js
@@ -1,0 +1,19 @@
+describe('CpsiMapview.view.button.PermalinkButton', function () {
+    Ext.Loader.syncRequire(['CpsiMapview.view.button.PermalinkButton']);
+
+    describe('Basics', function () {
+        it('is defined', function () {
+            expect(CpsiMapview.view.button.PermalinkButton).not.to.be(undefined);
+        });
+
+        it('can be instantiated', function () {
+            var inst = Ext.create('CpsiMapview.view.button.PermalinkButton');
+            expect(inst).to.be.a(CpsiMapview.view.button.PermalinkButton);
+        });
+
+        it('can be instantiated with a custom dialog size', function () {
+            var inst = Ext.create('CpsiMapview.view.button.PermalinkButton', { dialogWidth: 550 });
+            expect(inst.getController().getView().dialogWidth).to.equal(550);
+        });
+    });
+});


### PR DESCRIPTION
This adds a new button that opens a prompt allowing permalinks to be zoomed to - without having to reload the application, or open in a new tab.

![image](https://github.com/user-attachments/assets/6b5c1a9e-84bf-43cd-be47-c14af4a8e579)

![image](https://github.com/user-attachments/assets/e1be3994-cacd-41b6-ae19-2f347492c517)

To add the component, include `CpsiMapview.view.button.PermalinkButton` in the `requires`, and then define as follows:

```js
{
    xtype: 'cmv_permalink_button',
    dialogWidth: 500 // this can be used to set the width of the prompt text field
},
```
