### PR TITLE
Update Filter Icon Logic

### DIFF
--- a/app/util/Layer.js
+++ b/app/util/Layer.js
@@ -118,23 +118,10 @@ Ext.define('CpsiMapview.util.Layer', {
             Ext.log.warn('Layer type not recognized (updateLayerNodeUI)');
         }
 
-        const originalGlyph = layer.get('_origTreeConf')
-            ? layer.get('_origTreeConf').glyph
-            : null;
-        const expandedGlyph = 'f0b0';
         if (hasFilters) {
-            // only set the glyph and class if needed - better for performance
-            if (node.get('glyph') !== expandedGlyph) {
-                node.set('glyph', expandedGlyph);
-                node.addCls('cpsi-tree-node-filtered');
-            }
+            node.addCls('cpsi-tree-node-filtered');
         } else {
-            // only set the glyph and class if needed - better for performance
-            if (node.get('glyph') !== originalGlyph) {
-                // revert to the original glyph if set on the layer
-                node.set('glyph', originalGlyph);
-                node.removeCls('cpsi-tree-node-filtered');
-            }
+            node.removeCls('cpsi-tree-node-filtered');
         }
 
         if (triggerUIUpdate) {

--- a/sass/src/view/LayerTree.scss
+++ b/sass/src/view/LayerTree.scss
@@ -13,10 +13,22 @@
     font-style: italic;
     font-weight: bold;
 
-    .x-tree-checkbox:after {
-        content: "\f0b0";
-        font-family: "Font Awesome 5 Free" !important;
+    .x-tree-checkbox {
+        position: relative; // anchor point for the badge
+        margin-right: 14px; // make room so the badge doesn't collide with .x-tree-icon
     }
+
+        .x-tree-checkbox:after {
+            position: absolute;
+            left: 100%; // immediately to the right of the checkbox box
+            top: 50%;
+            transform: translateY(-50%);
+            margin-left: 2px; // add small gap between checkbox and icon
+            font-family: 'Font Awesome 5 Free' !important; // Solid — \f0b0 has no Regular version
+            font-size: 12px; // smaller than the tree icon
+            line-height: 1;
+            pointer-events: none; // don't let it handle clicks meant for the checkbox
+        }
 }
 
 .cpsi-tree-node-baselayer {

--- a/sass/src/view/LayerTree.scss
+++ b/sass/src/view/LayerTree.scss
@@ -19,6 +19,7 @@
     }
 
         .x-tree-checkbox:after {
+            content: "\f0b0";
             position: absolute;
             left: 100%; // immediately to the right of the checkbox box
             top: 50%;


### PR DESCRIPTION
When a layer is filtered, it should display the filter icon *and* its layer icon side-by-side.

<img width="120" height="59" alt="image" src="https://github.com/user-attachments/assets/745cb6e0-d68a-44b2-b222-d2ece7dc48ee" />

Handle this through CSS, rather than replacing glyphs. 