### PR TITLE
Allow extraParams to be added to the store requests

### DIFF
--- a/app/store/WfsFeatures.js
+++ b/app/store/WfsFeatures.js
@@ -29,5 +29,28 @@ Ext.define('CpsiMapview.store.WfsFeatures', {
     outputFormat: 'geojson',
     startIndex: 0,
     count: 20,
-    format: new ol.format.GeoJSON()
+    format: new ol.format.GeoJSON(),
+    /**
+    * Additional parameters to send with every WFS request
+    *
+    * @cfg {Object}
+    */
+    extraParams: null,
+
+    /**
+     * Extend the WFS parameters built by GeoExt.data.store.WfsFeatures with any
+     * #extraParams configured on this store.
+     * @private
+     * @return {Object} The WFS parameters
+     */
+    createParameters: function () {
+        var me = this;
+        var params = me.callParent(arguments);
+
+        if (me.extraParams) {
+            Ext.apply(params, me.extraParams);
+        }
+
+        return params;
+    }
 });

--- a/app/store/WfsFeatures.js
+++ b/app/store/WfsFeatures.js
@@ -31,10 +31,10 @@ Ext.define('CpsiMapview.store.WfsFeatures', {
     count: 20,
     format: new ol.format.GeoJSON(),
     /**
-    * Additional parameters to send with every WFS request
-    *
-    * @cfg {Object}
-    */
+     * Additional parameters to send with every WFS request
+     *
+     * @cfg {Object}
+     */
     extraParams: null,
 
     /**
@@ -44,8 +44,8 @@ Ext.define('CpsiMapview.store.WfsFeatures', {
      * @return {Object} The WFS parameters
      */
     createParameters: function () {
-        var me = this;
-        var params = me.callParent(arguments);
+        const me = this;
+        const params = me.callParent(arguments);
 
         if (me.extraParams) {
             Ext.apply(params, me.extraParams);


### PR DESCRIPTION
Allows additional parameters to always be sent with store requests (for example to support MapServer runtime-substitution variables:

```js
    extraParams: {
        someParam: 'someValue'
    }
```

For example:

```js
Ext.define('CpsiMapview.view.grids.MyLayerStore', {
    extend: 'CpsiMapview.store.WfsFeatures',
    url: '/mapserver/?',
    alias: 'store.MyLayer',
    storeId: 'MyLayer',
    model: 'CpsiMapview.view.grids.MyLayerModel',
    typeName: 'MyLayer',
    layerOptions: {
        displayInLayerSwitcher: false,
        name: 'MyLayer'
    },
    extraParams: {
        someParam: 'someValue'
    }
});
```