### PR TITLE
Fix icon for Font Awesome 5

### DIFF
--- a/app/view/button/SplitByClickButton.js
+++ b/app/view/button/SplitByClickButton.js
@@ -29,7 +29,7 @@ Ext.define('CpsiMapview.view.button.SplitByClickButton', {
     /**
      * The icon (scissors) used for the button
      */
-    iconCls: 'x-fa fa-scissors',
+    iconCls: 'x-fas fa-cut',
 
     config: {
         /**


### PR DESCRIPTION
For a full list of available icons in the ExtJS FontAwesome package see `ext/packages/font-awesome/sass/etc/_icons.scss`. 
