### PR TITLE
Filter out any keys with no layers in SnappingMixin

### DIFF
--- a/app/controller/button/SnappingMixin.js
+++ b/app/controller/button/SnappingMixin.js
@@ -85,10 +85,9 @@ Ext.define('CpsiMapview.controller.button.SnappingMixin', {
         const layerKeys = view.getSnappingLayerKeys();
         const allowSnapToHiddenFeatures = view.getAllowSnapToHiddenFeatures();
 
-        const mapLayers = me.map.getLayers().getArray();
         const layers = Ext.Array.filter(
             Ext.Array.map(layerKeys, function (key) {
-                const foundLayers = BasiGX.util.Layer.getLayersBy('layerKey', key, mapLayers);
+                const foundLayers = BasiGX.util.Layer.getLayersBy('layerKey', key);
 
                 if (foundLayers.length === 1 && foundLayers[0]) {
                     return foundLayers[0];

--- a/app/controller/button/SnappingMixin.js
+++ b/app/controller/button/SnappingMixin.js
@@ -84,9 +84,22 @@ Ext.define('CpsiMapview.controller.button.SnappingMixin', {
         const view = me.getView();
         const layerKeys = view.getSnappingLayerKeys();
         const allowSnapToHiddenFeatures = view.getAllowSnapToHiddenFeatures();
-        const layers = Ext.Array.map(layerKeys, function (key) {
-            return BasiGX.util.Layer.getLayersBy('layerKey', key)[0];
-        });
+
+        const mapLayers = me.map.getLayers().getArray();
+        const layers = Ext.Array.filter(
+            Ext.Array.map(layerKeys, function (key) {
+                const foundLayers = BasiGX.util.Layer.getLayersBy('layerKey', key, mapLayers);
+
+                if (foundLayers.length === 1 && foundLayers[0]) {
+                    return foundLayers[0];
+                }
+
+                return null;
+            }),
+            function (layer) {
+                return !!layer;
+            }
+        );
 
         Ext.Array.each(layers, function (layer) {
             const feats = layer.getSource().getFeatures(); // these are standard WFS layers so we use getSource without getFeaturesCollection here


### PR DESCRIPTION
Avoids `layers == [undefined, undefined]` if a layer with the key is not found. 