### PR TITLE
Destroy any duplicate records when already opened in a window

### DIFF
--- a/app/util/MenuMixin.js
+++ b/app/util/MenuMixin.js
@@ -1,4 +1,4 @@
-﻿Ext.define('CpsiMapview.util.MenuMixin', {
+Ext.define('CpsiMapview.util.MenuMixin', {
     extend: 'Ext.Mixin',
     requires: [
         'BasiGX.util.Layer',
@@ -33,6 +33,13 @@
         if (!vm.get('currentRecord')) {
             // for a new window set the currentRecord to the model
             vm.set('currentRecord', record);
+        } else {
+            // we can destroy the record as it is already in the window
+            var currentRecord = vm.get('currentRecord');
+            if (currentRecord.getId() === record.getId()) {
+                // check again that the Ids match
+                record.destroy();
+            }
         }
 
         win.show();

--- a/test/spec/util/MenuMixin.spec.js
+++ b/test/spec/util/MenuMixin.spec.js
@@ -1,0 +1,46 @@
+describe('CpsiMapview.util.MenuMixin', function () {
+
+    Ext.Loader.syncRequire(['CpsiMapview.view.window.MinimizableWindow', 'CpsiMapview.util.MenuMixin']);
+
+    describe('Basics', function () {
+        it('is defined', function () {
+            expect(CpsiMapview.util.MenuMixin).not.to.be(undefined);
+        });
+    });
+
+    describe('Functions', function () {
+        it('showEditWindow duplicate record is destroyed', function () {
+
+            var wt = 'CpsiMapview.view.window.MinimizableWindow';
+            var recId = 99;
+
+            var rec1 = {
+                getId: function () { return recId },
+                isDestroyed: false,
+                destroy: function () {
+                    this.isDestroyed = true;
+                }
+            };
+
+            var rec2 = {
+                getId: function () { return recId },
+                isDestroyed: false,
+                destroy: function () {
+                    this.isDestroyed = true;
+                }
+            };
+
+            Ext.create(wt, {
+                viewModel: {
+                    data: {
+                        currentRecord: rec1
+                    }
+                }
+            });
+            var mixin = Ext.create('CpsiMapview.util.MenuMixin');
+            mixin.showEditWindow(wt, rec2)
+            expect(rec1.isDestroyed).to.be(false);
+            expect(rec2.isDestroyed).to.be(true);
+        });
+    });
+});


### PR DESCRIPTION
This fixes an issue where the same record is opened twice. The new feature is not associated with the edit window and leaves a feature on the map even when the window is closed. To avoid this if a matching record is found in the form, the new record is destroyed. 