### PR TITLE
Add null and undefined guards

### DIFF
--- a/app/controller/button/StreetViewTool.js
+++ b/app/controller/button/StreetViewTool.js
@@ -134,9 +134,13 @@ Ext.define('CpsiMapview.controller.button.StreetViewTool', {
             // add layer and raise layer to top of stack
             me.map.addLayer(me.vectorLayer);
         } else {
-            me.map.removeLayer(me.vectorLayer);
+            if (me.map) {
+                me.map.removeLayer(me.vectorLayer);
+            }
             // cleanup
-            me.vectorLayer.getSource().clear();
+            if (me.vectorLayer) {
+                me.vectorLayer.getSource().clear();
+            }
             if (me.streetViewWin) {
                 me.streetViewWin.close();
             }
@@ -176,7 +180,9 @@ Ext.define('CpsiMapview.controller.button.StreetViewTool', {
         if (activate) {
             me.map.on('singleclick', me.onMapClick);
         } else {
-            me.map.un('singleclick', me.onMapClick);
+            if (me.map) {
+                me.map.un('singleclick', me.onMapClick);
+            }
         }
     },
 
@@ -472,7 +478,9 @@ Ext.define('CpsiMapview.controller.button.StreetViewTool', {
      */
     unregisterGmapsEvents: function () {
         const me = this;
-        google.maps.event.removeListener(me.svPovChangedListener);
-        google.maps.event.removeListener(me.svPositionChangedListener);
+        if (typeof google !== 'undefined') {
+            google.maps.event.removeListener(me.svPovChangedListener);
+            google.maps.event.removeListener(me.svPositionChangedListener);
+        }
     }
 });

--- a/app/view/toolbar/MapFooter.js
+++ b/app/view/toolbar/MapFooter.js
@@ -11,6 +11,7 @@ Ext.define('CpsiMapview.view.toolbar.MapFooter', {
         'BasiGX.view.panel.CoordinateMousePositionPanel',
         'CpsiMapview.view.button.LoginButton',
         'CpsiMapview.view.button.MinimizeAllButton',
+        'CpsiMapview.view.panel.NumericAttributeSlider',
         'CpsiMapview.util.Style'
     ],
 
@@ -24,7 +25,9 @@ Ext.define('CpsiMapview.view.toolbar.MapFooter', {
         {
             xtype: 'basigx-panel-coordinatemouseposition',
             showMarker: true,
-            markerStyle: CpsiMapview.util.Style.createRedPoiMarker(),
+            markerStyle: function () {
+                return CpsiMapview.util.Style.createRedPoiMarker();
+            },
             epsgCodeArray: ['EPSG:4326', 'EPSG:29902', 'EPSG:2157'],
             activeEpsgCode: 'EPSG:29902',
             segmentedButtonLimit: 3


### PR DESCRIPTION
Allows creation and destruction of `CpsiMapview.view.main.Map` (and derived classes) in tests without throwing errors. 

Also move `markerStyle` to return a function to avoid loading class directly. 