### PR TITLE
Add override for bug in Ext.grid.header.Container in ExtJS 7.8

### DIFF
--- a/app/overrides/Ext.grid.header.Container.js
+++ b/app/overrides/Ext.grid.header.Container.js
@@ -1,0 +1,21 @@
+﻿Ext.override(Ext.grid.header.Container, {
+    getHeaderMenu: function () {
+        var menu = this.getMenu(),
+            item;
+
+        if (menu) {
+            item = menu.child('#columnItem');
+            // no check to see if item is null here
+            // TypeError: Cannot read properties of null (reading 'menu')
+            // so move within guard block
+            // item.menu.hideOnScroll = false;
+
+            if (item) {
+                item.menu.hideOnScroll = false;
+                return item.menu;
+            }
+        }
+
+        return null;
+    },
+});


### PR DESCRIPTION
After updating from ExtJS 6.7 to 7.8 ran into a bug with grid column headers.

In 6.7 this code works fine: https://docs.sencha.com/extjs/6.7.0/classic/src/Container.js-5.html

```js
getHeaderMenu: function() {
        var menu = this.getMenu(),
            item;
 
        if (menu) {
            item = menu.child('#columnItem');
 
            if (item) {
                return item.menu;
            }
        }
 
        return null;
    },

```

In 7.8 `item` is null yet the code tries to access item.menu throwing an error (when moving a column and then calling `onGroupEditToggle` in `CpsiMapview.controller.grid.GroupEditMixin`.

https://docs.sencha.com/extjs/7.8.0/classic/src/Container.js-5.html

```js
    getHeaderMenu: function() {
        var menu = this.getMenu(),
            item;
 
        if (menu) {
            item = menu.child('#columnItem');
            // ERROR - no check to see if item is null here
            // TypeError: Cannot read properties of null (reading 'menu')
            item.menu.hideOnScroll = false;
 
            if (item) {
                return item.menu;
            }
        }
 
        return null;
    },
```