### PR TITLE
Added management for unfound layers

### DIFF
--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -647,9 +647,9 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
         }
 
         if (!layer) {
-            // Warn the user/developer that there is probably a configuration mismatch between a grid config and the layer tree layers.
+            // warn the developer of a configuration mismatch between the config for the grid and the layer tree
             Ext.log.warn(
-                '[CpsiMapview.controller.grid.Grid getOlLayer() ] - No layer found for a grid (' +
+                '[CpsiMapview.controller.grid.Grid getOlLayer() ] - No layer found for grid (' +
                 viewModel.type +
                 ') using one of these keys: wmsLayerKey / vectorLayerKey',
                 wmsLayerKey,
@@ -883,7 +883,7 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
         const layer = me.getOlLayer();
 
         if (!layer) {
-            //No action taken in applyPresetFilters - no layer found that this grid might require.
+            // return if no layer found for the grid
             return;
         }
 

--- a/app/controller/grid/Grid.js
+++ b/app/controller/grid/Grid.js
@@ -646,6 +646,17 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
             layer = me.getLayerByKey(vectorLayerKey);
         }
 
+        if (!layer) {
+            // Warn the user/developer that there is probably a configuration mismatch between a grid config and the layer tree layers.
+            Ext.log.warn(
+                '[CpsiMapview.controller.grid.Grid getOlLayer() ] - No layer found for a grid (' +
+                viewModel.type +
+                ') using one of these keys: wmsLayerKey / vectorLayerKey',
+                wmsLayerKey,
+                vectorLayerKey
+            );
+        }
+
         return layer;
     },
 
@@ -870,6 +881,12 @@ Ext.define('CpsiMapview.controller.grid.Grid', {
         const me = this;
 
         const layer = me.getOlLayer();
+
+        if (!layer) {
+            //No action taken in applyPresetFilters - no layer found that this grid might require.
+            return;
+        }
+
         const gridFilters = layer.get('gridFilters');
 
         if (!gridFilters || !Ext.isArray(gridFilters)) {


### PR DESCRIPTION
Mistakes (e.g. duplicate layer keys in the default layer *.json file) result in no layer found. That trigger an exception that stop some layer names to be rendered in the layertree. This pull request manage the exception and give feedback on what the configuration error might be.