### PR TITLE
Allow setting absolute path in groupEditService

### DIFF
--- a/app/controller/grid/GroupEditMixin.js
+++ b/app/controller/grid/GroupEditMixin.js
@@ -186,12 +186,12 @@ Ext.define('CpsiMapview.controller.grid.GroupEditMixin', {
             buttons: Ext.Msg.YESNO,
             scope: me,
             fn: function (buttonId) {
+                var idProperty, serviceUrl;
+                var data = {};
 
                 if (buttonId == 'yes') {
+                    idProperty = activeHeader.groupEditIdProperty || me.getViewModel().get('idProperty');
 
-                    var data = {};
-                    var idProperty = me.getViewModel().get('idProperty');
-                    var serviceUrl;
                     if (activeHeader.groupEditService.charAt(0) === '/') {
                         serviceUrl = activeHeader.groupEditService;
                     } else {

--- a/app/controller/grid/GroupEditMixin.js
+++ b/app/controller/grid/GroupEditMixin.js
@@ -191,7 +191,12 @@ Ext.define('CpsiMapview.controller.grid.GroupEditMixin', {
 
                     var data = {};
                     var idProperty = me.getViewModel().get('idProperty');
-                    var serviceUrl = me.getViewModel().get('serviceUrl') + activeHeader.groupEditService;
+                    var serviceUrl;
+                    if (activeHeader.groupEditService.charAt(0) === '/') {
+                        serviceUrl = activeHeader.groupEditService;
+                    } else {
+                        serviceUrl = me.getViewModel().get('serviceUrl') + activeHeader.groupEditService;
+                    }
 
                     // first char to lower case to match backend naming
                     idProperty = idProperty[0].toLowerCase() + idProperty.slice(1);


### PR DESCRIPTION
This PR allows overriding the serviceUrl generated from `groupEditService` property

If the property is set as is in existing codebases, the `groupEditService` value is appended to viewModel `serviceUrl` value (current behaviour)
```js
{
    groupEditable: true,
    groupEditService: 'isgreenway',
    groupEditDataProp: 'isGreenway',
}
```

If the property starts with a forward slash, `groupEditService` value is used as is, without appending it to viewModel `serviceUrl`
```js
{
    groupEditable: true,
    groupEditService: '/WebServices/namespace/override',
    groupEditDataProp: 'isGreenway',
}
```