### PR TITLE
Add null guard check for selectStyle

### DIFF
--- a/app/form/ViewModelMixin.js
+++ b/app/form/ViewModelMixin.js
@@ -100,7 +100,11 @@ Ext.define('CpsiMapview.form.ViewModelMixin', {
                 },
                 get: function (data) {
                     var layer = data.resultLayer;
-                    return layer.get('selectStyle');
+                    if (layer) {
+                        return layer.get('selectStyle');
+                    } else {
+                        return null;
+                    }
                 }
             },
 


### PR DESCRIPTION
Allows records to be destroyed, without breaking bindings. 