### PR TITLE
Add tooltipLayerConfigs for custom tooltip functions

### DIFF
--- a/app/controller/MapController.js
+++ b/app/controller/MapController.js
@@ -43,6 +43,30 @@ Ext.define('CpsiMapview.controller.MapController', {
     clickableLayerConfigs: {},
 
     /**
+     * A configuration object to custom function for layers that use CpsiMapview.view.layer.ToolTip.
+     * This should be overridden in inherited projects and should be in the following form:
+     *
+     * {
+     *   layerKeyName: function (feat) {
+     *   const tpl = new Ext.XTemplate(
+     *       '<div>',
+     *           '<strong>Name:</strong> {name}<br/>',
+     *           '<strong>Status:</strong> {status}',
+     *       '</div>'
+     *   );
+     *
+     *   return function (feature) {
+     *       return tpl.apply({
+     *           name:   feature.get('name'),
+     *           status: feature.get('status')
+     *       });
+     *   };
+     * }
+     *
+     */
+    tooltipLayerConfigs: {},
+
+    /**
      * Change the mouse cursor to a pointer if hovering over a feature that can be clicked to open a form
      * @param {any} evt
      */

--- a/app/controller/button/SnappingMixin.js
+++ b/app/controller/button/SnappingMixin.js
@@ -87,7 +87,10 @@ Ext.define('CpsiMapview.controller.button.SnappingMixin', {
 
         const layers = Ext.Array.filter(
             Ext.Array.map(layerKeys, function (key) {
-                const foundLayers = BasiGX.util.Layer.getLayersBy('layerKey', key);
+                const foundLayers = BasiGX.util.Layer.getLayersBy(
+                    'layerKey',
+                    key
+                );
 
                 if (foundLayers.length === 1 && foundLayers[0]) {
                     return foundLayers[0];

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -1371,7 +1371,12 @@ Ext.define('CpsiMapview.factory.Layer', {
         // and apply them to the layer (based on layerKey)
         const mapController = mapPanel.getController();
 
-        if (layerKey && mapController.tooltipLayerConfigs[layerKey]) {
+        if (
+            mapController &&
+            layerKey &&
+            mapController.tooltipLayerConfigs &&
+            mapController.tooltipLayerConfigs[layerKey]
+        ) {
             layer.formatFunction = mapController.tooltipLayerConfigs[layerKey];
         }
 

--- a/app/factory/Layer.js
+++ b/app/factory/Layer.js
@@ -692,7 +692,7 @@ Ext.define('CpsiMapview.factory.Layer', {
 
         if (layerConf.tooltipsConfig) {
             // create a custom tooltip for this layer
-            LayerFactory.registerLayerTooltip(wfsLayer);
+            LayerFactory.registerLayerTooltip(wfsLayer, layerConf.layerKey);
         }
 
         return wfsLayer;
@@ -982,7 +982,7 @@ Ext.define('CpsiMapview.factory.Layer', {
 
         if (layerConf.tooltipsConfig) {
             // enable map tooltips for this layer
-            LayerFactory.registerLayerTooltip(vtLayer);
+            LayerFactory.registerLayerTooltip(vtLayer, layerConf.layerKey);
         }
 
         // workaround to apply an opacity for the vector tile layer
@@ -1358,7 +1358,7 @@ Ext.define('CpsiMapview.factory.Layer', {
      *
      * @param  {ol.layer.Vector | ol.layer.VectorTile} layer The layer to enable map tooltips for
      */
-    registerLayerTooltip: function (layer) {
+    registerLayerTooltip: function (layer, layerKey) {
         const mapPanel = CpsiMapview.view.main.Map.guess();
         // create a custom tooltip for this layer
         const toolTip = Ext.create('CpsiMapview.view.layer.ToolTip', {
@@ -1366,6 +1366,14 @@ Ext.define('CpsiMapview.factory.Layer', {
             layer: layer
         });
         layer.toolTip = toolTip;
+
+        // check if there are any registered custom functions to use for the tooltips
+        // and apply them to the layer (based on layerKey)
+        const mapController = mapPanel.getController();
+
+        if (layerKey && mapController.tooltipLayerConfigs[layerKey]) {
+            layer.formatFunction = mapController.tooltipLayerConfigs[layerKey];
+        }
 
         // show / hide on appropriate events
         mapPanel.on('cmv-map-pointerrest', function (hoveredObjs, evt) {

--- a/app/view/layer/ToolTip.js
+++ b/app/view/layer/ToolTip.js
@@ -124,7 +124,7 @@ Ext.define('CpsiMapview.view.layer.ToolTip', {
     },
 
     /**
-     * Tranforms the feature's attributes to the wanted HTML structure shown in
+     * Transforms the feature's attributes to the wanted HTML structure shown in
      * this tooltip.
      * This function can be overridden if different HTML is needed for a custom
      * layer.

--- a/test/spec/factory/Layer.spec.js
+++ b/test/spec/factory/Layer.spec.js
@@ -390,4 +390,122 @@ describe('CpsiMapview.factory.Layer', function () {
             });
         });
     });
+
+    describe('registerLayerTooltip', function () {
+        it('should assign formatFunction when layerKey matches a tooltipLayerConfig', function () {
+            const mockFormatFunction = function () {
+                return 'test';
+            };
+
+            const mockLayer = {
+                get: function (key) {
+                    if (key === 'toolTipConfig') return {};
+                },
+                id: 'test-layer-id'
+            };
+
+            const mockMapPanel = {
+                getController: function () {
+                    return {
+                        tooltipLayerConfigs: {
+                            MY_LAYER: mockFormatFunction
+                        }
+                    };
+                },
+                on: Ext.emptyFn
+            };
+
+            // Stub Map.guess to return our mock
+            const originalGuess = CpsiMapview.view.main.Map.guess;
+            CpsiMapview.view.main.Map.guess = function () {
+                return mockMapPanel;
+            };
+
+            // Stub Ext.create to avoid real ToolTip instantiation
+            const originalCreate = Ext.create;
+            Ext.create = function () {
+                return { hide: Ext.emptyFn };
+            };
+
+            layerFactory.registerLayerTooltip(mockLayer, 'MY_LAYER');
+
+            expect(mockLayer.formatFunction).to.be(mockFormatFunction);
+
+            // Restore stubs
+            CpsiMapview.view.main.Map.guess = originalGuess;
+            Ext.create = originalCreate;
+        });
+
+        it('should not assign formatFunction when layerKey has no matching tooltipLayerConfig', function () {
+            const mockLayer = {
+                get: function (key) {
+                    if (key === 'toolTipConfig') return {};
+                },
+                id: 'test-layer-id'
+            };
+
+            const mockMapPanel = {
+                getController: function () {
+                    return {
+                        tooltipLayerConfigs: {}
+                    };
+                },
+                on: Ext.emptyFn
+            };
+
+            const originalGuess = CpsiMapview.view.main.Map.guess;
+            CpsiMapview.view.main.Map.guess = function () {
+                return mockMapPanel;
+            };
+
+            const originalCreate = Ext.create;
+            Ext.create = function () {
+                return { hide: Ext.emptyFn };
+            };
+
+            layerFactory.registerLayerTooltip(mockLayer, 'UNKNOWN_LAYER');
+
+            expect(mockLayer.formatFunction).to.be(undefined);
+
+            CpsiMapview.view.main.Map.guess = originalGuess;
+            Ext.create = originalCreate;
+        });
+
+        it('should not assign formatFunction when layerKey is absent', function () {
+            const mockLayer = {
+                get: function (key) {
+                    if (key === 'toolTipConfig') return {};
+                },
+                id: 'test-layer-id'
+            };
+
+            const mockMapPanel = {
+                getController: function () {
+                    return {
+                        tooltipLayerConfigs: {
+                            MY_LAYER: function () {}
+                        }
+                    };
+                },
+                on: Ext.emptyFn
+            };
+
+            const originalGuess = CpsiMapview.view.main.Map.guess;
+            CpsiMapview.view.main.Map.guess = function () {
+                return mockMapPanel;
+            };
+
+            const originalCreate = Ext.create;
+            Ext.create = function () {
+                return { hide: Ext.emptyFn };
+            };
+
+            layerFactory.registerLayerTooltip(mockLayer, null);
+
+            expect(mockLayer.formatFunction).to.be(undefined);
+
+            CpsiMapview.view.main.Map.guess = originalGuess;
+            Ext.create = originalCreate;
+        });
+    });
 });


### PR DESCRIPTION
Allows custom tooltip functions to return HTML when hovering over features.

Add any configs to `CpsiMapview.controller.MapController` (or extended class):

```js
    tooltipLayerConfigs: {
        MY_LAYER: function (feature) {

            const popupTpl = new Ext.XTemplate(
                '<div>',
                '<strong>ID:</strong> <strong>{ID}</strong><br/>',
                '<strong>Year:</strong> <strong>{Year}</strong><br/>',
                '<strong>Month:</strong> <strong>{MonthOfYear}</strong><br/>',
                '<strong>Time:</strong> <strong>{TimeBand}</strong><br/>',
                '<strong>Type:</strong> <strong>{IncidentType}</strong>',
                '</div>',
```
