### PR TITLE
Allow cutWithPolygonUrl URL to be overridden in a viewmodel

### DIFF
--- a/app/form/ViewMixin.js
+++ b/app/form/ViewMixin.js
@@ -166,6 +166,7 @@ Ext.define('CpsiMapview.form.ViewMixin', {
                 toggle: 'onDigitizingToolToggle'
             },
             bind: {
+                apiUrl: '{cutWithPolygonUrl}',
                 drawLayer: '{polygonLayer}',
                 disabled: '{isLocked}',
                 resultLayer: '{resultLayer}',


### PR DESCRIPTION
Override with:

```js
  cutWithPolygonUrl: function () {
      return '/WebServices/roadschedule/cutWithPolygon?onlyRoadway=true';
  },
```